### PR TITLE
stb_vorbis: Rename Point to stbv__point

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -1270,12 +1270,12 @@ static void neighbors(uint16 *x, int n, int *plow, int *phigh)
 typedef struct
 {
    uint16 x,y;
-} Point;
+} stbv__point;
 
 static int STBV_CDECL point_compare(const void *p, const void *q)
 {
-   Point *a = (Point *) p;
-   Point *b = (Point *) q;
+   stbv__point *a = (stbv__point *) p;
+   stbv__point *b = (stbv__point *) q;
    return a->x < b->x ? -1 : a->x > b->x;
 }
 
@@ -3871,7 +3871,7 @@ static int start_decoder(vorb *f)
             g->book_list[j] = get_bits(f,8);
          return error(f, VORBIS_feature_not_supported);
       } else {
-         Point p[31*8+2];
+         stbv__point p[31*8+2];
          Floor1 *g = &f->floor_config[i].floor1;
          int max_class = -1; 
          g->partitions = get_bits(f, 5);


### PR DESCRIPTION
`Point` clashes with the struct of the same name in MacTypes.h (included by CoreFoundation.h on macOS/iOS), which breaks stb_vorbis.c when a precompiled header includes these files. (Admittedly, this is only an issue because of my oddball project setup...)

The stb_image libraries use the `stbi__` prefix for internal structs/functions, so I've prefixed this struct with `stbv__`.

I'm not sure that "point" is a descriptive name to begin with. The struct is only used in one place, and the comment states that it's not really a point, but repurposed as something else. Is there a better name for what it is? An "X with index"? Should I rather rename the struct instead of prefixing it?