### PR TITLE
stb_dxt: 3Dc support

### DIFF
--- a/stb_dxt.h
+++ b/stb_dxt.h
@@ -32,6 +32,7 @@
 #define STB_DXT_HIGHQUAL  2   // high quality mode, does two refinement steps instead of 1. ~30-40% slower.
 
 void stb_compress_dxt_block(unsigned char *dest, const unsigned char *src, int alpha, int mode);
+void stb_compress_3dc_block_rgxx8(unsigned char *dest, const unsigned char *src, int mode);
 #define STB_COMPRESS_DXT_BLOCK
 
 #ifdef STB_DXT_IMPLEMENTATION
@@ -624,6 +625,12 @@ void stb_compress_dxt_block(unsigned char *dest, const unsigned char *src, int a
    }
 
    stb__CompressColorBlock(dest,(unsigned char*) src,mode);
+}
+
+void stb_compress_3dc_block_rgxx8(unsigned char *dest, const unsigned char *src, int mode)
+{
+   stb__CompressAlphaBlock(dest,(unsigned char*) src - 3,mode);
+   stb__CompressAlphaBlock(dest + 8,(unsigned char*) src - 2,mode);
 }
 #endif // STB_DXT_IMPLEMENTATION
 


### PR DESCRIPTION
As I wanted to compress some tangent space normal maps, I read some articles about the topic and found out that the 3Dc format is very good, and it is actually two DXT5 alpha blocks added together.

The commit shows how easy it would be to support 3Dc here. And that's really about it, since I wasn't sure what to do with the unused 'mode' variable as well as the padding bytes that 'src' requires (they didn't matter for me but they might for someone else).

Any chance you're interested in supporting 3Dc compression explicitly in this library?