### PR TITLE
fix spelling of "Hofmann"

### DIFF
--- a/stb_voxel_render.h
+++ b/stb_voxel_render.h
@@ -186,7 +186,7 @@
 //   Features             Porting            Bugfixes & Warnings
 //  Sean Barrett                          github:r-leyh   Jesus Fernandez
 //                                        Miguel Lechon   github:Arbeiterunfallversicherungsgesetz
-//                                        Thomas Frase    James Hoffman
+//                                        Thomas Frase    James Hofmann
 //
 // VERSION HISTORY
 //


### PR DESCRIPTION
Interesting factoid: my last name has four valid spellings. In Germany, the one I use is apparently the most common, while the other spellings are typical in the United States.