### PR TITLE
Added zeroing of the out after it is allocated in the function stbi__create_png_image_raw

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -4190,6 +4190,7 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
    STBI_ASSERT(out_n == s->img_n || out_n == s->img_n+1);
    a->out = (stbi_uc *) stbi__malloc_mad3(x, y, output_bytes, 0); // extra bytes to write off the end into
    if (!a->out) return stbi__err("outofmem", "Out of memory");
+   memset(a->out, 0, x * y * output_bytes);  
 
    img_width_bytes = (((img_n * x * depth) + 7) >> 3);
    img_len = (img_width_bytes + 1) * y;


### PR DESCRIPTION
As that `out` contents are used in the encoding.
I.e. in that line:
`case STBI__F_up         : cur[k] = STBI__BYTECAST(raw[k] + prior[k]); break;`
In that code `prior` points to `out`.

**p.s.** Thanks for the awesome library. I work on porting it to C#: https://github.com/rds1983/StbSharp
