### PR TITLE
stb_truetype: split stbtt_PackFontRanges() into 3 functions for advanced uses

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -2320,14 +2320,19 @@ int stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, stbtt_fontinfo *inf
       float scale = fh > 0 ? stbtt_ScaleForPixelHeight(info, fh) : stbtt_ScaleForMappingEmToPixels(info, -fh);
       for (j=0; j < ranges[i].num_chars_in_range; ++j) {
          int x0,y0,x1,y1;
-         stbtt_GetCodepointBitmapBoxSubpixel(info, ranges[i].first_unicode_char_in_range + j,
-                                             scale * spc->h_oversample,
-                                             scale * spc->v_oversample,
-                                             0,0,
-                                             &x0,&y0,&x1,&y1);
-         rects[k].w = (stbrp_coord) (x1-x0 + spc->padding + spc->h_oversample-1);
-         rects[k].h = (stbrp_coord) (y1-y0 + spc->padding + spc->v_oversample-1);
-         ++k;
+		 int glyph = stbtt_FindGlyphIndex(info,ranges[i].first_unicode_char_in_range + j);
+		 if (glyph) {
+            stbtt_GetGlyphBitmapBoxSubpixel(info,glyph,
+                                            scale * spc->h_oversample,
+                                            scale * spc->v_oversample,
+                                            0,0,
+                                            &x0,&y0,&x1,&y1);
+            rects[k].w = (stbrp_coord) (x1-x0 + spc->padding + spc->h_oversample-1);
+            rects[k].h = (stbrp_coord) (y1-y0 + spc->padding + spc->v_oversample-1);
+		 } else {
+			 rects[k].was_packed = false;
+		 }
+		 ++k;
       }
    }
 

--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -2165,7 +2165,8 @@ int stbtt_PackBegin(stbtt_pack_context *spc, unsigned char *pixels, int pw, int 
 
    stbrp_init_target(context, pw-padding, ph-padding, nodes, num_nodes);
 
-   STBTT_memset(pixels, 0, pw*ph); // background of 0 around pixels
+   if (pixels)
+      STBTT_memset(pixels, 0, pw*ph); // background of 0 around pixels
 
    return 1;
 }

--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -2331,7 +2331,6 @@ int stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, stbtt_fontinfo *inf
             rects[k].h = (stbrp_coord) (y1-y0 + spc->padding + spc->v_oversample-1);
 		 } else {
             rects[k].w = rects[k].h = 1;
-            rects[k].was_packed = false;
          }
 		 ++k;
       }

--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -91,7 +91,7 @@
 //           #include "stb_rect_pack.h"           -- optional, but you really want it
 //           stbtt_PackBegin()
 //           stbtt_PackSetOversample()            -- for improved quality on small fonts
-//           stbtt_PackFontRanges()
+//           stbtt_PackFontRanges()               -- pack and renders
 //           stbtt_PackEnd()
 //           stbtt_GetPackedQuad()
 //
@@ -493,6 +493,7 @@ typedef struct
 } stbtt_packedchar;
 
 typedef struct stbtt_pack_context stbtt_pack_context;
+typedef struct stbtt_fontinfo stbtt_fontinfo;
 
 extern int  stbtt_PackBegin(stbtt_pack_context *spc, unsigned char *pixels, int width, int height, int stride_in_bytes, int padding, void *alloc_context);
 // Initializes a packing context stored in the passed-in stbtt_pack_context.
@@ -538,6 +539,12 @@ extern int  stbtt_PackFontRanges(stbtt_pack_context *spc, unsigned char *fontdat
 // ranges. This will usually create a better-packed bitmap than multiple
 // calls to stbtt_PackFontRange.
 
+extern int  stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects);
+extern int  stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects);
+// Those functions are called by stbtt_PackFontRanges(). If you want to
+// pack multiple fonts or custom data into a same texture, you may copy
+// the contents of stbtt_PackFontRanges() and create a custom version 
+// using those functions.
 
 extern void stbtt_PackSetOversampling(stbtt_pack_context *spc, unsigned int h_oversample, unsigned int v_oversample);
 // Oversampling a font increases the quality by allowing higher-quality subpixel
