### PR TITLE
stb_textedit: Add support for custom move word left/right handlers

### DIFF
--- a/stb_textedit.h
+++ b/stb_textedit.h
@@ -148,15 +148,17 @@
 //    STB_TEXTEDIT_K_REDO        keyboard input to perform redo
 //
 // Optional:
-//    STB_TEXTEDIT_K_INSERT      keyboard input to toggle insert mode
-//    STB_TEXTEDIT_IS_SPACE(ch)  true if character is whitespace (e.g. 'isspace'),
-//                                 required for WORDLEFT/WORDRIGHT
-//    STB_TEXTEDIT_K_WORDLEFT    keyboard input to move cursor left one word // e.g. ctrl-LEFT
-//    STB_TEXTEDIT_K_WORDRIGHT   keyboard input to move cursor right one word // e.g. ctrl-RIGHT
-//    STB_TEXTEDIT_K_LINESTART2  secondary keyboard input to move cursor to start of line
-//    STB_TEXTEDIT_K_LINEEND2    secondary keyboard input to move cursor to end of line
-//    STB_TEXTEDIT_K_TEXTSTART2  secondary keyboard input to move cursor to start of text
-//    STB_TEXTEDIT_K_TEXTEND2    secondary keyboard input to move cursor to end of text
+//    STB_TEXTEDIT_K_INSERT              keyboard input to toggle insert mode
+//    STB_TEXTEDIT_IS_SPACE(ch)          true if character is whitespace (e.g. 'isspace'),
+//                                          required for default WORDLEFT/WORDRIGHT handlers
+//    STB_TEXTEDIT_MOVEWORDLEFT(obj,i)   custom handler for WORDLEFT, returns index to move cursor to
+//    STB_TEXTEDIT_MOVEWORDRIGHT(obj,i)  custom handler for WORDRIGHT, returns index to move cursor to
+//    STB_TEXTEDIT_K_WORDLEFT            keyboard input to move cursor left one word // e.g. ctrl-LEFT
+//    STB_TEXTEDIT_K_WORDRIGHT           keyboard input to move cursor right one word // e.g. ctrl-RIGHT
+//    STB_TEXTEDIT_K_LINESTART2          secondary keyboard input to move cursor to start of line
+//    STB_TEXTEDIT_K_LINEEND2            secondary keyboard input to move cursor to end of line
+//    STB_TEXTEDIT_K_TEXTSTART2          secondary keyboard input to move cursor to start of text
+//    STB_TEXTEDIT_K_TEXTEND2            secondary keyboard input to move cursor to end of text
 //
 // Todo:
 //    STB_TEXTEDIT_K_PGUP        keyboard input to move cursor up a page
@@ -615,9 +617,9 @@ static int is_word_boundary( STB_TEXTEDIT_STRING *_str, int _idx )
    return _idx > 0 ? (STB_TEXTEDIT_IS_SPACE( STB_TEXTEDIT_GETCHAR(_str,_idx-1) ) && !STB_TEXTEDIT_IS_SPACE( STB_TEXTEDIT_GETCHAR(_str, _idx) ) ) : 1;
 }
 
