### PR TITLE
stb_vorbis: Do not include <malloc.h> on FreeBSD.

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -553,7 +553,7 @@ enum STBVorbisError
 #include <string.h>
 #include <assert.h>
 #include <math.h>
-#if !(defined(__APPLE__) || defined(MACOSX) || defined(macintosh) || defined(Macintosh))
+#if !(defined(__APPLE__) || defined(MACOSX) || defined(macintosh) || defined(Macintosh) || defined(__FreeBSD__))
 #include <malloc.h>
 #if defined(__linux__) || defined(__linux) || defined(__EMSCRIPTEN__)
 #include <alloca.h>


### PR DESCRIPTION
On FreeBSD, `<malloc.h>` is deprecated. FreeBSD enforces this by making the compilation fail if `<malloc.h>` is included. Both, malloc() and alloca() are provided by `<stdlib.h>`, which is already included by stb_vorbis anyway.