### PR TITLE
Fix link to tinyobjloader-c

### DIFF
--- a/docs/other_libs.md
+++ b/docs/other_libs.md
@@ -61,7 +61,7 @@ files & filenames |  [TinyDir](https://github.com/cxong/tinydir)                
 geometry file     |  [tk_objfile](https://github.com/joeld42/tk_objfile)                  | MIT                  |C/C++|**1**| OBJ file loader
 geometry file     |  [tinyply](https://github.com/ddiakopoulos/tinyply)                   | **public domain**    | C++ |  2  | PLY mesh file loader
 geometry file     |  [tinyobjloader](https://github.com/syoyo/tinyobjloader)              | BSD                  | C++ |**1**| wavefront OBJ file loader
-geometry file     |  [tinyobjloader_c](https://github.com/syoyo/tinyobjloader_c)          | MIT                  |  C  |**1**| wavefront OBJ file loader
+geometry file     |  [tinyobjloader-c](https://github.com/syoyo/tinyobjloader-c)          | MIT                  |  C  |**1**| wavefront OBJ file loader
 geometry file     |  [yocto_obj.h](https://github.com/xelatihy/yocto-gl)                  | MIT                  |C/C++|**1**| wavefront OBJ file loader
 geometry math     |**[nv_voronoi.h](http://www.icculus.org/~mordred/nvlib/)**             | **public domain**    |C/C++|**1**| find voronoi regions on lattice w/ integer inputs
 geometry math     |**[sobol.h](https://github.com/Marc-B-Reynolds/Stand-alone-junk/)**    | **public domain**    |C/C++|**1**| sobol & stratified sampling sequences


### PR DESCRIPTION
The repository has been been relocated by syoyo from [tinyobjloader_c][oldlink] to [tinyobjloader-c][newlink] (note the dash).

[oldlink]:https://github.com/syoyo/tinyobjloader_c
[newlink]:https://github.com/syoyo/tinyobjloader-c