### PR TITLE
Slightly modify the public domain license

### DIFF
--- a/docs/stb_howto.txt
+++ b/docs/stb_howto.txt
@@ -165,9 +165,9 @@ public domain declarations aren't necessary recognized
 in the USA and some other locations. For that reason,
 I recommend a declaration along these lines:
 
-// This software is in the public domain. Where that dedication is not
-// recognized, you are granted a perpetual, irrevocable license to copy
-// and modify this file as you see fit.
+// This software is dual-licensed to the public domain and under the following
+// license: you are granted a perpetual, irrevocable license to copy, modify,
+// publish, and distribute this file as you see fit.
 
 I typically place this declaration at the end of the initial
 comment block of the file and just say 'public domain'

--- a/docs/why_public_domain.md
+++ b/docs/why_public_domain.md
@@ -95,9 +95,9 @@ public domain declarations aren't necessary recognized
 in the USA and some other locations. For that reason,
 I recommend a declaration along these lines:
 
-// This software is in the public domain. Where that dedication is not
-// recognized, you are granted a perpetual, irrevocable license to copy
-// and modify this file as you see fit.
+// This software is dual-licensed to the public domain and under the following
+// license: you are granted a perpetual, irrevocable license to copy, modify,
+// publish, and distribute this file as you see fit.
 
 I typically place this declaration at the end of the initial
 comment block of the file and just say 'public domain'

--- a/stb.h
+++ b/stb.h
@@ -171,9 +171,9 @@ Parenthesized items have since been removed.
 
 LICENSE
 
-This software is in the public domain. Where that dedication is not
-recognized, you are granted a perpetual, irrevocable license to copy,
-distribute, and modify this file as you see fit.
+This software is dual-licensed to the public domain and under the following
+license: you are granted a perpetual, irrevocable license to copy, modify,
+publish, and distribute this file as you see fit.
 
 CREDITS
 

--- a/stb_c_lexer.h
+++ b/stb_c_lexer.h
@@ -32,9 +32,9 @@
 //
 // LICENSE
 //
-//   This software is in the public domain. Where that dedication is not
-//   recognized, you are granted a perpetual, irrevocable license to copy,
-//   distribute, and modify this file as you see fit.
+//   This software is dual-licensed to the public domain and under the following
+//   license: you are granted a perpetual, irrevocable license to copy, modify,
+//   publish, and distribute this file as you see fit.
 
 #ifndef STB_C_LEXER_DEFINITIONS
 // to change the default parsing rules, copy the following lines

--- a/stb_divide.h
+++ b/stb_divide.h
@@ -78,9 +78,9 @@
 //
 // LICENSE
 //
-//   This software is in the public domain. Where that dedication is not
-//   recognized, you are granted a perpetual, irrevocable license to copy,
-//   distribute, and modify this file as you see fit.
+//   This software is dual-licensed to the public domain and under the following
+//   license: you are granted a perpetual, irrevocable license to copy, modify,
+//   publish, and distribute this file as you see fit.
 
 
 #ifndef INCLUDE_STB_DIVIDE_H

--- a/stb_dxt.h
+++ b/stb_dxt.h
@@ -19,9 +19,9 @@
 //
 // LICENSE
 //
-//   This software is in the public domain. Where that dedication is not
-//   recognized, you are granted a perpetual, irrevocable license to copy,
-//   distribute, and modify this file as you see fit.
+//   This software is dual-licensed to the public domain and under the following
+//   license: you are granted a perpetual, irrevocable license to copy, modify,
+//   publish, and distribute this file as you see fit.
 
 #ifndef STB_INCLUDE_STB_DXT_H
 #define STB_INCLUDE_STB_DXT_H

--- a/stb_easy_font.h
+++ b/stb_easy_font.h
@@ -67,9 +67,9 @@
 //
 // LICENSE
 //
