### PR TITLE
update public-domain dedication

### DIFF
--- a/stb.h
+++ b/stb.h
@@ -1,5 +1,4 @@
 /* stb.h - v2.24 - Sean's Tool Box -- public domain -- http://nothings.org/stb.h
-          no warranty is offered or implied; use this code at your own risk
 
    This is a single header file with a bunch of useful utilities
    for getting stuff done in C/C++.
@@ -166,6 +165,13 @@ Version History
           (stb_array), (stb_arena)
 
 Parenthesized items have since been removed.
+
+LICENSE
+
+This software is in the public domain. Where that dedication is not
+recognized, you are granted a perpetual, irrevocable license to copy,
+distribute, and modify this file as you see fit.
+
 */
 
 #ifndef STB__INCLUDE_STB_H

--- a/stb_c_lexer.h
+++ b/stb_c_lexer.h
@@ -28,6 +28,12 @@
 //     - haven't implemented octal/hex character constants
 //     - haven't implemented support for unicode CLEX_char
 //     - need to expand error reporting so you don't just get "CLEX_parse_error"
+//
+// LICENSE
+//
+//   This software is in the public domain. Where that dedication is not
+//   recognized, you are granted a perpetual, irrevocable license to copy,
+//   distribute, and modify this file as you see fit.
 
 #ifndef STB_C_LEXER_DEFINITIONS
 // to change the default parsing rules, copy the following lines

--- a/stb_divide.h
+++ b/stb_divide.h
@@ -75,6 +75,12 @@
 // by the euclidean division operator we define, so it's possibly not
 // always true. If any such platform turns up, we can add more cases.
 // (Possibly only stb_div_trunc currently relies on property (b).)
+//
+// LICENSE
+//
+//   This software is in the public domain. Where that dedication is not
+//   recognized, you are granted a perpetual, irrevocable license to copy,
+//   distribute, and modify this file as you see fit.
 
 
 #ifndef INCLUDE_STB_DIVIDE_H

--- a/stb_dxt.h
+++ b/stb_dxt.h
@@ -16,6 +16,12 @@
 //   v1.02  - (stb) fix alpha encoding bug
 //   v1.01  - (stb) fix bug converting to RGB that messed up quality, thanks ryg & cbloom
 //   v1.00  - (stb) first release
+//
+// LICENSE
+//
+//   This software is in the public domain. Where that dedication is not
+//   recognized, you are granted a perpetual, irrevocable license to copy,
+//   distribute, and modify this file as you see fit.
 
 #ifndef STB_INCLUDE_STB_DXT_H
 #define STB_INCLUDE_STB_DXT_H

--- a/stb_easy_font.h
+++ b/stb_easy_font.h
@@ -68,6 +68,12 @@
 //    Here's sample code for old OpenGL; it's a lot more complicated
 //    to make work on modern APIs, and that's your problem.
 //
