### PR TITLE
other_libs.md: Add Picol

### DIFF
--- a/docs/other_libs.md
+++ b/docs/other_libs.md
@@ -96,6 +96,7 @@ profiling         |  [Remotery](https://github.com/Celtoys/Remotery)            
 profiling         |  [MicroProfile](https://bitbucket.org/jonasmeyer/microprofile)        | **unlicense**        |     | 2-4 | CPU (and GPU?) profiler, 1-3 header files, uses miniz internally
 scripting         |  [LIL](http://runtimelegend.com/rep/lil/)                             | zlib                 |**C**|  2  | interpreter for a Tcl-like scripting language
 scripting         |  [lualite](https://github.com/janezz55/lualite/)                      | MIT                  | C++ |**1**| generate lua bindings in C++
+scripting         |  [Picol](https://chiselapp.com/user/dbohdan/repository/picol/)        | BSD                  |**C**|  2  | interpreter for a Tcl-like scripting language
 strings           |**[DG_misc.h](https://github.com/DanielGibson/Snippets/)**             | **public domain**    |     |**1**| Daniel Gibson's stb.h-esque cross-platform helpers: path/file, strings         
 strings           |**[utf8](https://github.com/sheredom/utf8.h)**                         | **public domain**    |     |**1**| utf8 string library
 strings           |**[strpool.h](https://github.com/mattiasgustavsson/libs)**             | **public domain**    |     |**1**| string interning


### PR DESCRIPTION
[This](https://chiselapp.com/user/dbohdan/repository/picol/home) version is still two files rather than one but in it the REPL has been separated from the library and two embedding examples have been added.