### PR TITLE
Single channel BMP loading

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -4668,6 +4668,7 @@ static stbi_uc *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int 
    if (req_comp && req_comp != target) {
       out = stbi__convert_format(out, target, req_comp, s->img_x, s->img_y);
       if (out == NULL) return out; // stbi__convert_format frees input on failure
+      s->img_n = req_comp;
    }
 
    *x = s->img_x;


### PR DESCRIPTION
Make sure to set number of channels after doing post-conversion of grayscale BMP images