### PR TITLE
Request a 24-bit depth buffer

### DIFF
--- a/tests/caveview/cave_main.c
+++ b/tests/caveview/cave_main.c
@@ -535,6 +535,7 @@ int SDL_main(int argc, char **argv)
    SDL_GL_SetAttribute(SDL_GL_RED_SIZE  , 8);
    SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
    SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE , 8);
+   SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
 
    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);


### PR DESCRIPTION
On an AMD GPU (HD 7800), I experienced severe z-fighting before making this change.