### PR TITLE
stb_vorbis: Fixed PS4/FreeBSD missing malloc.h

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -552,7 +552,7 @@ enum STBVorbisError
 #include <string.h>
 #include <assert.h>
 #include <math.h>
-#if !(defined(__APPLE__) || defined(MACOSX) || defined(macintosh) || defined(Macintosh))
+#if !(defined(__APPLE__) || defined(MACOSX) || defined(macintosh) || defined(Macintosh) || defined(__FreeBSD__))
 #include <malloc.h>
 #if defined(__linux__) || defined(__linux) || defined(__EMSCRIPTEN__)
 #include <alloca.h>


### PR DESCRIPTION
Including malloc.h failed on PS4/Orbis target.
AFAIK PS4 uses FreeBsd and testing for for `__FreeBSD__` should be right but I haven't tested on an actual "normal" FreeBSD system. Some man pages refer to stdlib.h (which would already be included), some refer to a sys/malloc.h (there's no sys/malloc.h on PS4 FreeBSD at least).

Could possibly replace the test for `__FreeBSD__` by `__ORBIS__` to be on the safe side if you can't test on FreeBSD and whoever may be using FreeBSD may or not apply their own fix later.