### PR TITLE
Fixed dangling else warnings.

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -1880,16 +1880,17 @@ static void stbtt__handle_clipped_edge(float *scanline, int x, stbtt__active_edg
       y1 = e->ey;
    }
 
-   if (x0 == x)
+   if (x0 == x) {
       STBTT_assert(x1 <= x+1);
-   else if (x0 == x+1)
+   } else if (x0 == x+1) {
       STBTT_assert(x1 >= x);
-   else if (x0 <= x)
+   } else if (x0 <= x) {
       STBTT_assert(x1 <= x);
-   else if (x0 >= x+1)
+   } else if (x0 >= x+1) {
       STBTT_assert(x1 >= x+1);
-   else
+   } else {
       STBTT_assert(x1 >= x && x1 <= x+1);
+   }
 
    if (x0 <= x && x1 <= x)
       scanline[x] += e->direction * (y1-y0);


### PR DESCRIPTION
Fixed `-Wdangling-else` (add explicit braces to avoid dangling else) thrown by Clang.