### PR TITLE
minor warn correction

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -378,7 +378,7 @@ int main(int arg, char **argv)
    #ifndef STBTT_malloc
    #include <stdlib.h>
    #define STBTT_malloc(x,u)  ((void)(u),malloc(x))
-   #define STBTT_free(x,u)    free(x)
+   #define STBTT_free(x,u)    ((void)(u),free(x))
    #endif
 
    #ifndef STBTT_assert


### PR DESCRIPTION
gcc warning: unused parameter removed for macro STBTT_free. (The same way STBTT_malloc do)