-static int stb_textedit_move_to_word_previous( STB_TEXTEDIT_STRING *_str, STB_TexteditState *_state )
+#ifndef STB_TEXTEDIT_MOVEWORDLEFT
+static int stb_textedit_move_to_word_previous( STB_TEXTEDIT_STRING *_str, int c )
 {
-   int c = _state->cursor - 1;
    while( c >= 0 && !is_word_boundary( _str, c ) )
       --c;
 
@@ -626,11 +628,13 @@ static int stb_textedit_move_to_word_previous( STB_TEXTEDIT_STRING *_str, STB_Te
 
    return c;
 }
+#define STB_TEXTEDIT_MOVEWORDLEFT stb_textedit_move_to_word_previous
+#endif
 
-static int stb_textedit_move_to_word_next( STB_TEXTEDIT_STRING *_str, STB_TexteditState *_state )
+#ifndef STB_TEXTEDIT_MOVEWORDRIGHT
+static int stb_textedit_move_to_word_next( STB_TEXTEDIT_STRING *_str, int c )
 {
    const int len = STB_TEXTEDIT_STRINGLEN(_str);
-   int c = _state->cursor+1;
    while( c < len && !is_word_boundary( _str, c ) )
       ++c;
 
@@ -639,6 +643,9 @@ static int stb_textedit_move_to_word_next( STB_TEXTEDIT_STRING *_str, STB_Texted
 
    return c;
 }
+#define STB_TEXTEDIT_MOVEWORDRIGHT stb_textedit_move_to_word_next
+#endif
+
 #endif
 
 // update selection and cursor to match each other
@@ -760,21 +767,12 @@ retry:
          state->has_preferred_x = 0;
          break;
 
-#ifdef STB_TEXTEDIT_IS_SPACE
+#ifdef STB_TEXTEDIT_MOVEWORDLEFT
       case STB_TEXTEDIT_K_WORDLEFT:
          if (STB_TEXT_HAS_SELECTION(state))
             stb_textedit_move_to_first(state);
          else {
-            state->cursor = stb_textedit_move_to_word_previous(str, state);
-            stb_textedit_clamp( str, state );
-         }
-         break;
-
-      case STB_TEXTEDIT_K_WORDRIGHT:
-         if (STB_TEXT_HAS_SELECTION(state)) 
-            stb_textedit_move_to_last(str, state);
-         else {
-            state->cursor = stb_textedit_move_to_word_next(str, state);
+            state->cursor = STB_TEXTEDIT_MOVEWORDLEFT(str, state->cursor-1);
             stb_textedit_clamp( str, state );
          }
          break;
@@ -783,17 +781,28 @@ retry:
          if( !STB_TEXT_HAS_SELECTION( state ) )
             stb_textedit_prep_selection_at_cursor(state);
 
-         state->cursor = stb_textedit_move_to_word_previous(str, state);
+         state->cursor = STB_TEXTEDIT_MOVEWORDLEFT(str, state->cursor-1);
          state->select_end = state->cursor;
 
          stb_textedit_clamp( str, state );
+         break;
+#endif
+
+#ifdef STB_TEXTEDIT_MOVEWORDRIGHT
+      case STB_TEXTEDIT_K_WORDRIGHT:
+         if (STB_TEXT_HAS_SELECTION(state)) 
+            stb_textedit_move_to_last(str, state);
+         else {
+            state->cursor = STB_TEXTEDIT_MOVEWORDRIGHT(str, state->cursor+1);
+            stb_textedit_clamp( str, state );
+         }
          break;
 
       case STB_TEXTEDIT_K_WORDRIGHT | STB_TEXTEDIT_K_SHIFT:
          if( !STB_TEXT_HAS_SELECTION( state ) )
             stb_textedit_prep_selection_at_cursor(state);
 
-         state->cursor = stb_textedit_move_to_word_next(str, state);
+         state->cursor = STB_TEXTEDIT_MOVEWORDRIGHT(str, state->cursor+1);
          state->select_end = state->cursor;
 
          stb_textedit_clamp( str, state );


### PR DESCRIPTION
*EDIT* Minor edits applied since first posting.

Sorry to submit that right after you've done a bunch yesterday!

This patch allows the user to optionally define two functions to override ctrl-arrow style per-word movement, `STB_TEXTEDIT_MOVEWORDLEFT(obj,i)` and `STB_TEXTEDIT_MOVEWORDRIGHT(obj,i)`

`STB_TEXTEDIT_IS_SPACE(ch)` is still supported and will generate default handlers for those, matching the existing code.

The reasoning is to allow applications to:
- Support OS X style word-jumping (move-to-next-word moves to the end of the current word instead of moving you to the beginning of the next word) to have an app be more friendly to OS. Someone made various mods to ImGui to match OS X behaviour and that was the only change they wanted that had to be done on textedit-side.
- Perform other/custom tailored word-jumping, where different tokens in a programming language may lead to slightly different moving behaviour.

Minor notes:

- I called them MOVEWORDLEFT/MOVEWORDRIGHT to match the WORDLEFT-WORDRIGHT terminology expressed in the public key definitions, whereas some of the internal code used "previous" "next". Also note that the existing `STB_TEXTEDIT_IS_SPACE` with underscore should be called ``STB_TEXTEDIT_ISSPACE` to strictly be consistent with the other function names. It doesn't really matter, but that is why the new define don't have underscores.

- I put the "burden" of passing `state->cursor-1` or `state->cursor+1` to the main key handling switch in textedit. Depending what you feel is best, the switch could pass `state->cursor` to both those functions and leave it to the handlers to do -1/+1. It may actually make more sense like that! (just realizing this as I'm typing this message, I could amend the PR for that if you want).

- Coding style: Some functions near the affected code used `_arg` for function arguments instead of `arg` commonly used in the rest of the code. I haven't changed that to minimize the patch overhead but kept one argument name `c` also to reduce the patch size and make it easier for you to parse it. I'm not sure if there was a reasoning for the extra underscore or if it came accidentally with another patch. While you are there you might want to rename the very few occurences of `_str` to `str` to make the code more consistent.

Thanks!
