### PR TITLE
Fixed Duplicate Symbols Linker Error

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -400,9 +400,9 @@ extern "C" {
 #endif
 
 #ifdef STB_IMAGE_STATIC
-#define STBIDEF static
+#define STBIDEF inline static
 #else
-#define STBIDEF extern
+#define STBIDEF inline extern
 #endif
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When including the header stb_image.h from another header, included from a source file. It makes duplicate symbols and causes 33 linker errors. Simply changing the functions to inline preserves all functionality and fixes the errors.