### PR TITLE
Fix for stbi_info on TGA files

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -6017,7 +6017,7 @@ static int stbi__hdr_info(stbi__context *s, int *x, int *y, int *comp)
    char *token;
    int valid = 0;
 
-   if (strcmp(stbi__hdr_gettoken(s,buffer), "#?RADIANCE") != 0) {
+   if (stbi__hdr_test(s) == 0) {
        stbi__rewind( s );
        return 0;
    }


### PR DESCRIPTION
If you call any of the `stbi_info*` family of functions right now on a TGA file it can easily break. `stbi__hdr_info` tries to read a token to verify the header, which reads to the next newline or EOF. Even if it then rewinds on failure, the original file header may well be long gone from `s->img_buffer`.

Since there's a nice test function that will only look at the first few bytes it's interested in, using that should be safer.