### PR TITLE
Fixed readdir_raw 64-bit crash

### DIFF
--- a/stb.h
+++ b/stb.h
@@ -5837,8 +5837,8 @@ static char **readdir_raw(char *dir, int return_subdirs, char *mask)
    #ifdef _MSC_VER
       stb__wchar *ws;
       struct _wfinddata_t data;
-      const long none = -1;
-      long z;
+      const intptr_t none = -1;
+      intptr_t z;
    #else
       const DIR *none = NULL;
       DIR *z;
@@ -6813,7 +6813,7 @@ static void stb__dirtree_scandir(char *path, time_t last_time, stb_dirtree *acti
    int n;
 
    struct _wfinddata_t c_file;
-   long hFile;
+   intptr_t hFile;
    stb__wchar full_path[1024];
    int has_slash;
 


### PR DESCRIPTION
_wfindfirst() returns handle of intptr_t type, which was incorrectly cast to long - this caused readdir_raw to crash in 64 bit builds (intermittently); I've also made similar fix for stb__dirtree_scandir