### PR TITLE
stb_vorbis: Fix memory leak in start_decoder().

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -3883,7 +3883,6 @@ static int start_decoder(vorb *f)
                   }
                }
             }
-            setup_temp_free(f, mults,sizeof(mults[0])*c->lookup_values);
             c->lookup_type = 2;
          }
          else
@@ -3899,11 +3898,11 @@ static int start_decoder(vorb *f)
                if (c->sequence_p)
                   last = val;
             }
-            setup_temp_free(f, mults,sizeof(mults[0])*c->lookup_values);
          }
 #ifndef STB_VORBIS_DIVIDES_IN_CODEBOOK
         skip:;
 #endif
+         setup_temp_free(f, mults, sizeof(mults[0])*c->lookup_values);
 
          CHECK(f);
       }


### PR DESCRIPTION
Fixes issue #265.
