### PR TITLE
Support for 1/2/4-bit PNG

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -13,7 +13,7 @@
           avoid problematic images and only need the trivial interface
 
       JPEG baseline (no JPEG progressive)
-      PNG 8-bit-per-channel only
+      PNG 1/2/4/8-bit-per-channel (16 bpc not supported)
 
       TGA (not sure what subset, if a subset)
       BMP non-1bpp, non-RLE
@@ -28,6 +28,7 @@
       - overridable dequantizing-IDCT, YCbCr-to-RGB conversion (define STBI_SIMD)
 
    Latest revisions:
+      1.xx (2014-09-26) 1/2/4-bit PNG support (both grayscale and paletted)
       1.46 (2014-08-26) fix broken tRNS chunk in non-paletted PNG
       1.45 (2014-08-16) workaround MSVC-ARM internal compiler error by wrapping malloc
       1.44 (2014-08-07) warnings


### PR DESCRIPTION
Support for 1/2/4-bit palettized PNG

I was using pngout.exe to crunch down PNG to optimal size and ended up with data that stb_image wouldn't load. Using the data suite from http://www.schaik.com/pngsuite/pngsuite_bas_png.html, the proposed change allow to load basn3p01, basn3p02 and basn3p04.

The resulting loaded data is always converted to 8-bpp which I thought made sense (and simplify implementation).

I haven't thoroughly tested the changes against a bunch of corner cases (you may have a better test suite).

The additional ops are making the common case (8 bpp) slower so my assumption is that you might want to expand the code for each bit depth (1/2/4/8) or at least separate 1/2/4 from 8, considering the later is most common? If you would like me to rework the PR in this way I can do that. Additionally I'm not happy with the name of the 4 local variables I added in stbi__create_png_image_raw() maybe you'd have a better idea. If the code is expanding for all supported depths those variables can be folded into constants and won't need the confusing names.
