### PR TITLE
Various minor fixes that get rid of warnings when compiling on linux

### DIFF
--- a/stb.h
+++ b/stb.h
@@ -1244,7 +1244,7 @@ void stb_newell_normal(float *normal, int num_vert, float **vert, int normalize)
 
 int stb_box_face_vertex_axis_side(int face_number, int vertex_number, int axis)
 {
-   static box_vertices[6][4][3] =
+   static int box_vertices[6][4][3] =
    {
       { { 1,1,1 }, { 1,0,1 }, { 1,0,0 }, { 1,1,0 } },
       { { 0,0,0 }, { 0,0,1 }, { 0,1,1 }, { 0,1,0 } },
@@ -2139,7 +2139,7 @@ void stb_replaceinplace(char *src, char *find, char *replace)
 {
    size_t len_find = strlen(find);
    size_t len_replace = strlen(replace);
-   int count = 0, delta;
+   int delta;
 
    char *s,*p,*q;
 
@@ -3875,15 +3875,17 @@ static int STB_(N,addset)(TYPE *a, KEY k, VALUE v,                            \
    unsigned int h = STB_(N, hash)(k);                                         \
    unsigned int n = h & a->mask;                                              \
    int b = -1;                                                                \
-   if (CCOMPARE(k,EMPTY))                                                     \
+   if (CCOMPARE(k,EMPTY)) {                                                   \
       if (a->has_empty ? allow_old : allow_new) {                             \
           n=a->has_empty; a->ev = v; a->has_empty = 1; return !n;             \
       } else return 0;                                                        \
-   if (CCOMPARE(k,DEL))                                                       \
+   }                                                                          \
+   if (CCOMPARE(k,DEL)) {                                                     \
       if (a->has_del ? allow_old : allow_new) {                               \
           n=a->has_del; a->dv = v; a->has_del = 1; return !n;                 \
       } else return 0;                                                        \
-   if (!CCOMPARE(a->table[n].k, EMPTY)) {                                      \
+   }                                                                          \
+   if (!CCOMPARE(a->table[n].k, EMPTY)) {                                     \
       unsigned int s;                                                         \
       if (CCOMPARE(a->table[n].k, DEL))                                       \
          b = n;                                                               \
@@ -4036,11 +4038,12 @@ void stb_ptrmap_delete(stb_ptrmap *e, void (*free_func)(void *))
    int i;
    if (free_func)
       for (i=0; i < e->limit; ++i)
-         if (e->table[i].k != STB_EMPTY && e->table[i].k != STB_EDEL)
+         if (e->table[i].k != STB_EMPTY && e->table[i].k != STB_EDEL) {
             if (free_func == free)
                free(e->table[i].v); // allow STB_MALLOC_WRAPPER to operate
             else
                free_func(e->table[i].v);
+         }
    stb_ptrmap_destroy(e);
 }
 
@@ -5341,7 +5344,10 @@ FILE *  stb_fopen(char *filename, char *mode)
    FILE *f;
    char name_full[4096];
    char temp_full[sizeof(name_full) + 12];
-   int j,p;
+   int p;
+#ifdef _MSC_VER
+   int j;
+#endif
    if (mode[0] != 'w' && !strchr(mode, '+'))
       return stb__fopen(filename, mode);
 
@@ -5904,7 +5910,6 @@ char **stb_readdir_subdirs_mask(char *dir, char *wild) { return readdir_raw(dir,
 int stb__rec_max=0x7fffffff;
 static char **stb_readdir_rec(char **sofar, char *dir, char *filespec)
 {
-   int n = strcmp(dir, ".") ? strlen(dir)+1 : 0;
    char **files;
    char ** dirs;
    char **p;
@@ -6491,7 +6496,7 @@ STB_EXTERN void stb_cfg_set_directory(char *dir)
 
 STB_EXTERN stb_cfg * stb_cfg_open(char *config, char *mode)
 {
-   unsigned int len;
+   size_t len;
    stb_cfg *z;
    char file[512];
    if (mode[0] != 'r' && mode[0] != 'w') return NULL;
@@ -7114,7 +7119,7 @@ static void stb__grow_alloc(void)
 static void stb__add_alloc(void *p, int sz, char *file, int line)
 {
    stb_uint32 h;
-   int n, f=-1;
+   int n;
    if (stb__alloc_count >= stb__alloc_limit)
       stb__grow_alloc();
    h = stb_hashptr(p);
@@ -9213,7 +9218,6 @@ static void stb__lex_reset(stb_matcher *matcher)
 
 stb_matcher *stb_regex_matcher(char *regex)
 {
-   void *c = stb__arr_context;
    char *z;
    stb_uint16 end;
    stb_matcher *matcher = stb__alloc_matcher();
@@ -10357,9 +10361,9 @@ stb_uint stb_compress(stb_uchar *out, stb_uchar *input, stb_uint length)
 
 int stb_compress_tofile(char *filename, char *input, unsigned int length)
 {
-   int maxlen = length + 512 + (length >> 2); // total guess
-   char *buffer = (char *) malloc(maxlen);
-   int blen = stb_compress((stb_uchar*)buffer, (stb_uchar*)input, length);
+   //int maxlen = length + 512 + (length >> 2); // total guess
+   //char *buffer = (char *) malloc(maxlen);
+   //int blen = stb_compress((stb_uchar*)buffer, (stb_uchar*)input, length);
    
    stb__out = NULL;
    stb__outfile = fopen(filename, "wb");
@@ -10377,7 +10381,7 @@ int stb_compress_tofile(char *filename, char *input, unsigned int length)
 
 int stb_compress_intofile(FILE *f, char *input, unsigned int length)
 {
-   int maxlen = length + 512 + (length >> 2); // total guess
+   //int maxlen = length + 512 + (length >> 2); // total guess
    //char *buffer = (char*)malloc(maxlen);
    //int blen = stb_compress((stb_uchar*)buffer, (stb_uchar*)input, length);
    

--- a/stb.h
+++ b/stb.h
@@ -5808,7 +5808,6 @@ void stb_readdir_free(char **files)
 }
 
 STB_EXTERN int stb_wildmatchi(char *expr, char *candidate);
-static double stb_readdir_size;
 static char **readdir_raw(char *dir, int return_subdirs, char *mask)
 {
    char **results = NULL;
@@ -5878,10 +5877,6 @@ static char **readdir_raw(char *dir, int return_subdirs, char *mask)
                      if (buffer[0] == '.' && buffer[1] == '/')
                         p = buffer+2;
                      stb_arr_push(results, strdup(p));
-                     #ifdef _MSC_VER
-                     if (!is_subdir)
-                        stb_readdir_size += data.size;
-                     #endif
                   }
                }
             }

--- a/stb.h
+++ b/stb.h
@@ -2771,7 +2771,7 @@ static void * malloc_base(void *context, size_t size, stb__alloc_type t, int ali
          break;
       }
 
-      default: assert(0); /* NOTREACHED */
+      default: p = NULL; assert(0); /* NOTREACHED */
    }
 
    ++stb_alloc_count_alloc;

--- a/stb.h
+++ b/stb.h
@@ -5348,6 +5348,7 @@ FILE *  stb_fopen(char *filename, char *mode)
    // save away the full path to the file so if the program
    // changes the cwd everything still works right! unix has
    // better ways to do this, but we have to work in windows
+   name_full[0] = '\0'; // stb_fullpath reads name_full[0]
    if (stb_fullpath(name_full, sizeof(name_full), filename)==0)
       return 0;
 

--- a/stb.h
+++ b/stb.h
@@ -11050,7 +11050,7 @@ stb_arith_symstate *stb_arith_state_create(int num_sym)
    return s;
 }
 
-static stb_arith_state_rescale(stb_arith_symstate *s)
+static void stb_arith_state_rescale(stb_arith_symstate *s)
 {
    if (s->pow2 < POW2_LIMIT) {
       int pcf, cf, cf_next, next, i;


### PR DESCRIPTION
3b1480f is potentially serious as stb_fullpath() reads the first character of its first argument, which at this point contains random stack data.

The rest are mainly silencing warnings.