### PR TITLE
Optimize

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -2845,7 +2845,9 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
             if (first) return stbi__err("first not IHDR", "Corrupt PNG");
             if (scan != SCAN_load) return 1;
             if (z->idata == NULL) return stbi__err("no IDAT","Corrupt PNG");
-            z->expanded = (stbi_uc *) stbi_zlib_decode_malloc_guesssize_headerflag((char *) z->idata, ioff, 16384, (int *) &raw_len, !is_iphone);
+            // initial guess for decoded data size to avoid unnecessary reallocs
+            raw_len = s->img_x * s->img_y * s->img_n /* pixels */ + s->img_y /* filter mode per row */;
+            z->expanded = (stbi_uc *) stbi_zlib_decode_malloc_guesssize_headerflag((char *) z->idata, ioff, raw_len, (int *) &raw_len, !is_iphone);
             if (z->expanded == NULL) return 0; // zlib should set error
             free(z->idata); z->idata = NULL;
             if ((req_comp == s->img_n+1 && req_comp != 3 && !pal_img_n) || has_trans)


### PR DESCRIPTION
stb_image: PNG/zlib decoder optimizations.

The goal was to focus on low-complexity, high-yield changes: improve
decoding speed significantly while staying with the original spirit of
the library.

This is more than 2x faster on my machine when decoding my 1680x1050
24-bit test PNG (screenshot of a website) - very scientific, I know.
Nevertheless, there's nothing particularly data-sensitive in here. The
one thing that is specific to that particular file is that I added a
fast path for the "none" filter when img_n == out_n (i.e. just do a
memcpy). But that's such a trivial change (and likely to benefit other
files, since "none" is common) that I don't feel guilty about it.
