### PR TITLE
stb_image: JPEG: Convert RGB to grayscale properly

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -3596,7 +3596,7 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp
    // determine actual number of components to generate
    n = req_comp ? req_comp : z->s->img_n;
 
-   if (z->s->img_n == 3 && n < 3)
+   if (z->s->img_n == 3 && n < 3 && z->rgb != 3)
       decode_n = 1;
    else
       decode_n = z->s->img_n;
@@ -3674,11 +3674,19 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp
                   out += n;
                }
          } else {
-            stbi_uc *y = coutput[0];
-            if (n == 1)
-               for (i=0; i < z->s->img_x; ++i) out[i] = y[i];
-            else
-               for (i=0; i < z->s->img_x; ++i) *out++ = y[i], *out++ = 255;
+            if (z->rgb == 3) {
+               for (i=0; i < z->s->img_x; ++i) {
+                  out[0] = stbi__compute_y(coutput[0][i], coutput[1][i], coutput[2][i]);
+                  out[1] = 255;
+                  out += n;
+               }
+            } else {
+               stbi_uc *y = coutput[0];
+               if (n == 1)
+                  for (i=0; i < z->s->img_x; ++i) out[i] = y[i];
+               else
+                  for (i=0; i < z->s->img_x; ++i) *out++ = y[i], *out++ = 255;
+            }
          }
       }
       stbi__cleanup_jpeg(z);

--- a/stb_image.h
+++ b/stb_image.h
@@ -192,7 +192,7 @@
     Ryamond Barbiero        Paul Du Bois       Engin Manap        github:snagar
     Michaelangel007@github  Oriol Ferrer Mesia Dale Weiler        github:Zelex
     Philipp Wiesemann       Josh Tobin         github:rlyeh       github:grim210@github
-    Blazej Dariusz Roszkowski                  github:sammyhw
+    Blazej Dariusz Roszkowski                  github:sammyhw     Jeremy Sawicki
 
 
 LICENSE


### PR DESCRIPTION
When reading an RGB JPEG and producing grayscale output, compute Y from RGB instead of outputting R.