### PR TITLE
stb_image: JPEG: Accept any component IDs

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -3004,13 +3004,8 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
    for (i=0; i < s->img_n; ++i) {
       static unsigned char rgb[3] = { 'R', 'G', 'B' };
       z->img_comp[i].id = stbi__get8(s);
-      if (z->img_comp[i].id != i+1)   // JFIF requires
-         if (z->img_comp[i].id != i) {  // some version of jpegtran outputs non-JFIF-compliant files!
-            // somethings output this (see http://fileformats.archiveteam.org/wiki/JPEG#Color_format)
-            if (z->img_comp[i].id != rgb[i])
-               return stbi__err("bad component ID","Corrupt JPEG");
-            ++z->rgb;
-         }
+      if (z->img_comp[i].id == rgb[i])
+         ++z->rgb;
       q = stbi__get8(s);
       z->img_comp[i].h = (q >> 4);  if (!z->img_comp[i].h || z->img_comp[i].h > 4) return stbi__err("bad H","Corrupt JPEG");
       z->img_comp[i].v = q & 15;    if (!z->img_comp[i].v || z->img_comp[i].v > 4) return stbi__err("bad V","Corrupt JPEG");


### PR DESCRIPTION
Accept JPEG files with any component IDs.

This fix is needed by 6995 images in the ImageNet dataset:

* 6176 have component IDs X, 2, 3 for various values of X (40 values in total, all multiples of 4)
* 714 have component IDs 'Y', 'U', 'V'
* 105 are grayscale with various component IDs (15 values in total, mostly but not all multiples of 4)

At this point it seems best to accept any component IDs rather than trying to code rules for all variants seen in the wild.