### PR TITLE
stb.h: compile fix for MinGW

### DIFF
--- a/stb.h
+++ b/stb.h
@@ -206,7 +206,7 @@ CREDITS
    #endif
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
    #define _CRT_SECURE_NO_WARNINGS
    #define _CRT_NONSTDC_NO_DEPRECATE
    #define _CRT_NON_CONFORMING_SWPRINTFS


### PR DESCRIPTION
Simple tweak to enable compiling stb.h with MinGW.

Background: `#ifdef _WIN32` is used to check if compiling with MSVC, but gcc under Windows is also _WIN32 (I guess clang is so too).

The MSVC-specific `intrin.h` is then included for, as far as I can tell, the optimized `_BitScanReverse` in `stb_log2_floor()`. However, 65ebe75124a69193748021fa96eaa6cf660db9b9, already chooses the unoptimized version of `stb_log2_floor()` when compiling with MinGW.

If this is the only use of `intrin.h`, this pull should not break anything.