### PR TITLE
Silence unused variable warning in STBI_REALLOC_SIZED macro

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -637,7 +637,7 @@ typedef unsigned char validate_uint32[sizeof(stbi__uint32)==4 ? 1 : -1];
 #endif
 
 #ifndef STBI_REALLOC_SIZED
-#define STBI_REALLOC_SIZED(p,oldsz,newsz) STBI_REALLOC(p,newsz)
+#define STBI_REALLOC_SIZED(p,oldsz,newsz) STBI_REALLOC(p,newsz-(0*oldsz))
 #endif
 
 // x86/x64 detection


### PR DESCRIPTION
A dirty hack to silence the "unused variable" warning. Compiler will optimise this and remove the (0*oldsz) part with any optimisation enabled.