### PR TITLE
Warnings C4703 and C4005 fix

### DIFF
--- a/stb.h
+++ b/stb.h
@@ -7786,7 +7786,7 @@ stb_ps *stb_ps_remove_any(stb_ps *ps, void **value)
 void ** stb_ps_getlist(stb_ps *ps, int *count)
 {
    int i,n=0;
-   void **p;
+   void **p = NULL;
    switch (3 & (int) ps) {
       case STB_ps_direct:
          if (ps == NULL) { *count = 0; return NULL; }

--- a/stb.h
+++ b/stb.h
@@ -207,9 +207,15 @@ CREDITS
 #endif
 
 #ifdef _WIN32
+   #ifndef _CRT_SECURE_NO_WARNINGS
    #define _CRT_SECURE_NO_WARNINGS
+   #endif
+   #ifndef _CRT_NONSTDC_NO_DEPRECATE
    #define _CRT_NONSTDC_NO_DEPRECATE
+   #endif
+   #ifndef _CRT_NON_CONFORMING_SWPRINTFS
    #define _CRT_NON_CONFORMING_SWPRINTFS
+   #endif
    #if !defined(_MSC_VER) || _MSC_VER > 1700
    #include <intrin.h> // _BitScanReverse
    #endif

--- a/stb_tilemap_editor.h
+++ b/stb_tilemap_editor.h
@@ -328,7 +328,9 @@
 #define STB_TILEMAP_INCLUDE_STB_TILEMAP_EDITOR_H
 
 #ifdef _WIN32
+  #ifndef _CRT_SECURE_NO_WARNINGS
   #define _CRT_SECURE_NO_WARNINGS
+  #endif
   #include <stdlib.h>
   #include <stdio.h>
 #endif


### PR DESCRIPTION
Warning C4703 treated as error with /sdl compiler switch. Also add conditions to prevent _CRT... stuff redefinition.