### PR TITLE
Add ccVector.h to other_libs.md

### DIFF
--- a/docs/other_libs.md
+++ b/docs/other_libs.md
@@ -94,6 +94,7 @@ images            |  [jpeg-compressor](https://github.com/richgel999/jpeg-compre
 images            |  [easyexif](https://github.com/mayanklahiri/easyexif)                 | MIT                  | C++ |  2  | EXIF metadata extractor for JPEG images
 images            |**[cro_mipmap.h](https://github.com/thebeast33/cro_lib)**              | **public domain**    |C/C++|**1**| average, min, max mipmap generators
 math              |  [mm_vec.h](https://github.com/vurtun/mmx)                            | BSD                  |C/C++|**1**| SIMD vector math
+math              |**[ccVector.h](https://github.com/jobtalle/ccVector)                   | BSD                  |C/C++|**1**| Vector, quaternion and matrix math
 math              |  [ShaderFastLibs](https://github.com/michaldrobot/ShaderFastLibs)     | MIT                  | C++ |**1**| (also HLSL) approximate transcendental functions optimized for shaders (esp. GCN)
 math              |  [TinyExpr](https://github.com/codeplea/tinyexpr)                     | zlib                 |  C  |  2  | evaluation of math expressions from strings
 math              |  [linalg.h](https://github.com/sgorsten/linalg)                      | **unlicense**         | C++ |**1**| vector/matrix/quaternion math

--- a/docs/other_libs.md
+++ b/docs/other_libs.md
@@ -94,7 +94,7 @@ images            |  [jpeg-compressor](https://github.com/richgel999/jpeg-compre
 images            |  [easyexif](https://github.com/mayanklahiri/easyexif)                 | MIT                  | C++ |  2  | EXIF metadata extractor for JPEG images
 images            |**[cro_mipmap.h](https://github.com/thebeast33/cro_lib)**              | **public domain**    |C/C++|**1**| average, min, max mipmap generators
 math              |  [mm_vec.h](https://github.com/vurtun/mmx)                            | BSD                  |C/C++|**1**| SIMD vector math
-math              |**[ccVector.h](https://github.com/jobtalle/ccVector)**                 | BSD                  |C/C++|**1**| Vector, quaternion and matrix math
+math              |**[ccVector.h](https://github.com/jobtalle/ccVector)**                 | **public domain**    |C/C++|**1**| Vector, quaternion and matrix math
 math              |  [ShaderFastLibs](https://github.com/michaldrobot/ShaderFastLibs)     | MIT                  | C++ |**1**| (also HLSL) approximate transcendental functions optimized for shaders (esp. GCN)
 math              |  [TinyExpr](https://github.com/codeplea/tinyexpr)                     | zlib                 |  C  |  2  | evaluation of math expressions from strings
 math              |  [linalg.h](https://github.com/sgorsten/linalg)                      | **unlicense**         | C++ |**1**| vector/matrix/quaternion math

--- a/docs/other_libs.md
+++ b/docs/other_libs.md
@@ -94,7 +94,7 @@ images            |  [jpeg-compressor](https://github.com/richgel999/jpeg-compre
 images            |  [easyexif](https://github.com/mayanklahiri/easyexif)                 | MIT                  | C++ |  2  | EXIF metadata extractor for JPEG images
 images            |**[cro_mipmap.h](https://github.com/thebeast33/cro_lib)**              | **public domain**    |C/C++|**1**| average, min, max mipmap generators
 math              |  [mm_vec.h](https://github.com/vurtun/mmx)                            | BSD                  |C/C++|**1**| SIMD vector math
-math              |**[ccVector.h](https://github.com/jobtalle/ccVector)                   | BSD                  |C/C++|**1**| Vector, quaternion and matrix math
+math              |**[ccVector.h](https://github.com/jobtalle/ccVector)**                 | BSD                  |C/C++|**1**| Vector, quaternion and matrix math
 math              |  [ShaderFastLibs](https://github.com/michaldrobot/ShaderFastLibs)     | MIT                  | C++ |**1**| (also HLSL) approximate transcendental functions optimized for shaders (esp. GCN)
 math              |  [TinyExpr](https://github.com/codeplea/tinyexpr)                     | zlib                 |  C  |  2  | evaluation of math expressions from strings
 math              |  [linalg.h](https://github.com/sgorsten/linalg)                      | **unlicense**         | C++ |**1**| vector/matrix/quaternion math


### PR DESCRIPTION
`ccVector.h` is a single file, C/C++ linear algebra library aimed at graphics development. It provides vectors, quaternions and matrices with utility functions.
All naming schemes are flexible and can be changed to the users preference in the top of the header.
If a vector or matrix with a dimension above 4 or 4x4 needs to be used, a new type and its functions can be created by the macro `CCV_DEFINE_VEC(x)` or `CCV_DEFINE_MAT(x)`.