### PR TITLE
Added a reset macro to allow the buffer to be reused

### DIFF
--- a/stretchy_buffer.h
+++ b/stretchy_buffer.h
@@ -65,6 +65,8 @@
 //         sb_push(TYPE *a, TYPE v)   adds v on the end of the array, a la push_back
 //         sb_add(TYPE *a, int n)     adds n uninitialized elements at end of array & returns pointer to first added
 //         sb_last(TYPE *a)           returns an lvalue of the last item in the array
+//         sb_reset(TYPE *a)          resets array index to 0 allowing reuse of the array 
+//                                    without new (re)allocs until the old capacity is exceeded
 //         a[n]                       access the nth (counting from 0) element of the array
 //
 //     #define STRETCHY_BUFFER_NO_SHORT_NAMES to only export
@@ -170,6 +172,7 @@
 #define sb_count  stb_sb_count
 #define sb_add    stb_sb_add
 #define sb_last   stb_sb_last
+#define sb_reset  stb_sb_reset
 #endif
 
 #define stb_sb_free(a)         ((a) ? free(stb__sbraw(a)),0 : 0)
@@ -177,6 +180,7 @@
 #define stb_sb_count(a)        ((a) ? stb__sbn(a) : 0)
 #define stb_sb_add(a,n)        (stb__sbmaybegrow(a,n), stb__sbn(a)+=(n), &(a)[stb__sbn(a)-(n)])
 #define stb_sb_last(a)         ((a)[stb__sbn(a)-1])
+#define stb_sb_reset(a)        ((a) ? stb__sbn(a) = 0,0 : 0)
 
 #define stb__sbraw(a) ((int *) (a) - 2)
 #define stb__sbm(a)   stb__sbraw(a)[0]


### PR DESCRIPTION
... without (re)allocs until the old capacity is exceeded.

Typically this is useful when you have some approximate upper limit of items. The buffer grows to a point where no more allocs are required (e.g. holding data generated during each frame of a game).
