### PR TITLE
Fix easy_font assuming math.h is already imported

### DIFF
--- a/stb_easy_font.h
+++ b/stb_easy_font.h
@@ -88,6 +88,7 @@ void print_string(float x, float y, char *text, float r, float g, float b)
 #define INCLUDE_STB_EASY_FONT_H
 
 #include <stdlib.h>
+#include <math.h>
 
 struct {
     unsigned char advance;


### PR DESCRIPTION
It uses the ceil() function but doesn't include math.h itself.