### PR TITLE
stretchy_buffer: Add sb_reserve feature

### DIFF
--- a/stretchy_buffer.h
+++ b/stretchy_buffer.h
@@ -65,6 +65,7 @@
 //         sb_count(TYPE *a)          the number of elements in the array
 //         sb_push(TYPE *a, TYPE v)   adds v on the end of the array, a la push_back
 //         sb_add(TYPE *a, int n)     adds n uninitialized elements at end of array & returns pointer to first added
+//         sb_reserve(TYPE *a, int n) reserves space for n elements, a la vector::reserve
 //         sb_last(TYPE *a)           returns an lvalue of the last item in the array
 //         a[n]                       access the nth (counting from 0) element of the array
 //
@@ -172,17 +173,19 @@
 #define STB_STRETCHY_BUFFER_H_INCLUDED
 
 #ifndef NO_STRETCHY_BUFFER_SHORT_NAMES
-#define sb_free   stb_sb_free
-#define sb_push   stb_sb_push
-#define sb_count  stb_sb_count
-#define sb_add    stb_sb_add
-#define sb_last   stb_sb_last
+#define sb_free     stb_sb_free
+#define sb_push     stb_sb_push
+#define sb_count    stb_sb_count
+#define sb_add      stb_sb_add
+#define sb_reserve  stb_sb_reserve
+#define sb_last     stb_sb_last
 #endif
 
 #define stb_sb_free(a)         ((a) ? free(stb__sbraw(a)),0 : 0)
 #define stb_sb_push(a,v)       (stb__sbmaybegrow(a,1), (a)[stb__sbn(a)++] = (v))
 #define stb_sb_count(a)        ((a) ? stb__sbn(a) : 0)
 #define stb_sb_add(a,n)        (stb__sbmaybegrow(a,n), stb__sbn(a)+=(n), &(a)[stb__sbn(a)-(n)])
+#define stb_sb_reserve(a,n)    (stb__sbmaybegrow(a,n), &(a)[stb__sbn(a)])
 #define stb_sb_last(a)         ((a)[stb__sbn(a)-1])
 
 #define stb__sbraw(a) ((int *) (a) - 2)


### PR DESCRIPTION
If you know you will need at least n elements in your array, you may wish to reserve space beforehand in order to avoid the first few reallocations