### PR TITLE
README.md: add direct links to files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,25 +7,25 @@ single-file public domain libraries for C/C++ <a name="stb_libs"></a>
 
 library    | lastest version | category | LoC | description
 --------------------- | ---- | -------- | --- | --------------------------------
-**stb_vorbis.c** | 1.09 | audio | 5397 | decode ogg vorbis files from file/memory to float/16-bit signed output
-**stb_image.h** | 2.12 | graphics | 6755 | image loading/decoding from file/memory: JPG, PNG, TGA, BMP, PSD, GIF, HDR, PIC
-**stb_truetype.h** | 1.11 | graphics | 3267 | parse, decode, and rasterize characters from truetype fonts
-**stb_image_write.h** | 1.02 | graphics | 1048 | image writing to disk: PNG, TGA, BMP
-**stb_image_resize.h** | 0.91 | graphics | 2578 | resize images larger/smaller with good quality
-**stb_rect_pack.h** | 0.08 | graphics | 572 | simple 2D rectangle packer with decent quality
-**stretchy_buffer.h** | 1.02 | utility | 216 | typesafe dynamic array for C (i.e. approximation to vector<>), doesn't compile as C++
-**stb_textedit.h** | 1.8 | user&nbsp;interface | 1304 | guts of a text editor for games etc implementing them from scratch
-**stb_voxel_render.h** | 0.84 | 3D&nbsp;graphics | 3752 | Minecraft-esque voxel rendering "engine" with many more features
-**stb_dxt.h** | 1.04 | 3D&nbsp;graphics | 630 | Fabian "ryg" Giesen's real-time DXT compressor
-**stb_perlin.h** | 0.2 | 3D&nbsp;graphics | 182 | revised Perlin noise (3D input, 1D output)
-**stb_easy_font.h** | 0.7 | 3D&nbsp;graphics | 258 | quick-and-dirty easy-to-deploy bitmap font for printing frame rate, etc
-**stb_tilemap_editor.h** | 0.37 | game&nbsp;dev | 4131 | embeddable tilemap editor
-**stb_herringbone_wa...** | 0.6 | game&nbsp;dev | 1220 | herringbone Wang tile map generator
-**stb_c_lexer.h** | 0.07 | parsing | 816 | simplify writing parsers for C-like languages
-**stb_divide.h** | 0.91 | math | 379 | more useful 32-bit modulus e.g. "euclidean divide"
-**stb_connected_comp...** | 0.94 | misc | 1000 | incrementally compute reachability on grids
-**stb.h** | 2.27 | misc | 14185 | helper functions for C, mostly redundant in C++; basically author's personal stuff
-**stb_leakcheck.h** | 0.2 | misc | 124 | quick-and-dirty malloc/free leak-checking
+**[stb_vorbis.c](stb_vorbis.c)** | 1.09 | audio | 5397 | decode ogg vorbis files from file/memory to float/16-bit signed output
+**[stb_image.h](stb_image.h)** | 2.12 | graphics | 6755 | image loading/decoding from file/memory: JPG, PNG, TGA, BMP, PSD, GIF, HDR, PIC
+**[stb_truetype.h](stb_truetype.h)** | 1.11 | graphics | 3267 | parse, decode, and rasterize characters from truetype fonts
+**[stb_image_write.h](stb_image_write.h)** | 1.02 | graphics | 1048 | image writing to disk: PNG, TGA, BMP
+**[stb_image_resize.h](stb_image_resize.h)** | 0.91 | graphics | 2578 | resize images larger/smaller with good quality
+**[stb_rect_pack.h](stb_rect_pack.h)** | 0.08 | graphics | 572 | simple 2D rectangle packer with decent quality
+**[stretchy_buffer.h](stretchy_buffer.h)** | 1.02 | utility | 216 | typesafe dynamic array for C (i.e. approximation to vector<>), doesn't compile as C++
+**[stb_textedit.h](stb_textedit.h)** | 1.8 | user&nbsp;interface | 1304 | guts of a text editor for games etc implementing them from scratch
+**[stb_voxel_render.h](stb_voxel_render.h)** | 0.84 | 3D&nbsp;graphics | 3752 | Minecraft-esque voxel rendering "engine" with many more features
+**[stb_dxt.h](stb_dxt.h)** | 1.04 | 3D&nbsp;graphics | 630 | Fabian "ryg" Giesen's real-time DXT compressor
+**[stb_perlin.h](stb_perlin.h)** | 0.2 | 3D&nbsp;graphics | 182 | revised Perlin noise (3D input, 1D output)
+**[stb_easy_font.h](stb_easy_font.h)** | 0.7 | 3D&nbsp;graphics | 258 | quick-and-dirty easy-to-deploy bitmap font for printing frame rate, etc
+**[stb_tilemap_editor.h](stb_tilemap_editor.h)** | 0.37 | game&nbsp;dev | 4131 | embeddable tilemap editor
+**[stb_herringbone_wa...](stb_herringbone_wang_tile.h)** | 0.6 | game&nbsp;dev | 1220 | herringbone Wang tile map generator
+**[stb_c_lexer.h](stb_c_lexer.h)** | 0.07 | parsing | 816 | simplify writing parsers for C-like languages
+**[stb_divide.h](stb_divide.h)** | 0.91 | math | 379 | more useful 32-bit modulus e.g. "euclidean divide"
+**[stb_connected_comp...](stb_connected_components.h)** | 0.94 | misc | 1000 | incrementally compute reachability on grids
+**[stb.h](stb.h)** | 2.27 | misc | 14185 | helper functions for C, mostly redundant in C++; basically author's personal stuff
+**[stb_leakcheck.h](stb_leakcheck.h)** | 0.2 | misc | 124 | quick-and-dirty malloc/free leak-checking
 
 Total libraries: 19  
 Total lines of C code: 47814

--- a/tools/make_readme.c
+++ b/tools/make_readme.c
@@ -30,15 +30,18 @@ int main(int argc, char  **argv)
       if (*s1 == 'v') ++s1;
       s3 = tokens[0];
       stb_trimwhite(s3);
+      fprintf(f, "**[");
       if (strlen(s3) < 21) {
-         fprintf(f, "**%s** | %s", tokens[0], s1);
+         fprintf(f, "%s", tokens[0]);
       } else {
          char buffer[256];
          strncpy(buffer, s3, 18);
          buffer[18] = 0;   
          strcat(buffer, "...");
-         fprintf(f, "**%s** | %s", buffer, s1);
+         fprintf(f, "%s", buffer);
       }
+      fprintf(f, "](%s)**", tokens[0]);
+      fprintf(f, " | %s", s1);
       s1 = stb_trimwhite(tokens[1]);           // stb_trimwhite -- advance pointer to after whitespace & delete trailing whitespace
       s2 = stb_dupreplace(s1, " ", "&nbsp;");  // stb_dupreplace -- search & replace string and malloc result
       fprintf(f, " | %s", s2);


### PR DESCRIPTION
As the title suggests, this replaces the (truncated) plain filenames with links pointing directly to the relevant files. I probably don't need to tell you that you can see the rendered result on [my fork](https://github.com/1ace/stb/tree/feature/add-link#readme) :)

Note: the generated file was missing `README.header.md`'s contents, but that seems unrelated to my code change, so I just didn't check that bit of the change in. I had a quick look at the code, and couldn't find anything wrong. Probably not worth raising an issue either, esp. considering the importance of that piece of code compared to the rest of the repo :)