### PR TITLE
stb_image: JPEG: Provide failure reason for unknown marker

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -2917,7 +2917,7 @@ static int stbi__process_marker(stbi__jpeg *z, int m)
       stbi__skip(z->s, stbi__get16be(z->s)-2);
       return 1;
    }
-   return 0;
+   return stbi__err("unknown marker","Corrupt JPEG");
 }
 
 // after we see SOS


### PR DESCRIPTION
Provide a failure reason when an unknown marker is encountered in a JPEG file.

This is the only case of a missing failure reason that I encountered in the ImageNet data set, though others exist in the code (e.g. "return L==0;" in the same function).