### PR TITLE
Fix the calculation of the input image shift when using subpixel regions

### DIFF
--- a/docs/other_libs.md
+++ b/docs/other_libs.md
@@ -64,7 +64,7 @@ this! But you might like them anyway:
 - **profiling** [Remotery](https://github.com/Celtoys/Remotery): CPU/GPU profiler Win/Mac/Linux, using web browser for viewer (Apache 2.0 license)
 - **profiling** [MicroProfile](https://bitbucket.org/jonasmeyer/microprofile): CPU (and GPU?) profiler, 1-3 header files (unlicense) *uses miniz internally*
 - **parsing** [json.h](https://github.com/sheredom/json.h): JSON parser (public domain)
-- _**parsing** [jzon.h](https://github.com/Zguy/Jzon): JSON parser, C++ (MIT license)
+- _**parsing** [jzon.h](https://github.com/Zguy/Jzon): JSON parser, C++ (MIT license)_
 - **strings** [dfa](http://bjoern.hoehrmann.de/utf-8/decoder/dfa/): fast utf8 decoder (MIT license)
 - **data structures** [klib](http://attractivechaos.github.io/klib/): many 2-file libs: hash, sort, b-tree, etc (MIT license)
 - _**data structures** [uthash](https://github.com/troydhanson/uthash): several 1-header, 1-license-file libs: generic hash, list, etc (BSD license)_

--- a/stb_image_resize.h
+++ b/stb_image_resize.h
@@ -2229,8 +2229,8 @@ static void stbir__calculate_transform(stbir__info *info, float s0, float t0, fl
         info->horizontal_scale = ((float)info->output_w / info->input_w) / (s1 - s0);
         info->vertical_scale = ((float)info->output_h / info->input_h) / (t1 - t0);
 
-        info->horizontal_shift = s0 * info->input_w / (s1 - s0);
-        info->vertical_shift = t0 * info->input_h / (t1 - t0);
+        info->horizontal_shift = s0 * info->output_w / (s1 - s0);
+        info->vertical_shift = t0 * info->output_h / (t1 - t0);
     }
 }
 

--- a/stb_image_resize.h
+++ b/stb_image_resize.h
@@ -1004,31 +1004,31 @@ stbir__inline static int stbir__edge_wrap(stbir_edge edge, int n, int max)
 }
 
 // What input pixels contribute to this output pixel?
-static void stbir__calculate_sample_range_upsample(int n, float out_filter_radius, float scale_ratio, float in_shift, int* in_first_pixel, int* in_last_pixel, float* in_center_of_out)
+static void stbir__calculate_sample_range_upsample(int n, float out_filter_radius, float scale_ratio, float out_shift, int* in_first_pixel, int* in_last_pixel, float* in_center_of_out)
 {
     float out_pixel_center = (float)n + 0.5f;
     float out_pixel_influence_lowerbound = out_pixel_center - out_filter_radius;
     float out_pixel_influence_upperbound = out_pixel_center + out_filter_radius;
 
-    float in_pixel_influence_lowerbound = out_pixel_influence_lowerbound / scale_ratio + in_shift;
-    float in_pixel_influence_upperbound = out_pixel_influence_upperbound / scale_ratio + in_shift;
+    float in_pixel_influence_lowerbound = (out_pixel_influence_lowerbound + out_shift) / scale_ratio;
+    float in_pixel_influence_upperbound = (out_pixel_influence_upperbound + out_shift) / scale_ratio;
 
-    *in_center_of_out = out_pixel_center / scale_ratio + in_shift;
+    *in_center_of_out = (out_pixel_center + out_shift) / scale_ratio;
     *in_first_pixel = (int)(floor(in_pixel_influence_lowerbound + 0.5));
     *in_last_pixel = (int)(floor(in_pixel_influence_upperbound - 0.5));
 }
 
 // What output pixels does this input pixel contribute to?
-static void stbir__calculate_sample_range_downsample(int n, float in_pixels_radius, float scale_ratio, float in_shift, int* out_first_pixel, int* out_last_pixel, float* out_center_of_in)
+static void stbir__calculate_sample_range_downsample(int n, float in_pixels_radius, float scale_ratio, float out_shift, int* out_first_pixel, int* out_last_pixel, float* out_center_of_in)
 {
     float in_pixel_center = (float)n + 0.5f;
     float in_pixel_influence_lowerbound = in_pixel_center - in_pixels_radius;
     float in_pixel_influence_upperbound = in_pixel_center + in_pixels_radius;
 
-    float out_pixel_influence_lowerbound = (in_pixel_influence_lowerbound - in_shift) * scale_ratio;
-    float out_pixel_influence_upperbound = (in_pixel_influence_upperbound - in_shift) * scale_ratio;
+    float out_pixel_influence_lowerbound = in_pixel_influence_lowerbound * scale_ratio - out_shift;
+    float out_pixel_influence_upperbound = in_pixel_influence_upperbound * scale_ratio - out_shift;
 
-    *out_center_of_in = (in_pixel_center - in_shift) * scale_ratio;
+    *out_center_of_in = in_pixel_center * scale_ratio - out_shift;
     *out_first_pixel = (int)(floor(out_pixel_influence_lowerbound + 0.5));
     *out_last_pixel = (int)(floor(out_pixel_influence_upperbound - 0.5));
 }

--- a/tests/resample_test.cpp
+++ b/tests/resample_test.cpp
@@ -510,6 +510,18 @@ void test_subpixel_1()
 			STBIR_ASSERT(output_data[y * 16 + x + 8] == output_right[y * 8 + x]);
 		}
 	}
+
+	stbir_resize_subpixel(image, 8, 8, 0, output_left, 8, 16, 0, STBIR_TYPE_UINT8, 1, STBIR_ALPHA_CHANNEL_NONE, 0, STBIR_EDGE_CLAMP, STBIR_EDGE_CLAMP, STBIR_FILTER_CATMULLROM, STBIR_FILTER_CATMULLROM, STBIR_COLORSPACE_SRGB, &g_context, 2, 2, 0, 0);
+	stbir_resize_subpixel(image, 8, 8, 0, output_right, 8, 16, 0, STBIR_TYPE_UINT8, 1, STBIR_ALPHA_CHANNEL_NONE, 0, STBIR_EDGE_CLAMP, STBIR_EDGE_CLAMP, STBIR_FILTER_CATMULLROM, STBIR_FILTER_CATMULLROM, STBIR_COLORSPACE_SRGB, &g_context, 2, 2, 8, 0);
+
+	for (int x = 0; x < 8; x++)
+	{
+		for (int y = 0; y < 16; y++)
+		{
+			STBIR_ASSERT(output_data[y * 16 + x] == output_left[y * 8 + x]);
+			STBIR_ASSERT(output_data[y * 16 + x + 8] == output_right[y * 8 + x]);
+		}
+	}
 }
 
 // test that replicating an image and using a subtile of it produces same results as wraparound
@@ -547,6 +559,14 @@ void test_subpixel_2()
 		for (int y = 0; y < 16; y++)
 			STBIR_ASSERT(output_data_1[y * 16 + x] == output_data_2[y * 16 + x]);
 	}}
+
+	stbir_resize_subpixel(large_image, 32, 32, 0, output_data_2, 16, 16, 0, STBIR_TYPE_UINT8, 1, STBIR_ALPHA_CHANNEL_NONE, 0, STBIR_EDGE_WRAP, STBIR_EDGE_WRAP, STBIR_FILTER_CATMULLROM, STBIR_FILTER_CATMULLROM, STBIR_COLORSPACE_SRGB, &g_context, 2, 2, 16, 16);
+
+	{for (int x = 0; x < 16; x++)
+	{
+		for (int y = 0; y < 16; y++)
+			STBIR_ASSERT(output_data_1[y * 16 + x] == output_data_2[y * 16 + x]);
+	}}
 }
 
 // test that 0,0,1,1 subpixel produces same result as no-rect
