### PR TITLE
stb_image: JPEG: Accept non-zero junk bytes at the end of image data

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -3123,8 +3123,6 @@ static int stbi__decode_jpeg_image(stbi__jpeg *j)
                if (x == 255) {
                   j->marker = stbi__get8(j->s);
                   break;
-               } else if (x != 0) {
-                  return stbi__err("junk before marker", "Corrupt JPEG");
                }
             }
             // if we reach eof without hitting a marker, stbi__get_marker() below will fail and we'll eventually return 0


### PR DESCRIPTION
Accept junk bytes having any value (instead of only 0x00) before the marker at the end of image data.

This fix is needed by 2 images in the ImageNet dataset.  Both have a junk byte of 0x7f.