+// LICENSE
+//
+//   This software is in the public domain. Where that dedication is not
+//   recognized, you are granted a perpetual, irrevocable license to copy,
+//   distribute, and modify this file as you see fit.
+//
 #if 0
 void print_string(float x, float y, char *text, float r, float g, float b)
 {

--- a/stb_herringbone_wang_tile.h
+++ b/stb_herringbone_wang_tile.h
@@ -1,8 +1,11 @@
 /* stbhw - v0.6 -  http://nothings.org/gamedev/herringbone
    Herringbone Wang Tile Generator - Sean Barrett 2014 - public domain
 
- This file is in the public domain. In case that declaration is ineffective,
- you are also granted a license to use and modify it without restriction.
+== LICENSE ==============================
+
+This software is in the public domain. Where that dedication is not
+recognized, you are granted a perpetual, irrevocable license to copy,
+distribute, and modify this file as you see fit.
 
 == WHAT IT IS ===========================
 

--- a/stb_image.h
+++ b/stb_image.h
@@ -1,5 +1,4 @@
 /* stb_image - v2.06 - public domain image loader - http://nothings.org/stb_image.h
-                                     no warranty implied; use at your own risk
 
    Do this:
       #define STB_IMAGE_IMPLEMENTATION
@@ -204,10 +203,11 @@
                                                  Joseph Thomson
                                                  Phil Jordan
 
-License:
-   This software is in the public domain. Where that dedication is not
-   recognized, you are granted a perpetual, irrevocable license to copy
-   and modify this file however you want.
+LICENSE
+
+This software is in the public domain. Where that dedication is not
+recognized, you are granted a perpetual, irrevocable license to copy,
+distribute, and modify this file as you see fit.
 
 */
 

--- a/stb_image_resize.h
+++ b/stb_image_resize.h
@@ -159,9 +159,10 @@
       0.90 (2014-09-17) first released version
 
    LICENSE
-      This software is in the public domain. Where that dedication is not
-      recognized, you are granted a perpetual, irrevocable license to copy
-      and modify this file as you see fit.
+
+     This software is in the public domain. Where that dedication is not
+     recognized, you are granted a perpetual, irrevocable license to copy,
+     distribute, and modify this file as you see fit.
 
    TODO
       Don't decode all of the image data when only processing a partial tile

--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -1,6 +1,5 @@
 /* stb_image_write - v0.98 - public domain - http://nothings.org/stb/stb_image_write.h
    writes out PNG/BMP/TGA images to C stdio - Sean Barrett 2010
-                            no warranty implied; use at your own risk
 
 
    Before #including,
@@ -75,6 +74,12 @@ CREDITS:
       Tim Kelsey
    bugfixes:
       github:Chribba
+      
+LICENSE
+
+This software is in the public domain. Where that dedication is not
+recognized, you are granted a perpetual, irrevocable license to copy,
+distribute, and modify this file as you see fit.      
 */
 
 #ifndef INCLUDE_STB_IMAGE_WRITE_H

--- a/stb_leakcheck.h
+++ b/stb_leakcheck.h
@@ -1,4 +1,9 @@
 // stb_leakcheck.h - v0.2 - quick & dirty malloc leak-checking - public domain
+// LICENSE
+//
+//   This software is in the public domain. Where that dedication is not
+//   recognized, you are granted a perpetual, irrevocable license to copy,
+//   distribute, and modify this file as you see fit.
 
 #ifdef STB_LEAKCHECK_IMPLEMENTATION
 #undef STB_LEAKCHECK_IMPLEMENTATION // don't implenment more than once

--- a/stb_perlin.h
+++ b/stb_perlin.h
@@ -1,6 +1,13 @@
 // stb_perlin.h - v0.2 - perlin noise
 // public domain single-file C implementation by Sean Barrett
 //
+// LICENSE
+//
+//   This software is in the public domain. Where that dedication is not
+//   recognized, you are granted a perpetual, irrevocable license to copy,
+//   distribute, and modify this file as you see fit.
+//
+//
 // to create the implementation,
 //     #define STB_PERLIN_IMPLEMENTATION
 // in *one* C/CPP file that includes this file.

--- a/stb_rect_pack.h
+++ b/stb_rect_pack.h
@@ -36,6 +36,12 @@
 //     0.05:  added STBRP_ASSERT to allow replacing assert
 //     0.04:  fixed minor bug in STBRP_LARGE_RECTS support
 //     0.01:  initial release
+//
+// LICENSE
+//
+//   This software is in the public domain. Where that dedication is not
+//   recognized, you are granted a perpetual, irrevocable license to copy,
+//   distribute, and modify this file as you see fit.
 
 //////////////////////////////////////////////////////////////////////////////
 //

--- a/stb_textedit.h
+++ b/stb_textedit.h
@@ -17,9 +17,9 @@
 //
 // LICENSE
 //
-// This software has been placed in the public domain by its author.
-// Where that dedication is not recognized, you are granted a perpetual,
-// irrevocable license to copy and modify this file as you see fit.
+//   This software is in the public domain. Where that dedication is not
+//   recognized, you are granted a perpetual, irrevocable license to copy,
+//   distribute, and modify this file as you see fit.
 //
 //
 // DEPENDENCIES

--- a/stb_tilemap_editor.h
+++ b/stb_tilemap_editor.h
@@ -1,5 +1,5 @@
 // stb_tilemap_editor.h - v0.35 - Sean Barrett - http://nothings.org/stb
-// placed in the public domain - not copyrighted - first released 2014-09
+// first released 2014-09
 //
 // Embeddable tilemap editor for C/C++
 //
@@ -313,9 +313,9 @@
 //
 // LICENSE
 //
-//   This software has been placed in the public domain by its author.
-//   Where that dedication is not recognized, you are granted a perpetual,
-//   irrevocable license to copy and modify this file as you see fit.
+//   This software is in the public domain. Where that dedication is not
+//   recognized, you are granted a perpetual, irrevocable license to copy,
+//   distribute, and modify this file as you see fit.
 
 
 

--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -4,8 +4,11 @@
 // Written by Sean Barrett in 2007, last updated in 2014
 // Sponsored by RAD Game Tools.
 //
-// Placed in the public domain April 2007 by the author: no copyright
-// is claimed, and you may use it for any purpose you like.
+// LICENSE
+//
+//   This software is in the public domain. Where that dedication is not
+//   recognized, you are granted a perpetual, irrevocable license to copy,
+//   distribute, and modify this file as you see fit.
 //
 // No warranty for any purpose is expressed or implied by the author (nor
 // by RAD Game Tools). Report bugs and send enhancements to the author.

--- a/stb_voxel_render.h
+++ b/stb_voxel_render.h
@@ -210,6 +210,13 @@
 //   stb_voxel_render   20-byte quads   2015/01
 //   zmc engine         32-byte quads   2013/12
 //   zmc engine         96-byte quads   2011/10
+//
+//
+// LICENSE
+//
+//   This software is in the public domain. Where that dedication is not
+//   recognized, you are granted a perpetual, irrevocable license to copy,
+//   distribute, and modify this file as you see fit.
 
 #ifndef INCLUDE_STB_VOXEL_RENDER_H
 #define INCLUDE_STB_VOXEL_RENDER_H

--- a/stretchy_buffer.h
+++ b/stretchy_buffer.h
@@ -161,6 +161,12 @@
 //    The details are trivial and implementation is straightforward;
 //    the main trick is in realizing in the first place that it's
 //    possible to do this in a generic, type-safe way in C.
+//
+// LICENSE
+//
+//   This software is in the public domain. Where that dedication is not
+//   recognized, you are granted a perpetual, irrevocable license to copy,
+//   distribute, and modify this file as you see fit.
 
 #ifndef STB_STRETCHY_BUFFER_H_INCLUDED
 #define STB_STRETCHY_BUFFER_H_INCLUDED


### PR DESCRIPTION
This is the best I can do with issue #155.  I tried to use the truetype license text as the template, but keep the formatting of the individual file headers similar to what is already present.  Merge if this is what is desired or close this request if you plan to do the work yourself @nothings.