-//   This software is in the public domain. Where that dedication is not
-//   recognized, you are granted a perpetual, irrevocable license to copy,
-//   distribute, and modify this file as you see fit.
+//   This software is dual-licensed to the public domain and under the following
+//   license: you are granted a perpetual, irrevocable license to copy, modify,
+//   publish, and distribute this file as you see fit.
 //
 // VERSION HISTORY
 //

--- a/stb_herringbone_wang_tile.h
+++ b/stb_herringbone_wang_tile.h
@@ -3,9 +3,9 @@
 
 == LICENSE ==============================
 
-This software is in the public domain. Where that dedication is not
-recognized, you are granted a perpetual, irrevocable license to copy,
-distribute, and modify this file as you see fit.
+This software is dual-licensed to the public domain and under the following
+license: you are granted a perpetual, irrevocable license to copy, modify,
+publish, and distribute this file as you see fit.
 
 == WHAT IT IS ===========================
 

--- a/stb_image.h
+++ b/stb_image.h
@@ -209,9 +209,9 @@
 
 LICENSE
 
-This software is in the public domain. Where that dedication is not
-recognized, you are granted a perpetual, irrevocable license to copy,
-distribute, and modify this file as you see fit.
+This software is dual-licensed to the public domain and under the following
+license: you are granted a perpetual, irrevocable license to copy, modify,
+publish, and distribute this file as you see fit.
 
 */
 

--- a/stb_image_resize.h
+++ b/stb_image_resize.h
@@ -160,9 +160,9 @@
 
    LICENSE
 
-     This software is in the public domain. Where that dedication is not
-     recognized, you are granted a perpetual, irrevocable license to copy,
-     distribute, and modify this file as you see fit.
+     This software is dual-licensed to the public domain and under the following
+     license: you are granted a perpetual, irrevocable license to copy, modify,
+     publish, and distribute this file as you see fit.
 
    TODO
       Don't decode all of the image data when only processing a partial tile

--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -105,9 +105,9 @@ CREDITS:
       
 LICENSE
 
-This software is in the public domain. Where that dedication is not
-recognized, you are granted a perpetual, irrevocable license to copy,
-distribute, and modify this file as you see fit.
+This software is dual-licensed to the public domain and under the following
+license: you are granted a perpetual, irrevocable license to copy, modify,
+publish, and distribute this file as you see fit.
 
 */
 

--- a/stb_leakcheck.h
+++ b/stb_leakcheck.h
@@ -1,9 +1,9 @@
 // stb_leakcheck.h - v0.2 - quick & dirty malloc leak-checking - public domain
 // LICENSE
 //
-//   This software is in the public domain. Where that dedication is not
-//   recognized, you are granted a perpetual, irrevocable license to copy,
-//   distribute, and modify this file as you see fit.
+//   This software is dual-licensed to the public domain and under the following
+//   license: you are granted a perpetual, irrevocable license to copy, modify,
+//   publish, and distribute this file as you see fit.
 
 #ifdef STB_LEAKCHECK_IMPLEMENTATION
 #undef STB_LEAKCHECK_IMPLEMENTATION // don't implenment more than once

--- a/stb_perlin.h
+++ b/stb_perlin.h
@@ -3,9 +3,9 @@
 //
 // LICENSE
 //
-//   This software is in the public domain. Where that dedication is not
-//   recognized, you are granted a perpetual, irrevocable license to copy,
-//   distribute, and modify this file as you see fit.
+//   This software is dual-licensed to the public domain and under the following
+//   license: you are granted a perpetual, irrevocable license to copy, modify,
+//   publish, and distribute this file as you see fit.
 //
 //
 // to create the implementation,

--- a/stb_rect_pack.h
+++ b/stb_rect_pack.h
@@ -41,9 +41,9 @@
 //
 // LICENSE
 //