@@ -2301,63 +2308,50 @@ static float stbtt__oversample_shift(int oversample)
    return (float)-(oversample - 1) / (2.0f * (float)oversample);
 }
 
-int stbtt_PackFontRanges(stbtt_pack_context *spc, unsigned char *fontdata, int font_index, stbtt_pack_range *ranges, int num_ranges)
+// rects array must be big enough to accommodate all characters in the given ranges
+int stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects)
 {
-   stbtt_fontinfo info;
-   float recip_h = 1.0f / spc->h_oversample;
-   float recip_v = 1.0f / spc->v_oversample;
-   float sub_x = stbtt__oversample_shift(spc->h_oversample);
-   float sub_y = stbtt__oversample_shift(spc->v_oversample);
-   int i,j,k,n, return_value = 1;
-   stbrp_context *context = (stbrp_context *) spc->pack_info;
-   stbrp_rect    *rects;
+   int i,j,k;
 
-   // flag all characters as NOT packed
-   for (i=0; i < num_ranges; ++i)
-      for (j=0; j < ranges[i].num_chars_in_range; ++j)
-         ranges[i].chardata_for_range[j].x0 =
-         ranges[i].chardata_for_range[j].y0 =
-         ranges[i].chardata_for_range[j].x1 =
-         ranges[i].chardata_for_range[j].y1 = 0;
-
-   n = 0;
-   for (i=0; i < num_ranges; ++i)
-      n += ranges[i].num_chars_in_range;
-         
-   rects = (stbrp_rect *) STBTT_malloc(sizeof(*rects) * n, spc->user_allocator_context);
-   if (rects == NULL)
-      return 0;
-
-   stbtt_InitFont(&info, fontdata, stbtt_GetFontOffsetForIndex(fontdata,font_index));
    k=0;
    for (i=0; i < num_ranges; ++i) {
       float fh = ranges[i].font_size;
-      float scale = fh > 0 ? stbtt_ScaleForPixelHeight(&info, fh) : stbtt_ScaleForMappingEmToPixels(&info, -fh);
+      float scale = fh > 0 ? stbtt_ScaleForPixelHeight(info, fh) : stbtt_ScaleForMappingEmToPixels(info, -fh);
       for (j=0; j < ranges[i].num_chars_in_range; ++j) {
          int x0,y0,x1,y1;
-         stbtt_GetCodepointBitmapBoxSubpixel(&info, ranges[i].first_unicode_char_in_range + j,
-                                              scale * spc->h_oversample,
-                                              scale * spc->v_oversample,
-                                              0,0,
-                                              &x0,&y0,&x1,&y1);
+         stbtt_GetCodepointBitmapBoxSubpixel(info, ranges[i].first_unicode_char_in_range + j,
+                                             scale * spc->h_oversample,
+                                             scale * spc->v_oversample,
+                                             0,0,
+                                             &x0,&y0,&x1,&y1);
          rects[k].w = (stbrp_coord) (x1-x0 + spc->padding + spc->h_oversample-1);
          rects[k].h = (stbrp_coord) (y1-y0 + spc->padding + spc->v_oversample-1);
          ++k;
       }
    }
 
-   stbrp_pack_rects(context, rects, k);
+   return k;
+}
+
+// rects array must be big enough to accommodate all characters in the given ranges
+int stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects)
+{
+   float recip_h = 1.0f / spc->h_oversample;
+   float recip_v = 1.0f / spc->v_oversample;
+   float sub_x = stbtt__oversample_shift(spc->h_oversample);
+   float sub_y = stbtt__oversample_shift(spc->v_oversample);
+   int i,j,k, return_value = 1;
 
    k = 0;
    for (i=0; i < num_ranges; ++i) {
       float fh = ranges[i].font_size;
-      float scale = fh > 0 ? stbtt_ScaleForPixelHeight(&info, fh) : stbtt_ScaleForMappingEmToPixels(&info, -fh);
+      float scale = fh > 0 ? stbtt_ScaleForPixelHeight(info, fh) : stbtt_ScaleForMappingEmToPixels(info, -fh);
       for (j=0; j < ranges[i].num_chars_in_range; ++j) {
          stbrp_rect *r = &rects[k];
          if (r->was_packed) {
             stbtt_packedchar *bc = &ranges[i].chardata_for_range[j];
             int advance, lsb, x0,y0,x1,y1;
-            int glyph = stbtt_FindGlyphIndex(&info, ranges[i].first_unicode_char_in_range + j);
+            int glyph = stbtt_FindGlyphIndex(info, ranges[i].first_unicode_char_in_range + j);
             stbrp_coord pad = (stbrp_coord) spc->padding;
 
             // pad on left and top
@@ -2365,12 +2359,12 @@ int stbtt_PackFontRanges(stbtt_pack_context *spc, unsigned char *fontdata, int f
             r->y += pad;
             r->w -= pad;
             r->h -= pad;
-            stbtt_GetGlyphHMetrics(&info, glyph, &advance, &lsb);
-            stbtt_GetGlyphBitmapBox(&info, glyph,
+            stbtt_GetGlyphHMetrics(info, glyph, &advance, &lsb);
+            stbtt_GetGlyphBitmapBox(info, glyph,
                                     scale * spc->h_oversample,
                                     scale * spc->v_oversample,
                                     &x0,&y0,&x1,&y1);
-            stbtt_MakeGlyphBitmapSubpixel(&info,
+            stbtt_MakeGlyphBitmapSubpixel(info,
                                           spc->pixels + r->x + r->y*spc->stride_in_bytes,
                                           r->w - spc->h_oversample+1,
                                           r->h - spc->v_oversample+1,
@@ -2406,6 +2400,40 @@ int stbtt_PackFontRanges(stbtt_pack_context *spc, unsigned char *fontdata, int f
          ++k;
       }
    }
+
+   return return_value;
+}
+
+int stbtt_PackFontRanges(stbtt_pack_context *spc, unsigned char *fontdata, int font_index, stbtt_pack_range *ranges, int num_ranges)
+{
+   stbtt_fontinfo info;
+   int i,j,n, return_value = 1;
+   stbrp_context *context = (stbrp_context *) spc->pack_info;
+   stbrp_rect    *rects;
+
+   // flag all characters as NOT packed
+   for (i=0; i < num_ranges; ++i)
+      for (j=0; j < ranges[i].num_chars_in_range; ++j)
+         ranges[i].chardata_for_range[j].x0 =
+         ranges[i].chardata_for_range[j].y0 =
+         ranges[i].chardata_for_range[j].x1 =
+         ranges[i].chardata_for_range[j].y1 = 0;
+
+   n = 0;
+   for (i=0; i < num_ranges; ++i)
+      n += ranges[i].num_chars_in_range;
+         
+   rects = (stbrp_rect *) STBTT_malloc(sizeof(*rects) * n, spc->user_allocator_context);
+   if (rects == NULL)
+      return 0;
+
+   stbtt_InitFont(&info, fontdata, stbtt_GetFontOffsetForIndex(fontdata,font_index));
+
+   n = stbtt_PackFontRangesGatherRects(spc, &info, ranges, num_ranges, rects);
+
+   stbrp_pack_rects(context, rects, n);
+  
+   return_value = stbtt_PackFontRangesRenderIntoRects(spc, &info, ranges, num_ranges, rects);
 
    return return_value;
 }

--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -2330,8 +2330,9 @@ int stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, stbtt_fontinfo *inf
             rects[k].w = (stbrp_coord) (x1-x0 + spc->padding + spc->h_oversample-1);
             rects[k].h = (stbrp_coord) (y1-y0 + spc->padding + spc->v_oversample-1);
 		 } else {
-			 rects[k].was_packed = false;
-		 }
+            rects[k].w = rects[k].h = 1;
+            rects[k].was_packed = false;
+         }
 		 ++k;
       }
    }


### PR DESCRIPTION
The reasoning is: If I want to pack multiple fonts together or custom graphics data along with a font, right now the user needs to make a very customized copy of stbtt_PackFontRanges() - 107 lines, possibly breaks with update.

So I split stbtt_PackFontRanges() and created two extra functions called by it.

    int stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects);
    int stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects);

stbtt_PackFontRanges is now 32 lines and is conceptually a high-level helper, contains the essential for packing a single font into a texture. Easy to copy to adapt for more advanced packing.

The new function names or parameters may be renamed if you have a more suitable idea.