### PR TITLE
fix wrong components problem in png loading

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -4606,7 +4606,7 @@ static unsigned char *stbi__do_png(stbi__png *p, int *x, int *y, int *n, int req
       }
       *x = p->s->img_x;
       *y = p->s->img_y;
-      if (n) *n = p->s->img_n;
+      if (n) *n = p->s->img_out_n;
    }
    STBI_FREE(p->out);      p->out      = NULL;
    STBI_FREE(p->expanded); p->expanded = NULL;


### PR DESCRIPTION
number of components returned is wrong in png loading if req is not equal zero.