### PR TITLE
don't redefine __forceinline with mingw

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -1646,7 +1646,7 @@ stbi_inline static int stbi__extend_receive(stbi__jpeg *j, int n)
 
    sgn = (stbi__int32)j->code_buffer >> 31; // sign bit is always in MSB
    k = stbi_lrot(j->code_buffer, n);
-   STBI_ASSERT(n >= 0 && n < sizeof(stbi__bmask)/sizeof(*stbi__bmask));
+   STBI_ASSERT(n >= 0 && n < (int) (sizeof(stbi__bmask)/sizeof(*stbi__bmask)));
    j->code_buffer = k & ~stbi__bmask[n];
    k &= stbi__bmask[n];
    j->code_bits -= n;

--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -553,7 +553,7 @@ enum STBVorbisError
 #define NULL 0
 #endif
 
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) && !(defined(__MINGW32__) && defined(__forceinline))
    #if __GNUC__
       #define __forceinline inline
    #else


### PR DESCRIPTION
MinGW redefines `__forceinline`, which caused a warning. This was fixed by not redefining it if MinGW has already defined it. A quick google search tells me not every MinGW version out there defines `__forceinline`, which is why it checks if it is defined.

Tested with MinGW and Visual Studio 2013. 

The emitted warning:
```
C:\stb_vorbis.cpp:558:0: warning: "__forceinline" redefined
       #define __forceinline inline
 ^
In file included from C:/Qt/Tools/mingw491_32/i686-w64-mingw32/include/crtdefs.h:10:0,
                 from C:/Qt/Tools/mingw491_32/i686-w64-mingw32/include/stdio.h:9,
                 from C:\stb_vorbis.cpp:58:
C:/Qt/Tools/mingw491_32/i686-w64-mingw32/include/_mingw.h:261:0: note: this is the location of the previous definition
 #define __forceinline inline __attribute__((__always_inline__))
```