### PR TITLE
Added the old size as argument to STBI_REALLOC and STBIW_REALLOC

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -166,9 +166,9 @@ STBIWDEF int stbi_write_hdr_to_func(stbi_write_func *func, void *context, int w,
 #endif
 
 #ifndef STBIW_MALLOC
-#define STBIW_MALLOC(sz)    malloc(sz)
-#define STBIW_REALLOC(p,sz) realloc(p,sz)
-#define STBIW_FREE(p)       free(p)
+#define STBIW_MALLOC(sz)             malloc(sz)
+#define STBIW_REALLOC(p,oldsz,newsz) realloc(p,newsz)
+#define STBIW_FREE(p)                free(p)
 #endif
 #ifndef STBIW_MEMMOVE
 #define STBIW_MEMMOVE(a,b,sz) memmove(a,b,sz)
@@ -647,7 +647,7 @@ int stbi_write_hdr(char const *filename, int x, int y, int comp, const float *da
 static void *stbiw__sbgrowf(void **arr, int increment, int itemsize)
 {
    int m = *arr ? 2*stbiw__sbm(*arr)+increment : increment+1;
-   void *p = STBIW_REALLOC(*arr ? stbiw__sbraw(*arr) : 0, itemsize * m + sizeof(int)*2);
+   void *p = STBIW_REALLOC(*arr ? stbiw__sbraw(*arr) : 0, *arr ? (stbiw__sbm(*arr)*itemsize + sizeof(int)*2) : 0, itemsize * m + sizeof(int)*2);
    STBIW_ASSERT(p);
    if (p) {
       if (!*arr) ((int *) p)[1] = 0;


### PR DESCRIPTION
I often find myself in situations where allocators don't have a realloc feature and querying the size of an allocated block is not possible either. As a workaround I added the previously allocated size as an argument to the STBxx_REALLOC() macros.

Unfortunately, this change breaks backward compatibility for those who redefined the macros. But then, the fix is trivial.