### PR TITLE
Add explicit wchar_t casts in stb.h

### DIFF
--- a/stb.h
+++ b/stb.h
@@ -851,7 +851,7 @@ void stbprint(const char *fmt, ...)
 
 
 #ifdef _WIN32
-   #define stb__fopen(x,y)    _wfopen(stb__from_utf8(x), stb__from_utf8_alt(y))
+   #define stb__fopen(x,y)    _wfopen((const wchar_t *)stb__from_utf8(x), (const wchar_t *)stb__from_utf8_alt(y))
    #define stb__windows(x,y)  x
 #else
    #define stb__fopen(x,y)    fopen(x,y)
@@ -1244,7 +1244,7 @@ void stb_newell_normal(float *normal, int num_vert, float **vert, int normalize)
 
 int stb_box_face_vertex_axis_side(int face_number, int vertex_number, int axis)
 {
-   static box_vertices[6][4][3] =
+   static int box_vertices[6][4][3] =
    {
       { { 1,1,1 }, { 1,0,1 }, { 1,0,0 }, { 1,1,0 } },
       { { 0,0,0 }, { 0,0,1 }, { 0,1,1 }, { 0,1,0 } },
@@ -4910,7 +4910,7 @@ void stb_nptr_recache(void)
 
 
 #ifdef _MSC_VER
-  #define stb_rename(x,y)   _wrename(stb__from_utf8(x), stb__from_utf8_alt(y))
+  #define stb_rename(x,y)   _wrename((const wchar_t *)stb__from_utf8(x), (const wchar_t *)stb__from_utf8_alt(y))
   #define stb_mktemp   _mktemp
 #else
   #define stb_mktemp   mktemp
@@ -5049,7 +5049,7 @@ int stb_fexists(char *filename)
 {
    struct stb__stat buf;
    return stb__windows(
-             _wstat(stb__from_utf8(filename), &buf),
+             _wstat((const wchar_t *)stb__from_utf8(filename), &buf),
                stat(filename,&buf)
           ) == 0;
 }
@@ -5058,7 +5058,7 @@ time_t stb_ftimestamp(char *filename)
 {
    struct stb__stat buf;
    if (stb__windows(
-             _wstat(stb__from_utf8(filename), &buf),
+             _wstat((const wchar_t *)stb__from_utf8(filename), &buf),
                stat(filename,&buf)
           ) == 0)
    {
@@ -5837,7 +5837,7 @@ static char **readdir_raw(char *dir, int return_subdirs, char *mask)
    #ifdef _MSC_VER
       strcpy(buffer+n, "*.*");
       ws = stb__from_utf8(buffer);
-      z = _wfindfirst(ws, &data);
+      z = _wfindfirst((const wchar_t *)ws, &data);
    #else
       z = opendir(dir);
    #endif
@@ -5855,7 +5855,7 @@ static char **readdir_raw(char *dir, int return_subdirs, char *mask)
          do {
             int is_subdir;
             #ifdef _MSC_VER
-            char *name = stb__to_utf8(data.name);
+            char *name = stb__to_utf8((stb__wchar *)data.name);
             if (name == NULL) {
                fprintf(stderr, "%s to convert '%S' to %s!\n", "Unable", data.name, "utf8");
                continue;
@@ -6804,9 +6804,9 @@ static void stb__dirtree_scandir(char *path, time_t last_time, stb_dirtree *acti
 
    has_slash = (path[0] && path[strlen(path)-1] == '/'); 
    if (has_slash)
-      swprintf(full_path, L"%s*", stb__from_utf8(path));
+      swprintf((wchar_t *)full_path, L"%s*", stb__from_utf8(path));
    else
-      swprintf(full_path, L"%s/*", stb__from_utf8(path));
+      swprintf((wchar_t *)full_path, L"%s/*", stb__from_utf8(path));
 
    // it's possible this directory is already present: that means it was in the
    // cache, but its parent wasn't... in that case, we're done with it
@@ -6818,13 +6818,13 @@ static void stb__dirtree_scandir(char *path, time_t last_time, stb_dirtree *acti
    stb__dirtree_add_dir(path, last_time, active);
    n = stb_arr_lastn(active->dirs);
 
-   if( (hFile = _wfindfirst( full_path, &c_file )) != -1L ) {
+   if( (hFile = _wfindfirst((const wchar_t *)full_path, &c_file )) != -1L ) {
       do {
          if (c_file.attrib & _A_SUBDIR) {
             // ignore subdirectories starting with '.', e.g. "." and ".."
             if (c_file.name[0] != '.') {
                char *new_path = (char *) full_path;
-               char *temp = stb__to_utf8(c_file.name);
+               char *temp = stb__to_utf8((stb__wchar *)c_file.name);
                if (has_slash)
                   sprintf(new_path, "%s%s", path, temp);
                else
@@ -6832,7 +6832,7 @@ static void stb__dirtree_scandir(char *path, time_t last_time, stb_dirtree *acti
                stb__dirtree_scandir(new_path, c_file.time_write, active);
             }
          } else {
-            char *temp = stb__to_utf8(c_file.name);
+            char *temp = stb__to_utf8((stb__wchar *)c_file.name);
             stb__dirtree_add_file(temp, n, c_file.size, c_file.time_write, active);
          }
       } while( _wfindnext( hFile, &c_file ) == 0 );
@@ -11049,7 +11049,7 @@ stb_arith_symstate *stb_arith_state_create(int num_sym)
    return s;
 }
 
-static stb_arith_state_rescale(stb_arith_symstate *s)
+static void stb_arith_state_rescale(stb_arith_symstate *s)
 {
    if (s->pow2 < POW2_LIMIT) {
       int pcf, cf, cf_next, next, i;


### PR DESCRIPTION
Hi,

I ran into the errors below when compiling stb.h with VS2013. Most of them are complaints that you can't implicitly cast unsigned short to and from wchar_t because the latter is now a built-in type. It's possible to get rid of them with the `/Zc:wchar_t-` switch, but that's not the default, so I thought it might be good to add some explicit casts.

A couple of the others were about the use of implicit-int or an implicit void return type which are also fixed in this commit.

The only one remaining is the use of `strdup()` instead of `_strdup()`. I didn't want to change that because I don't know if the version with the underscore is available on VC6. In any case that error can be turned off by defining `_CRT_NONSTDC_NO_WARNINGS`.

Thomas

P.S. Thanks for the great library!

```
stb.h(713): error C4996: 'strdup': The POSIX name for this item is deprecated. Instead, use the ISO C++ conformant name: _strdup. See online help for details.
          c:\program files (x86)\microsoft visual studio 12.0\vc\include\string.h(245) : see declaration of 'strdup'
stb.h(1248): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
stb.h(5054): error C2664: 'int _wstat64i32(const wchar_t *,_stat64i32 *)' : cannot convert argument 1 from 'stb__wchar *' to 'const wchar_t *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(5063): error C2664: 'int _wstat64i32(const wchar_t *,_stat64i32 *)' : cannot convert argument 1 from 'stb__wchar *' to 'const wchar_t *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(5083): error C2664: 'FILE *_wfopen(const wchar_t *,const wchar_t *)' : cannot convert argument 1 from 'stb__wchar *' to 'const wchar_t *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(5118): error C2664: 'FILE *_wfopen(const wchar_t *,const wchar_t *)' : cannot convert argument 1 from 'stb__wchar *' to 'const wchar_t *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(5133): error C2664: 'FILE *_wfopen(const wchar_t *,const wchar_t *)' : cannot convert argument 1 from 'stb__wchar *' to 'const wchar_t *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(5294): error C2664: 'FILE *_wfopen(const wchar_t *,const wchar_t *)' : cannot convert argument 1 from 'stb__wchar *' to 'const wchar_t *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(5295): error C2664: 'FILE *_wfopen(const wchar_t *,const wchar_t *)' : cannot convert argument 1 from 'stb__wchar *' to 'const wchar_t *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(5311): error C2664: 'FILE *_wfopen(const wchar_t *,const wchar_t *)' : cannot convert argument 1 from 'stb__wchar *' to 'const wchar_t *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(5312): error C2664: 'FILE *_wfopen(const wchar_t *,const wchar_t *)' : cannot convert argument 1 from 'stb__wchar *' to 'const wchar_t *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(5346): error C2664: 'FILE *_wfopen(const wchar_t *,const wchar_t *)' : cannot convert argument 1 from 'stb__wchar *' to 'const wchar_t *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(5435): error C2664: 'int _wrename(const wchar_t *,const wchar_t *)' : cannot convert argument 1 from 'stb__wchar *' to 'const wchar_t *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(5464): error C2664: 'FILE *_wfopen(const wchar_t *,const wchar_t *)' : cannot convert argument 1 from 'stb__wchar *' to 'const wchar_t *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(5468): error C2664: 'FILE *_wfopen(const wchar_t *,const wchar_t *)' : cannot convert argument 1 from 'stb__wchar *' to 'const wchar_t *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(5840): error C2664: 'intptr_t _wfindfirst64i32(const wchar_t *,_wfinddata64i32_t *)' : cannot convert argument 1 from 'stb__wchar *' to 'const wchar_t *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(5858): error C2664: 'char *stb__to_utf8(stb__wchar *)' : cannot convert argument 1 from 'wchar_t [260]' to 'stb__wchar *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(6261): error C2664: 'FILE *_wfopen(const wchar_t *,const wchar_t *)' : cannot convert argument 1 from 'stb__wchar *' to 'const wchar_t *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(6807): error C2665: 'swprintf' : none of the 2 overloads could convert all the argument types
          c:\program files (x86)\microsoft visual studio 12.0\vc\include\swprintf.inl(85): could be 'int swprintf(wchar_t *,const wchar_t *,...)'
          c:\program files (x86)\microsoft visual studio 12.0\vc\include\swprintf.inl(36): or       'int swprintf(wchar_t *,size_t,const wchar_t *,...)'
          while trying to match the argument list '(stb__wchar [1024], const wchar_t [4], stb__wchar *)'
stb.h(6809): error C2665: 'swprintf' : none of the 2 overloads could convert all the argument types
          c:\program files (x86)\microsoft visual studio 12.0\vc\include\swprintf.inl(85): could be 'int swprintf(wchar_t *,const wchar_t *,...)'
          c:\program files (x86)\microsoft visual studio 12.0\vc\include\swprintf.inl(36): or       'int swprintf(wchar_t *,size_t,const wchar_t *,...)'
          while trying to match the argument list '(stb__wchar [1024], const wchar_t [5], stb__wchar *)'
stb.h(6821): error C2664: 'intptr_t _wfindfirst64i32(const wchar_t *,_wfinddata64i32_t *)' : cannot convert argument 1 from 'stb__wchar [1024]' to 'const wchar_t *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(6827): error C2664: 'char *stb__to_utf8(stb__wchar *)' : cannot convert argument 1 from 'wchar_t [260]' to 'stb__wchar *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(6835): error C2664: 'char *stb__to_utf8(stb__wchar *)' : cannot convert argument 1 from 'wchar_t [260]' to 'stb__wchar *'
          Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
stb.h(11053): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
stb.h(11086): warning C4508: 'stb_arith_state_rescale' : function should return a value; 'void' return type assumed

```