### PR TITLE
Apple TrueType fonts

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -978,6 +978,7 @@ static int stbtt__isfont(stbtt_uint8 *font)
    if (stbtt_tag(font, "typ1"))   return 1; // TrueType with type 1 font -- we don't support this!
    if (stbtt_tag(font, "OTTO"))   return 1; // OpenType with CFF
    if (stbtt_tag4(font, 0,1,0,0)) return 1; // OpenType 1.0
+   if (stbtt_tag(font, "true"))   return 1; // Apple specification for TrueType fonts
    return 0;
 }
 


### PR DESCRIPTION
This adds a check for the tag 'true' in stbtt__isfont to support Apple TrueType fonts.

I found this reference at www.microsoft.com/typography/otspec/otff.htm:

    NOTE: The Apple specification for TrueType fonts allows for 'true' and 'typ1' for sfnt version.

I've attached an Apple font containing the 'true' tag for testing: [Apple Chancery.ttf.zip](https://github.com/nothings/stb/files/629907/Apple.Chancery.ttf.zip)
