### PR TITLE
stbte: layer name buttons grow with layer panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ library    | lastest version | category | description
 **stb_textedit.h** | 1.5 | UI | guts of a text editor for games etc implementing them from scratch
 **stb_dxt.h** | 1.04 | 3D&nbsp;graphics | Fabian "ryg" Giesen's real-time DXT compressor
 **stb_perlin.h** | 0.2 | 3D&nbsp;graphics | revised Perlin noise (3D input, 1D output)
-**stb_tilemap_editor.h** | 0.30 | games | embeddable tilemap editor
+**stb_tilemap_editor.h** | 0.31 | games | embeddable tilemap editor
 **stb_herringbone_wang_tile.h** | 0.6 | games | herringbone Wang tile map generator
 **stb_c_lexer.h** | 0.06 | parsing | simplify writing parsers for C-like languages
 **stb_divide.h** | 0.91 | math | more useful 32-bit modulus e.g. "euclidean divide"
@@ -82,6 +82,3 @@ for other people to use them from other languages.
 
 I still use MSVC 6 (1998) as my IDE because it has better human factors
 for me than later versions of MSVC.
-
-
-

--- a/stb_tilemap_editor.h
+++ b/stb_tilemap_editor.h
@@ -938,6 +938,7 @@ struct stbte_tilemap
     int tileinfo_dirty;
     stbte__layer layerinfo[STBTE_MAX_LAYERS];
     int has_layer_names;
+    int layername_width;
     int layer_scroll;
     int propmode;
     int solo_layer;
