### PR TITLE
stbi__bmp_load() might not return correct Channel

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -4603,6 +4603,11 @@ typedef struct
 {
    int bpp, offset, hsz;
    unsigned int mr,mg,mb,ma, all_a;
+   // added by snagar.dev - missing initialization. Fix the channel value for 24bit BMP files
+   void init()
+   {
+     mr = mg = mb = ma = all_a = 0;
+   }
 } stbi__bmp_data;
 
 static void *stbi__bmp_parse_header(stbi__context *s, stbi__bmp_data *info)
@@ -4699,6 +4704,7 @@ static stbi_uc *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int 
    int flip_vertically, pad, target;
    stbi__bmp_data info;
 
+   info.init(); // added by saar
    info.all_a = 255;   
    if (stbi__bmp_parse_header(s, &info) == NULL)
       return NULL; // error code already set


### PR DESCRIPTION
Struct stbi__bmp_data in stbi__bmp_load() does not have initialize code for the: mr,mg,mb,ma, all_a as the code does in the beginning of " stbi__bmp_load()" function.
When I tried to load 24bit BMP image, the number of channels returned was 4. Image displayed wrongly.
When I done the same on the old stb_image (v1.33) image displayed correctly. On that code, the channel number returned was: 3.
After debugging, I found out that difference was in the use of the named struct. The values of the parameters above were not initialized for the 24bit BMP when calling "stbi__bmp_parse_header()" 
function.

I uploaded a BMP image that had this issue.

Proposed solution:
I added an init() function to the struct, and called it just before we initialized the "info.all_a" in "stbi__bmp_load()" function.
Since the "stbi__bmp_parse_header()" is called only from  stbi__bmp_load(), I think my suggestion is safe.


[swisshut1.zip](https://github.com/nothings/stb/files/127005/swisshut1.zip)
