### PR TITLE
Fix memory leak in decode_residue() and inverse_mdct() when redefining temp_alloc() and temp_free()

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -2325,6 +2325,11 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
    }
   done:
    CHECK(f);
+   #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
+   temp_free(f,part_classdata);
+   #else
+   temp_free(f,classifications);
+   #endif
    temp_alloc_restore(f,temp_alloc_point);
 }
 
@@ -2970,6 +2975,7 @@ static void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
       }
    }
 
+   temp_free(f,buf2);
    temp_alloc_restore(f,save_point);
 }
 


### PR DESCRIPTION

Fixes #260:

temp_alloc() and temp_free() are documented as customization points in section "MEMORY ALLOCATION" (stb_vorbis.c:81).
However, in decode_residue() and inverse_mdct() (via temp_block_array() and temp_alloc() respectively), stb_vorbis allocates temporary memory but does not call temp_free() when finished. It does call temp_alloc_restore() though, but there is no sane way to provide an implementation thereof when using a malloc()/free()-like allocation backend.

Adding calls to temp_free() before the respective calls to temp_alloc_restore() is safe, because in case of a non-empty temp_alloc_restore() implementation, temp_free() would simply be implemented empty (the current implementation of temp_*() is fine in this regard). That way, all possible temporary memory allocation schemes (i.e. alloca(), custom provided alloc_buffer, malloc()) are handled properly.

Add the appropriate temp_free() calls.