-//   This software is in the public domain. Where that dedication is not
-//   recognized, you are granted a perpetual, irrevocable license to copy,
-//   distribute, and modify this file as you see fit.
+//   This software is dual-licensed to the public domain and under the following
+//   license: you are granted a perpetual, irrevocable license to copy, modify,
+//   publish, and distribute this file as you see fit.
 
 //////////////////////////////////////////////////////////////////////////////
 //

--- a/stb_textedit.h
+++ b/stb_textedit.h
@@ -17,9 +17,9 @@
 //
 // LICENSE
 //
-//   This software is in the public domain. Where that dedication is not
-//   recognized, you are granted a perpetual, irrevocable license to copy,
-//   distribute, and modify this file as you see fit.
+//   This software is dual-licensed to the public domain and under the following
+//   license: you are granted a perpetual, irrevocable license to copy, modify,
+//   publish, and distribute this file as you see fit.
 //
 //
 // DEPENDENCIES

--- a/stb_tilemap_editor.h
+++ b/stb_tilemap_editor.h
@@ -316,9 +316,9 @@
 //
 // LICENSE
 //
-//   This software is in the public domain. Where that dedication is not
-//   recognized, you are granted a perpetual, irrevocable license to copy,
-//   distribute, and modify this file as you see fit.
+//   This software is dual-licensed to the public domain and under the following
+//   license: you are granted a perpetual, irrevocable license to copy, modify,
+//   publish, and distribute this file as you see fit.
 
 
 

--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -68,9 +68,9 @@
 //
 // LICENSE
 //
-//   This software is in the public domain. Where that dedication is not
-//   recognized, you are granted a perpetual, irrevocable license to copy,
-//   distribute, and modify this file as you see fit.
+//   This software is dual-licensed to the public domain and under the following
+//   license: you are granted a perpetual, irrevocable license to copy, modify,
+//   publish, and distribute this file as you see fit.
 //
 // USAGE
 //

--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -9,9 +9,9 @@
 //
 // LICENSE
 //
-//   This software is in the public domain. Where that dedication is not
-//   recognized, you are granted a perpetual, irrevocable license to copy,
-//   distribute, and modify this file as you see fit.
+//   This software is dual-licensed to the public domain and under the following
+//   license: you are granted a perpetual, irrevocable license to copy, modify,
+//   publish, and distribute this file as you see fit.
 //
 // No warranty for any purpose is expressed or implied by the author (nor
 // by RAD Game Tools). Report bugs and send enhancements to the author.

--- a/stb_voxel_render.h
+++ b/stb_voxel_render.h
@@ -215,9 +215,9 @@
 //
 // LICENSE
 //
-//   This software is in the public domain. Where that dedication is not
-//   recognized, you are granted a perpetual, irrevocable license to copy,
-//   distribute, and modify this file as you see fit.
+//   This software is dual-licensed to the public domain and under the following
+//   license: you are granted a perpetual, irrevocable license to copy, modify,
+//   publish, and distribute this file as you see fit.
 
 #ifndef INCLUDE_STB_VOXEL_RENDER_H
 #define INCLUDE_STB_VOXEL_RENDER_H

--- a/stretchy_buffer.h
+++ b/stretchy_buffer.h
@@ -164,9 +164,9 @@
 //
 // LICENSE
 //
-//   This software is in the public domain. Where that dedication is not
-//   recognized, you are granted a perpetual, irrevocable license to copy,
-//   distribute, and modify this file as you see fit.
+//   This software is dual-licensed to the public domain and under the following
+//   license: you are granted a perpetual, irrevocable license to copy, modify,
+//   publish, and distribute this file as you see fit.
 
 #ifndef STB_STRETCHY_BUFFER_H_INCLUDED
 #define STB_STRETCHY_BUFFER_H_INCLUDED


### PR DESCRIPTION
Slightly modify the public domain license to keep it in the public domain, but make it clear that even when dedications might not be recognized that the code is still usable.  Given that this isn't dual-licensing under a different license, I'm hoping this will be acceptable, and considered within the spirit of stb.  This is a wonderful library, and this change makes it more generally usable.