@@ -570,6 +590,14 @@ void test_subpixel_3()
 		for (int y = 0; y < 32; y++)
 			STBIR_ASSERT(output_data_1[y * 32 + x] == output_data_2[y * 32 + x]);
 	}
+
+	stbir_resize_subpixel(image, 8, 8, 0, output_data_1, 32, 32, 0, STBIR_TYPE_UINT8, 1, 0, STBIR_ALPHA_CHANNEL_NONE, STBIR_EDGE_CLAMP, STBIR_EDGE_CLAMP, STBIR_FILTER_CATMULLROM, STBIR_FILTER_CATMULLROM, STBIR_COLORSPACE_LINEAR, NULL, 4, 4, 0, 0);
+
+	for (int x = 0; x < 32; x++)
+	{
+		for (int y = 0; y < 32; y++)
+			STBIR_ASSERT(output_data_1[y * 32 + x] == output_data_2[y * 32 + x]);
+	}
 }
 
 // test that 1:1 resample using s,t=0,0,1,1 with bilinear produces original image
@@ -585,6 +613,9 @@ void test_subpixel_4()
 	unsigned char output[8 * 8];
 
 	stbir_resize_region(image, 8, 8, 0, output, 8, 8, 0, STBIR_TYPE_UINT8, 1, STBIR_ALPHA_CHANNEL_NONE, 0, STBIR_EDGE_CLAMP, STBIR_EDGE_CLAMP, STBIR_FILTER_TRIANGLE, STBIR_FILTER_TRIANGLE, STBIR_COLORSPACE_LINEAR, &g_context, 0, 0, 1, 1);
+	STBIR_ASSERT(memcmp(image, output, 8 * 8) == 0);
+
+	stbir_resize_subpixel(image, 8, 8, 0, output, 8, 8, 0, STBIR_TYPE_UINT8, 1, STBIR_ALPHA_CHANNEL_NONE, 0, STBIR_EDGE_CLAMP, STBIR_EDGE_CLAMP, STBIR_FILTER_TRIANGLE, STBIR_FILTER_TRIANGLE, STBIR_COLORSPACE_LINEAR, &g_context, 1, 1, 0, 0);
 	STBIR_ASSERT(memcmp(image, output, 8 * 8) == 0);
 }
 


### PR DESCRIPTION
Includes some more tests which had incorrect results before, but work fine with the included fixes. The test does a subpixel region that slides from [0, 0.5] to [0.5, 1] for both upsampling and downsampling. I think that should cover all of the uses of the subpixel stuff. I'm not bothering with s < 0 or t > 1 because I don't think we ever intended to support that in the first place. At the very least, non-subpixel stuff is unaffected because s0 = t0 = 0 means in_shift = 0.