### PR TITLE
stb_c_lexer self-test doesn't clean up if file is not found

### DIFF
--- a/stb_c_lexer.h
+++ b/stb_c_lexer.h
@@ -798,6 +798,8 @@ int main(int argc, char **argv)
    stb_lexer lex;
    if (len < 0) {
       fprintf(stderr, "Error opening file\n");
+      free(text);
+      fclose(f);
       return 1;
    }
    fclose(f);


### PR DESCRIPTION
```
[stb_c_lexer.h:801]: (error) Memory leak: text
[stb_c_lexer.h:801]: (error) Resource leak: f
```

Found by https://github.com/bryongloden/cppcheck
