### PR TITLE
remove gcc4.9.0 / c++11 warnings

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -4127,7 +4127,8 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
 static stbi_uc *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
 {
    stbi_uc *u = 0;
-   stbi__gif g={0};
+   stbi__gif g;
+   memset(&g, 0, sizeof(g));
 
    u = stbi__gif_load_next(s, &g, comp, req_comp);
    if (u == (void *) 1) u = 0;  // end of animated gif marker


### PR DESCRIPTION
corrected annoying warnings about 'missing initializer'. The memset
version is not better, but gcc like it more.
