### PR TITLE
stb_textedit/stb_text_locate_coord:

### DIFF
--- a/stb_textedit.h
+++ b/stb_textedit.h
@@ -417,10 +417,9 @@ static int stb_text_locate_coord(STB_TEXTEDIT_STRING *str, float x, float y)
    // check if it's before the end of the line
    if (x < r.x1) {
       // search characters in row for one that straddles 'x'
-      k = i;
       prev_x = r.x0;
-      for (i=0; i < r.num_chars; ++i) {
-         float w = STB_TEXTEDIT_GETWIDTH(str, k, i);
+      for (k=0; k < r.num_chars; ++k) {
+         float w = STB_TEXTEDIT_GETWIDTH(str, i, k);
          if (x < prev_x+w) {
             if (x < prev_x+w/2)
                return k+i;


### PR DESCRIPTION
fix cursor position in the "shouldn't happen, but if it does, fall through to end-of-line case" case (`i=0` causes problems with the return values in this case). 


in my case this happened because STB_TEXTEDIT_LAYOUTROW reported 296.5 pixels, but the individual character sum only made it to 295.5 pixels. the result was the cursor in the middle of the textfield when i was clicking the last pixel of the last character in the last line. 