### PR TITLE
Fix stb_arr_insertn and stb_arr_deleten memmove lengths

### DIFF
--- a/stb.h
+++ b/stb.h
@@ -3062,7 +3062,7 @@ typedef struct
 #define stb_arr_insertn(a,i,n) (stb__arr_insertn((void **) &(a), sizeof(*a), i, n))
 
 // insert an element at i
-#define stb_arr_insert(a,i,v)  (stb__arr_insertn((void **) &(a), sizeof(*a), i, n), ((a)[i] = v))
+#define stb_arr_insert(a,i,v)  (stb__arr_insertn((void **) &(a), sizeof(*a), i, 1), ((a)[i] = v))
 
 // delete N elements from the middle starting at index 'i'
 #define stb_arr_deleten(a,i,n) (stb__arr_deleten((void **) &(a), sizeof(*a), i, n))

--- a/stb.h
+++ b/stb.h
@@ -3249,7 +3249,7 @@ void stb__arr_insertn_(void **pp, int size, int i, int n  STB__PARAMS)
 
       z = stb_arr_len2(p);
       stb__arr_addlen_(&p, size, i  STB__ARGS);
-      memmove((char *) p + (i+n)*size, (char *) p + i*size, size * (z-i));
+      memmove((char *) p + (i+n)*size, (char *) p + i*size, size * (z-(i+n)));
    }
    *pp = p;
 }
@@ -3258,7 +3258,7 @@ void stb__arr_deleten_(void **pp, int size, int i, int n  STB__PARAMS)
 {
    void *p = *pp;
    if (n) {
-      memmove((char *) p + i*size, (char *) p + (i+n)*size, size * (stb_arr_len2(p)-i));
+      memmove((char *) p + i*size, (char *) p + (i+n)*size, size * (stb_arr_len2(p)-(i+n)));
       stb_arrhead2(p)->len -= n;
    }
    *pp = p;

--- a/stb.h
+++ b/stb.h
@@ -3248,8 +3248,8 @@ void stb__arr_insertn_(void **pp, int size, int i, int n  STB__PARAMS)
       }
 
       z = stb_arr_len2(p);
-      stb__arr_addlen_(&p, size, i  STB__ARGS);
-      memmove((char *) p + (i+n)*size, (char *) p + i*size, size * (z-(i+n)));
+      stb__arr_addlen_(&p, size, n  STB__ARGS);
+      memmove((char *) p + (i+n)*size, (char *) p + i*size, size * (z-i));
    }
    *pp = p;
 }


### PR DESCRIPTION
deleten was moving memory beyond the array bounds.
insert meant to pass 1 to insertn
insertn was resizing to +i in length instead of +n