### PR TITLE
fix: Build on MinGW32

### DIFF
--- a/stb.h
+++ b/stb.h
@@ -193,6 +193,8 @@ CREDITS
   Tim Sjostrand
 */
 
+#include <stdarg.h>
+
 #ifndef STB__INCLUDE_STB_H
 #define STB__INCLUDE_STB_H
 

--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -576,6 +576,7 @@ enum STBVorbisError
    #undef __forceinline
    #endif
    #define __forceinline
+#define alloca __builtin_alloca
 #elif !defined(_MSC_VER)
    #if __GNUC__
       #define __forceinline inline


### PR DESCRIPTION
Add include to `stb.h` and predefine `alloca` function for MINGW