### PR TITLE
Fixed bug where NEON code was #ifdef’d out on GCC/clang even with STBI_NEON

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -624,7 +624,7 @@ typedef unsigned char validate_uint32[sizeof(stbi__uint32)==4 ? 1 : -1];
 #define STBI_FREE(p)       free(p)
 #endif
 
-#if defined(__GNUC__) && !defined(__SSE2__) && !defined(STBI_NO_SIMD)
+#if defined(__GNUC__) && (defined(__x86_64__) || defined(__i386)) && !defined(__SSE2__) && !defined(STBI_NO_SIMD)
 // gcc doesn't support sse2 intrinsics unless you compile with -msse2,
 // (but compiling with -msse2 allows the compiler to use SSE2 everywhere;
 // this is just broken and gcc are jerks for not fixing it properly


### PR DESCRIPTION
Hi Sean,

We're trying to use stb_image as a drop-in replacement for libjpeg/libjpeg-turbo for IDCT in a project. It's working pretty great - thanks for making this awesome library available! We were scratching our heads for a while why the NEON version wasn't being compiled in on iOS - turns out the SSE2 compiler feature detection is active on non-x86 architectures as well, and STBI_NO_SIMD ends up being #defined even with a #define  STBI_NEON before the #include. Looks like a simple oversight/regression, and the attached patch makes sure the SSE2 detection only is used on x86 architectures. (Not sure x86-64 is worth including there - as far as I'm aware SSE2 is part of the baseline there, but I've left it in just in case)

Thanks
Phil