### PR TITLE
Removie implicit cast to float

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -467,7 +467,7 @@ void stbiw__linear_to_rgbe(unsigned char *rgbe, float *linear)
    int exponent;
    float maxcomp = stbiw__max(linear[0], stbiw__max(linear[1], linear[2]));
 
-   if (maxcomp < 1e-32) {
+   if (maxcomp < 1e-32f) {
       rgbe[0] = rgbe[1] = rgbe[2] = rgbe[3] = 0;
    } else {
       float normalize = (float) frexp(maxcomp, &exponent) * 256.0f/maxcomp;


### PR DESCRIPTION
When compiling with more restrictive compiler options
such casting from double to float will cause a warning.

Ex. GCC -Wdouble-promotion

Signed-off-by: Filip Wasil <filip.wasil@gmail.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nothings/stb/194)
<!-- Reviewable:end -->