@@ -1016,6 +1017,7 @@ stbte_tilemap *stbte_create_map(int map_x, int map_y, int map_layers, int spacin
    tm->layer_scroll = 0;
    tm->propmode = 0;
    tm->has_layer_names = 0;
+   tm->layername_width = 0;
    tm->undo_available_valid = 0;
 
    for (i=0; i < tm->num_layers; ++i) {
@@ -1088,12 +1090,16 @@ void stbte_define_tile(stbte_tilemap *tm, unsigned short id, unsigned int layerm
    tm->tileinfo_dirty = 1;
 }
 
+static int stbte__text_width(const char *str);
+
 void stbte_set_layername(stbte_tilemap *tm, int layer, const char *layername)
 {
    STBTE_ASSERT(layer >= 0 && layer < tm->num_layers);
    if (layer >= 0 && layer < tm->num_layers) {
       tm->layerinfo[layer].name = layername;
       tm->has_layer_names = 1;
+      int width = stbte__text_width(layername);
+      tm->layername_width = (width > tm->layername_width ? width : tm->layername_width);
    }
 }
 
@@ -3385,7 +3391,9 @@ static void stbte__layers(stbte_tilemap *tm, int x0, int y0, int w, int h)
    int i, y, n;
    int x1 = x0+w;
    int y1 = y0+h;
-   int xoff = tm->has_layer_names ? 50 : 20;
+   int side = stbte__ui.panel[STBTE__layer].side;
+   int xoff = tm->has_layer_names ? stbte__region[side].width - 42 : 20;
+   xoff = (xoff < tm->layername_width + 10 ? xoff : tm->layername_width + 10);
    static char *propmodes[3] = {
       "default", "always", "never"
    };

--- a/stb_tilemap_editor.h
+++ b/stb_tilemap_editor.h
@@ -3398,7 +3398,7 @@ static void stbte__layers(stbte_tilemap *tm, int x0, int y0, int w, int h)
    
    if (tm->has_layer_names) {
       int side = stbte__ui.panel[STBTE__panel_layers].side;
-      xoff = tm->has_layer_names ? stbte__region[side].width - 42 : 20;
+      xoff = stbte__region[side].width - 42;
       xoff = (xoff < tm->layername_width + 10 ? xoff : tm->layername_width + 10);
    }
 

--- a/stb_tilemap_editor.h
+++ b/stb_tilemap_editor.h
@@ -3394,9 +3394,14 @@ static void stbte__layers(stbte_tilemap *tm, int x0, int y0, int w, int h)
    int i, y, n;
    int x1 = x0+w;
    int y1 = y0+h;
-   int side = stbte__ui.panel[STBTE__panel_layers].side;
-   int xoff = tm->has_layer_names ? stbte__region[side].width - 42 : 20;
-   xoff = (xoff < tm->layername_width + 10 ? xoff : tm->layername_width + 10);
+   int xoff = 20;
+   
+   if (tm->has_layer_names) {
+      int side = stbte__ui.panel[STBTE__panel_layers].side;
+      xoff = tm->has_layer_names ? stbte__region[side].width - 42 : 20;
+      xoff = (xoff < tm->layername_width + 10 ? xoff : tm->layername_width + 10);
+   }
+
    static char *propmodes[3] = {
       "default", "always", "never"
    };

--- a/stb_tilemap_editor.h
+++ b/stb_tilemap_editor.h
@@ -3394,7 +3394,7 @@ static void stbte__layers(stbte_tilemap *tm, int x0, int y0, int w, int h)
    int i, y, n;
    int x1 = x0+w;
    int y1 = y0+h;
-   int side = stbte__ui.panel[STBTE__layer].side;
+   int side = stbte__ui.panel[STBTE__panel_layers].side;
    int xoff = tm->has_layer_names ? stbte__region[side].width - 42 : 20;
    xoff = (xoff < tm->layername_width + 10 ? xoff : tm->layername_width + 10);
    static char *propmodes[3] = {

--- a/stb_tilemap_editor.h
+++ b/stb_tilemap_editor.h
@@ -1,4 +1,4 @@
-// stb_tilemap_editor.h - v0.30 - Sean Barrett - http://nothings.org/stb
+// stb_tilemap_editor.h - v0.31 - Sean Barrett - http://nothings.org/stb
 // placed in the public domain - not copyrighted - first released 2014-09
 //
 // Embeddable tilemap editor for C/C++
@@ -275,6 +275,9 @@
 //   either approach allows cut&pasting between levels.)
 //
 // REVISION HISTORY
+//   0.31  layername button changes
+//          - layername buttons grow with the layer panel
+//          - fix stbte_create_map being declared as stbte_create
 //   0.30  properties release
 //          - properties panel for editing user-defined "object" properties
 //          - can link each tile to one other tile
@@ -296,11 +299,11 @@
 //   Support STBTE_HITTEST_TILE above
 //  ?Cancel drags by clicking other button? - may be fixed
 //   Finish support for toolbar at side
-//   Layer name buttons grow to fill box
 //
 // CREDITS
 //
 //   Written by Sean Barrett, September & October 2014.
+//   Contributions from Josh Huelsman, January 2015.
 //
 // LICENSE
 //

--- a/stb_tilemap_editor.h
+++ b/stb_tilemap_editor.h
@@ -3443,7 +3443,7 @@ static void stbte__layers(stbte_tilemap *tm, int x0, int y0, int w, int h)
    n = stbte__text_width("prop:")+2;
    stbte__draw_text(x0,y+2, "prop:", w, STBTE__TEXTCOLOR(STBTE__cpanel));
    i = w - n - 4;
-   if (i > 45) i = 45;
+   if (i > 50) i = 50;
    if (stbte__button(STBTE__clayer_button, propmodes[tm->propmode], x0+n,y,0,i, STBTE__ID(STBTE__layer,256), 0,0))
       tm->propmode = (tm->propmode+1)%3;
 #endif

--- a/stb_tilemap_editor.h
+++ b/stb_tilemap_editor.h
@@ -339,7 +339,7 @@ enum
 // creation
 //
 
-extern stbte_tilemap *stbte_create(int map_x, int map_y, int map_layers, int spacing_x, int spacing_y, int max_tiles);
+extern stbte_tilemap *stbte_create_map(int map_x, int map_y, int map_layers, int spacing_x, int spacing_y, int max_tiles);
 // create an editable tilemap
 //   map_x      : dimensions of map horizontally (user can change this in editor), <= STBTE_MAX_TILEMAP_X
 //   map_y      : dimensions of map vertically (user can change this in editor)    <= STBTE_MAX_TILEMAP_Y


### PR DESCRIPTION
Layername buttons will grow/shrink to fill layer panel width. Grows to a maximum of the draw width of the widest set layer name.
Also fixes #47 