### PR TITLE
Fix MSVC warnings in stb_image_write

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -143,9 +143,15 @@ STBIWDEF int stbi_write_hdr_to_func(stbi_write_func *func, void *context, int w,
 
 #ifdef STB_IMAGE_WRITE_IMPLEMENTATION
 
-#ifdef _WIN32
-   #define _CRT_SECURE_NO_WARNINGS
-   #define _CRT_NONSTDC_NO_DEPRECATE
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+//MSVC complains if either are already defined
+#pragma warning(push)
+#pragma warning(disable: 4005)
+#endif
+#define _CRT_SECURE_NO_WARNINGS
+#define _CRT_NONSTDC_NO_DEPRECATE
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#pragma warning(pop)
 #endif
 
 #ifndef STBI_WRITE_NO_STDIO


### PR DESCRIPTION
Checking if _WIN32 is defined is redundant when _MSC_VER is defined, so took that out as well.