### PR TITLE
Add atomic-ring to other_libs

### DIFF
--- a/docs/other_libs.md
+++ b/docs/other_libs.md
@@ -54,6 +54,7 @@ images | [jpeg-compressor](https://github.com/richgel999/jpeg-compressor) | **pu
 math | [mm_vec.h](https://github.com/vurtun/mmx) | BSD | **1** | SIMD vector math
 math | [ShaderFastLibs](https://github.com/michaldrobot/ShaderFastLibs) | MIT | **1** | approximate transcendental functions optimized for shaders (esp. GCN)
 multithreading | [mm_sched.h](https://github.com/vurtun/mmx) | zlib | **1** | cross-platform multithreaded task scheduler
+multithreading | [atomic-ring](https://github.com/djcapelis/atomic-ring) | **public&nbsp;domain** | 2 | Single Producer Single Consumer (SPSC) lock-free queue
 network | **[zed_net](https://github.com/ZedZull/zed_net)**|**public&nbsp;domain**|**1**|cross-platform socket wrapper
 network | [mm_web.h](https://github.com/vurtun/mmx) | BSD | **1** | lightweight webserver, fork of webby
 network | [par_easycurl.h](https://github.com/prideout/par) | MIT | **1** | curl wrapper


### PR DESCRIPTION
I saw your awesome list of single file libraries and thought I'd propose a project I wrote as part of it. :)  It's a lock-free queue I use to pass tasks between threads in most of my multithreaded code.  No locks.  It does unfortunately require C11, but there's no dependencies beyond that, not even POSIX.  Should work on every architecture you can find a C11 compiler for.  (The tests uses POSIX, but the library is all pure standardized cross platform C.)

Cheers!  And thanks for putting this list together, it's quirky and I like it.