### PR TITLE
Fix error on FreeBSD "#error malloc.h has been replaced by stdlib.h"

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -553,7 +553,7 @@ enum STBVorbisError
 #include <string.h>
 #include <assert.h>
 #include <math.h>
-#if !(defined(__APPLE__) || defined(MACOSX) || defined(macintosh) || defined(Macintosh))
+#if !(defined(__APPLE__) || defined(MACOSX) || defined(macintosh) || defined(Macintosh) || defined(__FreeBSD__))
 #include <malloc.h>
 #if defined(__linux__) || defined(__linux) || defined(__EMSCRIPTEN__)
 #include <alloca.h>


### PR DESCRIPTION
Fixed error "#error malloc.h has been replaced by stdlib.h"