### PR TITLE
DMC doesn't accept struct initializer syntax

### DIFF
--- a/stb_voxel_render.h
+++ b/stb_voxel_render.h
@@ -3382,7 +3382,7 @@ static void stbvox_make_mesh_for_block_with_geo(stbvox_mesh_maker *mm, stbvox_po
 
 static void stbvox_make_mesh_for_column(stbvox_mesh_maker *mm, int x, int y, int z0)
 {
-   stbvox_pos pos = { x,y,0 };
+   stbvox_pos pos; pos.x = x; pos.y = y; pos.z = 0;
    int v_off = x * mm->x_stride_in_bytes + y * mm->y_stride_in_bytes;
    int ns_off = mm->y_stride_in_bytes;
    int ew_off = mm->x_stride_in_bytes;


### PR DESCRIPTION
It expects constants. The long way compiles (but I haven't actually called this function yet)