### PR TITLE
stb_textedit: better support for keying while holding mouse drag button

### DIFF
--- a/stb_textedit.h
+++ b/stb_textedit.h
@@ -451,6 +451,8 @@ static void stb_textedit_click(STB_TEXTEDIT_STRING *str, STB_TexteditState *stat
 static void stb_textedit_drag(STB_TEXTEDIT_STRING *str, STB_TexteditState *state, float x, float y)
 {
    int p = stb_text_locate_coord(str, x, y);
+   if (state->select_start == state->select_end)
+      state->select_start = state->cursor;
    state->cursor = state->select_end = p;
 }
 


### PR DESCRIPTION
This stem from a user bug report here https://github.com/ocornut/imgui/issues/429

Basically the code expect stb_textedit_click() to typically be followed by stb_textedit_drag(). If other actions are performed in-between the results are usually odd.

Below a reading of what is happening in both cases. This is probably hard to digest and annoying to read, probably easier to test with/without the patch. With the patch seems to match Windows behavior if the users make sure to only call stb_textedit_drag() when mouse is moving and not when mouse is still. If the user keeps calling _drag() every tick behaviour will be different to the user but still more reasonable with patch. At this point Windows does haven't a threshold lock so a single unit of mouse movement triggers the refresh of drag.

This are all examples while holding the mouse button:

Scenario 1
- Text is "Hello", user click() after last character (5) and drags far right, select_start=select_end=5. User input "A" while holding mouse. stb_textedit_delete_selection() does `state->select_start = state->cursor = state->select_end` (==5); then key handler does ++cursor (==6). Text is "HelloA". 

- Without patch:
On next call to stb_textedit_drag(). **select_start is still 5, select_end becomes 6 (because mouse is far right) so  "A" is selected. Further input will overwrite the "A".**, which is weird.

- With patch
On next call to stb_textedit_drag(), **select_start gets set to cursor. select_start is 6 (because cursor), select_end becomes 6 (because mouse is far right), so nothing is selected and further key inputs keeps appending to the text.**

Scenario 2
- Text is "Hello", user click() after last character (5) and drags far left. select_start=5, select_end=0. User input "A" while holding mouse. stb_textedit_delete_selection() does `state->select_start = state->cursor = state->select_end` (==0); then key handler does ++cursor (==1). Text is "A". 

- Without patch: 
On next call to stb_textedit_drag(), **select_end and cursor gets updated to 0, so cursor is on zero and we have no selection. Further input will input character on the LEFT side of "A".**, which is weird.

- With patch:
On next call to stb_textedit_drag(), **select_start gets set to cursor. select_start is 1 (because cursor), select_end becomes 0 (because mouse is far left), so "A" is selected and further key inputs will keep overwriting it.**, which is not useful but appears more logical.

Scenario 3
- Text is "Hello", user click() after character 2, drags far right, selects "llo". User input "A" while holding mouse. stb_textedit_delete_selection() does `state->select_end = state->cursor = state->select_start` (==2). then key handler does ++cursor (==3). Text is "HeA".

- Without patch:
On next call to stb_textedit_drag(), **select_start is still 2, select_end gets updated to 3 (because mouse is far right), so "A" is selected and further input will overwrite the "A".**, which is weird.

- With patch:
On next call to stb_textedit_drag(), **select_start gets set to cursor. select_start is 3. select_end is 3 (because far right), so nothing is selected and further key inputs keeps adding to text**
