### PR TITLE
stb_image_write: Remove useless stbiw__paeth calls in stbi_write_png_to_mem

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -924,7 +924,7 @@ unsigned char *stbi_write_png_to_mem(unsigned char *pixels, int stride_bytes, in
                   case 1: line_buffer[i] = z[i]; break;
                   case 2: line_buffer[i] = z[i] - z[i-stride_bytes]; break;
                   case 3: line_buffer[i] = z[i] - (z[i-stride_bytes]>>1); break;
-                  case 4: line_buffer[i] = (signed char) (z[i] - stbiw__paeth(0,z[i-stride_bytes],0)); break;
+                  case 4: line_buffer[i] = z[i] - z[i-stride_bytes]; break;
                   case 5: line_buffer[i] = z[i]; break;
                   case 6: line_buffer[i] = z[i]; break;
                }
@@ -936,7 +936,7 @@ unsigned char *stbi_write_png_to_mem(unsigned char *pixels, int stride_bytes, in
                   case 3: line_buffer[i] = z[i] - ((z[i-n] + z[i-stride_bytes])>>1); break;
                   case 4: line_buffer[i] = z[i] - stbiw__paeth(z[i-n], z[i-stride_bytes], z[i-stride_bytes-n]); break;
                   case 5: line_buffer[i] = z[i] - (z[i-n]>>1); break;
-                  case 6: line_buffer[i] = z[i] - stbiw__paeth(z[i-n], 0,0); break;
+                  case 6: line_buffer[i] = z[i] - z[i-n]; break;
                }
             }
             if (p) break;


### PR DESCRIPTION
If I am not mistaken, 
stbiw__paeth(a, 0, 0) gives a
stbiw__paeth(0, b, 0) gives b

I also removed a cast to signed char as it was used in one case only.
If there were a reason for this, please put it back.

Thank you for your time and your great libs!