### PR TITLE
ttf: Correct direct use of fabs()

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -403,6 +403,11 @@ int main(int arg, char **argv)
    #define STBTT_sqrt(x)      sqrt(x)
    #endif
 
+   #ifndef STBTT_fabs
+   #include <math.h>
+   #define STBTT_fabs(x)      fabs(x)
+   #endif
+
    // #define your own functions "STBTT_malloc" / "STBTT_free" to avoid malloc.h
    #ifndef STBTT_malloc
    #include <stdlib.h>


### PR DESCRIPTION
Add a macro to allow fabs() to be provided by the user, as with the other
maths functions.

Signed-off-by: Simon Glass <sjg@chromium.org>