### PR TITLE
Explicit CDECL needed

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -1084,7 +1084,7 @@ static void compute_accelerated_huffman(Codebook *c)
    }
 }
 
-static int uint32_compare(const void *p, const void *q)
+static int __cdecl uint32_compare(const void *p, const void *q)
 {
    uint32 x = * (uint32 *) p;
    uint32 y = * (uint32 *) q;
@@ -1240,7 +1240,7 @@ typedef struct
    uint16 x,y;
 } Point;
 
-int point_compare(const void *p, const void *q)
+int __cdecl point_compare(const void *p, const void *q)
 {
    Point *a = (Point *) p;
    Point *b = (Point *) q;


### PR DESCRIPTION
QSORT only takes CDECL, but project settings can define different defaults for calling conventions.
