### PR TITLE
Error control in stb_vorbis_open_memory.

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -4980,6 +4980,7 @@ stb_vorbis * stb_vorbis_open_memory(const unsigned char *data, int len, int *err
       if (f) {
          *f = p;
          vorbis_pump_first_frame(f);
+         if (error) *error = VORBIS__no_error;
          return f;
       }
    }


### PR DESCRIPTION
Overwrites error parameter in stb_vorbis_open_memory when there is no error. This avoid confusion due to previous values.