### PR TITLE
Add DG_dynarr.h to other_libs.md

### DIFF
--- a/docs/other_libs.md
+++ b/docs/other_libs.md
@@ -53,6 +53,7 @@ data&nbsp;structures|[klib](http://attractivechaos.github.io/klib/)             
 data structures   |  [uthash](https://github.com/troydhanson/uthash)                      | BSD                  |C/C++|  2  | several 1-header, 1-license-file libs: generic hash, list, etc
 data structures   |  [PackedArray](https://github.com/gpakosz/PackedArray)                | **WTFPLv2**          |  C  |  2  | memory-efficient array of elements with non-pow2 bitcount
 data structures   |  [minilibs](https://github.com/ccxvii/minilibs)                       | **public domain**    |  C  |  2  | two-file binary tress (also regex, etc)
+data structures   |**[DG_dynarr.h](https://github.com/DanielGibson/Snippets/)**           | **public domain**    |C/C++|**1**| typesafe dynamic arrays (like std::vector) for plain C
 files & filenames |**[DG_misc.h](https://github.com/DanielGibson/Snippets/)**             | **public domain**    |C/C++|**1**| Daniel Gibson's stb.h-esque cross-platform helpers: path/file, strings
 files & filenames |  [whereami](https://github.com/gpakosz/whereami)                      |**WTFPLv2**           |C/C++|  2  | get path/filename of executable or module
 files & filenames |  [noc_file_dialog.h](https://github.com/guillaumechereau/noc)         | MIT                  |C/C++|  1  | file open/save dialogs (Linux/OSX/Windows)


### PR DESCRIPTION
It provides typesafe dynamic arrays for plain C, but in contrast to stretchy_buffers.h/stb_arr it uses a struct that contains the pointer + count/capacity, which makes it easier to pass the arrays around and modify them elsewhere, with the drawback of having to type `arr.p[i]` instead of `arr[i]` to access elements (otherwise it's pretty similar to stb_arr)