### PR TITLE
stb_image: JPEG: Accept fill bytes in stbi__grow_buffer_unsafe

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -1851,6 +1851,7 @@ static void stbi__grow_buffer_unsafe(stbi__jpeg *j)
       int b = j->nomore ? 0 : stbi__get8(j->s);
       if (b == 0xff) {
          int c = stbi__get8(j->s);
+         while (c == 0xff) c = stbi__get8(j->s);
          if (c != 0) {
             j->marker = (unsigned char) c;
             j->nomore = 1;


### PR DESCRIPTION
Accept JPEG files with fill bytes (extra 0xff bytes) before markers while huffman decoding.  Fill bytes are currently accepted in stbi__get_marker but not stbi__grow_buffer_unsafe.

This fix is needed by 138 images in the ImageNet dataset.