### PR TITLE
stb_truetype: fix wrong result returned by stbtt_GetFontOffsetForIndex

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -952,7 +952,7 @@ int stbtt_GetFontOffsetForIndex(const unsigned char *font_collection, int index)
          stbtt_int32 n = ttLONG(font_collection+8);
          if (index >= n)
             return -1;
-         return ttULONG(font_collection+12+index*14);
+         return ttULONG(font_collection+12+index*4);
       }
    }
    return -1;


### PR DESCRIPTION
fixed the typo in stbtt_GetFontOffsetForIndex, where the field size should be 4 instead of 14.