### PR TITLE
stb_truetype: very minor unused variable warning fix in V2 rasterizer path

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -2073,6 +2073,7 @@ static void stbtt__fill_active_edges_new(float *scanline, float *scanline_fill, 
 // directly AA rasterize edges w/o supersampling
 static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result, stbtt__edge *e, int n, int vsubsample, int off_x, int off_y, void *userdata)
 {
+   (void)vsubsample;
    stbtt__hheap hh = { 0, 0, 0 };
    stbtt__active_edge *active = NULL;
    int y,j=0, i;


### PR DESCRIPTION
(That or remove "vsubsample" name in declaration, I forgot if Ansi C allows that.)