### PR TITLE
Avoid GCC sign-compare warning.

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -4642,7 +4642,7 @@ static stbi_uc *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int 
             }
          } else {
             for (i=0; i < (int) s->img_x; ++i) {
-               stbi__uint32 v = (stbi__uint32) (bpp == 16 ? stbi__get16le(s) : stbi__get32le(s));
+               stbi__uint32 v = (bpp == 16 ? (stbi__uint32) stbi__get16le(s) : stbi__get32le(s));
                int a;
                out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mr, rshift, rcount));
                out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mg, gshift, gcount));


### PR DESCRIPTION
GCC 4.7 gave the warning "signed and unsigned type in conditional
expression" because the ternary operator mixes signed and unsigned
integers. Fixed by casting to unsigned inside the "if" branch instead
of casting the result of the entire conditional.