### PR TITLE
stb image: Fix dangling else and unused variable warnings

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -1723,11 +1723,12 @@ static int stbi__jpeg_decode_block_prog_ac(stbi__jpeg *j, short data[64], stbi__
             short *p = &data[stbi__jpeg_dezigzag[k]];
             if (*p != 0)
                if (stbi__jpeg_get_bit(j))
-                  if ((*p & bit)==0)
+                  if ((*p & bit)==0) {
                      if (*p > 0)
                         *p += bit;
                      else
                         *p -= bit;
+                  }
          }
       } else {
          k = j->spec_start;
@@ -1759,11 +1760,12 @@ static int stbi__jpeg_decode_block_prog_ac(stbi__jpeg *j, short data[64], stbi__
                short *p = &data[stbi__jpeg_dezigzag[k]];
                if (*p != 0) {
                   if (stbi__jpeg_get_bit(j))
-                     if ((*p & bit)==0)
+                     if ((*p & bit)==0) {
                         if (*p > 0)
                            *p += bit;
                         else
                            *p -= bit;
+                     }
                   ++k;
                } else {
                   if (r == 0) {

--- a/stb_image.h
+++ b/stb_image.h
@@ -2421,7 +2421,6 @@ static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
                      for (x=0; x < z->img_comp[n].h; ++x) {
                         int x2 = (i*z->img_comp[n].h + x);
                         int y2 = (j*z->img_comp[n].v + y);
-                        int ha = z->img_comp[n].ha;
                         short *data = z->img_comp[n].coeff + 64 * (x2 + y2 * z->img_comp[n].coeff_w);
                         if (!stbi__jpeg_decode_block_prog_dc(z, data, &z->huff_dc[z->img_comp[n].hd], n))
                            return 0;


### PR DESCRIPTION
The first commit fixes 2 dangling else warnings at lines 1729 and 1765. This way fixes issue #65.
I tired to make the change as small as possible.

Second commit fixes warning unused variable, cause by variable "ha" at line 2424. It looks like a copy paste left over so I simply removed it.