### PR TITLE
Fix "#ifndef STBI_WRITE_NO_STDIO" scope for stbi_write_hdr()

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -475,7 +475,6 @@ int stbi_write_tga(char const *filename, int x, int y, int comp, const void *dat
 // *************************************************************************************************
 // Radiance RGBE HDR writer
 // by Baldur Karlsson
-#ifndef STBI_WRITE_NO_STDIO
 
 #define stbiw__max(a, b)  ((a) > (b) ? (a) : (b))
 
@@ -630,6 +629,7 @@ int stbi_write_hdr_to_func(stbi_write_func *func, void *context, int x, int y, i
    return stbi_write_hdr_core(&s, x, y, comp, (float *) data);
 }
 
+#ifndef STBI_WRITE_NO_STDIO
 int stbi_write_hdr(char const *filename, int x, int y, int comp, const float *data)
 {
    stbi__write_context s;


### PR DESCRIPTION
stbi_write_hdr_to_func() should still be available without STBI_WRITE_NO_STDIO,
just like other formats.