### PR TITLE
stb_wingraph.h: missing lib pragmas for completeness

### DIFF
--- a/tests/oversample/stb_wingraph.h
+++ b/tests/oversample/stb_wingraph.h
@@ -25,6 +25,8 @@
    #pragma comment(lib, "opengl32.lib")
    #pragma comment(lib, "glu32.lib")
    #pragma comment(lib, "winmm.lib")
+   #pragma comment(lib, "gdi32.lib")
+   #pragma comment(lib, "user32.lib")
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Very minor but since that file uses the pragma lib facility, gdi32.lib and user32.lib are also required to link. (Tested with tests/oversample/main.c on VS 2010)

for reference
```
# cl main.c -I..\..
Microsoft (R) 32-bit C/C++ Optimizing Compiler Version 16.00.30319.01 for 80x86
Copyright (C) Microsoft Corporation.  All rights reserved.

main.c
Microsoft (R) Incremental Linker Version 10.00.30319.01
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:main.exe
main.obj
main.obj : error LNK2019: unresolved external symbol __imp__MessageBoxA@16 referenced in function _stbwingraph_MessageBox
main.obj : error LNK2019: unresolved external symbol __imp__ChangeDisplaySettingsA@8 referenced in function _stbwingraph_ChangeResolution
main.obj : error LNK2019: unresolved external symbol __imp__EnumDisplaySettingsA@12 referenced in function _stbwingraph_ChangeResolution
main.obj : error LNK2019: unresolved external symbol __imp__SetPixelFormat@12 referenced in function _stbwingraph_SetPixelFormat
main.obj : error LNK2019: unresolved external symbol __imp__DescribePixelFormat@16 referenced in function _stbwingraph_SetPixelFormat
main.obj : error LNK2019: unresolved external symbol __imp__ChoosePixelFormat@8 referenced in function _stbwingraph_SetPixelFormat
main.obj : error LNK2019: unresolved external symbol __imp__GetDC@4 referenced in function _stbwingraph_SetPixelFormat
main.obj : error LNK2019: unresolved external symbol __imp__RegisterClassExA@4 referenced in function _stbwingraph_DefineClass
main.obj : error LNK2019: unresolved external symbol __imp__GetStockObject@4 referenced in function _stbwingraph_DefineClass
main.obj : error LNK2019: unresolved external symbol __imp__LoadCursorA@8 referenced in function _stbwingraph_DefineClass
main.obj : error LNK2019: unresolved external symbol __imp__LoadIconA@8 referenced in function _stbwingraph_DefineClass
main.obj : error LNK2019: unresolved external symbol __imp__DefWindowProcA@16 referenced in function _stbwingraph_WinProc@16
main.obj : error LNK2019: unresolved external symbol __imp__GetClientRect@8 referenced in function _stbwingraph_WinProc@16
main.obj : error LNK2019: unresolved external symbol __imp__PostQuitMessage@4 referenced in function _stbwingraph_WinProc@16
main.obj : error LNK2019: unresolved external symbol __imp__EndPaint@8 referenced in function _stbwingraph_WinProc@16
main.obj : error LNK2019: unresolved external symbol __imp__SelectObject@8 referenced in function _stbwingraph_WinProc@16
main.obj : error LNK2019: unresolved external symbol __imp__BeginPaint@8 referenced in function _stbwingraph_WinProc@16
main.obj : error LNK2019: unresolved external symbol __imp__SetWindowLongA@12 referenced in function _stbwingraph_WinProc@16
main.obj : error LNK2019: unresolved external symbol __imp__GetWindowLongA@8 referenced in function _stbwingraph_WinProc@16
main.obj : error LNK2019: unresolved external symbol __imp__ShowCursor@4 referenced in function _stbwingraph__inclient
main.obj : error LNK2019: unresolved external symbol __imp__GetKeyState@4 referenced in function _stbwingraph__key
main.obj : error LNK2019: unresolved external symbol __imp__ReleaseCapture@0 referenced in function _stbwingraph__mouse
main.obj : error LNK2019: unresolved external symbol __imp__SetCapture@4 referenced in function _stbwingraph__mouse
main.obj : error LNK2019: unresolved external symbol __imp__UpdateWindow@4 referenced in function _stbwingraph_ShowWindow
main.obj : error LNK2019: unresolved external symbol __imp__InvalidateRect@12 referenced in function _stbwingraph_ShowWindow
main.obj : error LNK2019: unresolved external symbol __imp__ShowWindow@8 referenced in function _stbwingraph_ShowWindow
main.obj : error LNK2019: unresolved external symbol __imp__CreateWindowExA@48 referenced in function _stbwingraph_CreateWindow
main.obj : error LNK2019: unresolved external symbol __imp__AdjustWindowRect@12 referenced in function _stbwingraph_CreateWindow
main.obj : error LNK2019: unresolved external symbol __imp__DestroyWindow@4 referenced in function _stbwingraph_DestroyWindow
main.obj : error LNK2019: unresolved external symbol __imp__DispatchMessageA@4 referenced in function _stbwingraph_MainLoop
main.obj : error LNK2019: unresolved external symbol __imp__TranslateMessage@4 referenced in function _stbwingraph_MainLoop
main.obj : error LNK2019: unresolved external symbol __imp__GetMessageA@16 referenced in function _stbwingraph_MainLoop
main.obj : error LNK2019: unresolved external symbol __imp__PeekMessageA@20 referenced in function _stbwingraph_MainLoop
main.obj : error LNK2019: unresolved external symbol __imp__SwapBuffers@4 referenced in function _stbwingraph_SwapBuffers
```