### PR TITLE
image-write: fix monochrome bitmap writing from 8-bit-buffers

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -293,9 +293,7 @@ static void stbiw__write_pixel(stbi__write_context *s, int rgb_dir, int comp, in
       s->func(s->context, &d[comp - 1], 1);
 
    switch (comp) {
-      case 1:
-         s->func(s->context,d,1);
-         break;
+      case 1: /* fall-through wanted */
       case 2:
          if (expand_mono)
             stbiw__write3(s, d[0], d[0], d[0]); // monochrome bmp


### PR DESCRIPTION
Now writing out monochrome bitmaps from 8-bit arrays works as it does when using PNG. Bitmaps need 3 bytes per pixel.

I noticed that this was not working when switching from write_png to write_bmp with the same uint8_t-buffer.

Feel free to integrate.
