### PR TITLE
Removed unused parameter warning

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -196,7 +196,7 @@
 
 #define STBI_VERSION 1
 
-#define STB_UNUSED(var) 
+#define STBI_UNUSED(var) 
 
 enum
 {
@@ -576,7 +576,7 @@ static unsigned char *stbi_load_main(stbi__context *s, int *x, int *y, int *comp
 
 #ifndef STBI_NO_STDIO
 
-FILE *stbi__fopen(char const *filename, char const* STB_UNUSED(mode))
+FILE *stbi__fopen(char const *filename, char const* STBI_UNUSED(mode))
 {
    FILE *f;
 #if _MSC_VER >= 1400


### PR DESCRIPTION
I added a macro for use on unused parameters to remove them from function prototypes and prevent build warnings.
