### PR TITLE
Sprintf reformat

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -559,13 +559,9 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
          cs = 0;
          goto scopy;
 #else
-      case 'A': // float
-         h = hexu;
-         goto hexfloat;
-
+      case 'A': // hex float
       case 'a': // hex float
-         h = hex;
-      hexfloat:
+         h = (f[0] == 'A') ? hexu : hex;
          fv = va_arg(va, double);
          if (pr == -1)
             pr = 6; // default is 6
@@ -636,12 +632,8 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
          goto scopy;
 
       case 'G': // float
-         h = hexu;
-         goto dosmallfloat;
-
       case 'g': // float
-         h = hex;
-      dosmallfloat:
+         h = (f[0] == 'G') ? hexu : hex;
          fv = va_arg(va, double);
          if (pr == -1)
             pr = 6;
@@ -677,12 +669,8 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
          goto dofloatfromg;
 
       case 'E': // float
-         h = hexu;
-         goto doexp;
-
       case 'e': // float
-         h = hex;
-      doexp:
+         h = (f[0] == 'E') ? hexu : hex;
          fv = va_arg(va, double);
          if (pr == -1)
             pr = 6; // default is 6
@@ -911,12 +899,8 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
 #endif
 
       case 'B': // upper binary
-         h = hexu;
-         goto binary;
-
       case 'b': // lower binary
-         h = hex;
-      binary:
+         h = (f[0] == 'B') ? hexu : hex;
          lead[0] = 0;
          if (fl & STBSP__LEADING_0X) {
             lead[0] = 2;
@@ -942,13 +926,9 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
          fl &= ~STBSP__LEADINGZERO; // 'p' only prints the pointer with zeros
                                     // drop through to X
 
-      case 'X': // upper binary
-         h = hexu;
-         goto dohexb;
-
-      case 'x': // lower binary
-         h = hex;
-      dohexb:
+      case 'X': // upper hex
+      case 'x': // lower hex
+         h = (f[0] == 'X') ? hexu : hex;
          l = (4 << 4) | (4 << 8);
          lead[0] = 0;
          if (fl & STBSP__LEADING_0X) {

--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -131,9 +131,9 @@ PERFORMANCE vs MSVC 2008 32-/64-bit (GCC is even slower than MSVC):
 */
 
 #if defined(__has_feature)
-#if __has_feature(address_sanitizer)
-#define STBI__ASAN __attribute__((no_sanitize("address")))
-#endif
+   #if __has_feature(address_sanitizer)
+      #define STBI__ASAN __attribute__((no_sanitize("address")))
+   #endif
 #endif
 #ifndef STBI__ASAN
 #define STBI__ASAN
@@ -271,33 +271,33 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
       stbsp__int32 fw, pr, tz;
       stbsp__uint32 fl;
 
-// macros for the callback buffer stuff
-#define stbsp__chk_cb_bufL(bytes)                        \
-   {                                                     \
-      int len = (int)(bf - buf);                         \
-      if ((len + (bytes)) >= STB_SPRINTF_MIN) {          \
-         tlen += len;                                    \
-         if (0 == (bf = buf = callback(buf, user, len))) \
-            goto done;                                   \
-      }                                                  \
-   }
-#define stbsp__chk_cb_buf(bytes)    \
-   {                                \
-      if (callback) {               \
-         stbsp__chk_cb_bufL(bytes); \
-      }                             \
-   }
-#define stbsp__flush_cb()                      \
-   {                                           \
-      stbsp__chk_cb_bufL(STB_SPRINTF_MIN - 1); \
-   } // flush if there is even one byte in the buffer
-#define stbsp__cb_buf_clamp(cl, v)                \
-   cl = v;                                        \
-   if (callback) {                                \
-      int lg = STB_SPRINTF_MIN - (int)(bf - buf); \
-      if (cl > lg)                                \
-         cl = lg;                                 \
-   }
+      // macros for the callback buffer stuff
+      #define stbsp__chk_cb_bufL(bytes)                        \
+         {                                                     \
+            int len = (int)(bf - buf);                         \
+            if ((len + (bytes)) >= STB_SPRINTF_MIN) {          \
+               tlen += len;                                    \
+               if (0 == (bf = buf = callback(buf, user, len))) \
+                  goto done;                                   \
+            }                                                  \
+         }
+      #define stbsp__chk_cb_buf(bytes)    \
+         {                                \
+            if (callback) {               \
+               stbsp__chk_cb_bufL(bytes); \
+            }                             \
+         }
+      #define stbsp__flush_cb()                      \
+         {                                           \
+            stbsp__chk_cb_bufL(STB_SPRINTF_MIN - 1); \
+         } // flush if there is even one byte in the buffer
+      #define stbsp__cb_buf_clamp(cl, v)                \
+         cl = v;                                        \
+         if (callback) {                                \
+            int lg = STB_SPRINTF_MIN - (int)(bf - buf); \
+            if (cl > lg)                                \
+               cl = lg;                                 \
+         }
 
       // fast copy everything up to the next % (or end of string)
       for (;;) {
@@ -465,7 +465,7 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
 
       // handle each replacement
       switch (f[0]) {
-#define STBSP__NUMSZ 512 // big enough for e308 (with commas) or e-307
+         #define STBSP__NUMSZ 512 // big enough for e308 (with commas) or e-307
          char num[STBSP__NUMSZ];
          char lead[8];
          char tail[8];
@@ -1427,84 +1427,100 @@ static stbsp__int32 stbsp__real_to_parts(stbsp__int64 *bits, stbsp__int32 *expo,
    return (stbsp__int32)(b >> 63);
 }
 
-static double const stbsp__bot[23] = {1e+000, 1e+001, 1e+002, 1e+003, 1e+004, 1e+005, 1e+006, 1e+007, 1e+008, 1e+009, 1e+010, 1e+011,
-                                      1e+012, 1e+013, 1e+014, 1e+015, 1e+016, 1e+017, 1e+018, 1e+019, 1e+020, 1e+021, 1e+022};
-static double const stbsp__negbot[22] = {1e-001, 1e-002, 1e-003, 1e-004, 1e-005, 1e-006, 1e-007, 1e-008, 1e-009, 1e-010, 1e-011,
-                                         1e-012, 1e-013, 1e-014, 1e-015, 1e-016, 1e-017, 1e-018, 1e-019, 1e-020, 1e-021, 1e-022};
+static double const stbsp__bot[23] = {
+   1e+000, 1e+001, 1e+002, 1e+003, 1e+004, 1e+005, 1e+006, 1e+007, 1e+008, 1e+009, 1e+010, 1e+011,
+   1e+012, 1e+013, 1e+014, 1e+015, 1e+016, 1e+017, 1e+018, 1e+019, 1e+020, 1e+021, 1e+022
+};
+static double const stbsp__negbot[22] = {
+   1e-001, 1e-002, 1e-003, 1e-004, 1e-005, 1e-006, 1e-007, 1e-008, 1e-009, 1e-010, 1e-011,
+   1e-012, 1e-013, 1e-014, 1e-015, 1e-016, 1e-017, 1e-018, 1e-019, 1e-020, 1e-021, 1e-022
+};
 static double const stbsp__negboterr[22] = {
    -5.551115123125783e-018,  -2.0816681711721684e-019, -2.0816681711721686e-020, -4.7921736023859299e-021, -8.1803053914031305e-022, 4.5251888174113741e-023,
    4.5251888174113739e-024,  -2.0922560830128471e-025, -6.2281591457779853e-026, -3.6432197315497743e-027, 6.0503030718060191e-028,  2.0113352370744385e-029,
    -3.0373745563400371e-030, 1.1806906454401013e-032,  -7.7705399876661076e-032, 2.0902213275965398e-033,  -7.1542424054621921e-034, -7.1542424054621926e-035,
-   2.4754073164739869e-036,  5.4846728545790429e-037,  9.2462547772103625e-038,  -4.8596774326570872e-039};
-static double const stbsp__top[13] = {1e+023, 1e+046, 1e+069, 1e+092, 1e+115, 1e+138, 1e+161, 1e+184, 1e+207, 1e+230, 1e+253, 1e+276, 1e+299};
-static double const stbsp__negtop[13] = {1e-023, 1e-046, 1e-069, 1e-092, 1e-115, 1e-138, 1e-161, 1e-184, 1e-207, 1e-230, 1e-253, 1e-276, 1e-299};
-static double const stbsp__toperr[13] = {8388608,
-                                         6.8601809640529717e+028,
-                                         -7.253143638152921e+052,
-                                         -4.3377296974619174e+075,
-                                         -1.5559416129466825e+098,
-                                         -3.2841562489204913e+121,
-                                         -3.7745893248228135e+144,
-                                         -1.7356668416969134e+167,
-                                         -3.8893577551088374e+190,
-                                         -9.9566444326005119e+213,
-                                         6.3641293062232429e+236,
-                                         -5.2069140800249813e+259,
-                                         -5.2504760255204387e+282};
-static double const stbsp__negtoperr[13] = {3.9565301985100693e-040,  -2.299904345391321e-063,  3.6506201437945798e-086,  1.1875228833981544e-109,
-                                            -5.0644902316928607e-132, -6.7156837247865426e-155, -2.812077463003139e-178,  -5.7778912386589953e-201,
-                                            7.4997100559334532e-224,  -4.6439668915134491e-247, -6.3691100762962136e-270, -9.436808465446358e-293,
-                                            8.0970921678014997e-317};
+   2.4754073164739869e-036,  5.4846728545790429e-037,  9.2462547772103625e-038,  -4.8596774326570872e-039
+};
+static double const stbsp__top[13] = {
+   1e+023, 1e+046, 1e+069, 1e+092, 1e+115, 1e+138, 1e+161, 1e+184, 1e+207, 1e+230, 1e+253, 1e+276, 1e+299
+};
+static double const stbsp__negtop[13] = {
+   1e-023, 1e-046, 1e-069, 1e-092, 1e-115, 1e-138, 1e-161, 1e-184, 1e-207, 1e-230, 1e-253, 1e-276, 1e-299
+};
+static double const stbsp__toperr[13] = {
+   8388608,
+   6.8601809640529717e+028,
+   -7.253143638152921e+052,
+   -4.3377296974619174e+075,
+   -1.5559416129466825e+098,
+   -3.2841562489204913e+121,
+   -3.7745893248228135e+144,
+   -1.7356668416969134e+167,
+   -3.8893577551088374e+190,
+   -9.9566444326005119e+213,
+   6.3641293062232429e+236,
+   -5.2069140800249813e+259,
+   -5.2504760255204387e+282
+};
+static double const stbsp__negtoperr[13] = {
+   3.9565301985100693e-040,  -2.299904345391321e-063,  3.6506201437945798e-086,  1.1875228833981544e-109,
+   -5.0644902316928607e-132, -6.7156837247865426e-155, -2.812077463003139e-178,  -5.7778912386589953e-201,
+   7.4997100559334532e-224,  -4.6439668915134491e-247, -6.3691100762962136e-270, -9.436808465446358e-293,
+   8.0970921678014997e-317
+};
 
 #if defined(_MSC_VER) && (_MSC_VER <= 1200)
-static stbsp__uint64 const stbsp__powten[20] = {1,
-                                                10,
-                                                100,
-                                                1000,
-                                                10000,
-                                                100000,
-                                                1000000,
-                                                10000000,
-                                                100000000,
-                                                1000000000,
-                                                10000000000,
-                                                100000000000,
-                                                1000000000000,
-                                                10000000000000,
-                                                100000000000000,
-                                                1000000000000000,
-                                                10000000000000000,
-                                                100000000000000000,
-                                                1000000000000000000,
-                                                10000000000000000000U};
+static stbsp__uint64 const stbsp__powten[20] = {
+   1,
+   10,
+   100,
+   1000,
+   10000,
+   100000,
+   1000000,
+   10000000,
+   100000000,
+   1000000000,
+   10000000000,
+   100000000000,
+   1000000000000,
+   10000000000000,
+   100000000000000,
+   1000000000000000,
+   10000000000000000,
+   100000000000000000,
+   1000000000000000000,
+   10000000000000000000U
+};
 #define stbsp__tento19th ((stbsp__uint64)1000000000000000000)
 #else
-static stbsp__uint64 const stbsp__powten[20] = {1,
-                                                10,
-                                                100,
-                                                1000,
-                                                10000,
-                                                100000,
-                                                1000000,
-                                                10000000,
-                                                100000000,
-                                                1000000000,
-                                                10000000000ULL,
-                                                100000000000ULL,
-                                                1000000000000ULL,
-                                                10000000000000ULL,
-                                                100000000000000ULL,
-                                                1000000000000000ULL,
-                                                10000000000000000ULL,
-                                                100000000000000000ULL,
-                                                1000000000000000000ULL,
-                                                10000000000000000000ULL};
+static stbsp__uint64 const stbsp__powten[20] = {
+   1,
+   10,
+   100,
+   1000,
+   10000,
+   100000,
+   1000000,
+   10000000,
+   100000000,
+   1000000000,
+   10000000000ULL,
+   100000000000ULL,
+   1000000000000ULL,
+   10000000000000ULL,
+   100000000000000ULL,
+   1000000000000000ULL,
+   10000000000000000ULL,
+   100000000000000000ULL,
+   1000000000000000000ULL,
+   10000000000000000000ULL
+};
 #define stbsp__tento19th (1000000000000000000ULL)
 #endif
 
 #define stbsp__ddmulthi(oh, ol, xh, yh)                            \
-   \
-{                                                            \
+   {                                                               \
       double ahi = 0, alo, bhi = 0, blo;                           \
       stbsp__int64 bt;                                             \
       oh = xh * yh;                                                \
@@ -1517,12 +1533,10 @@ static stbsp__uint64 const stbsp__powten[20] = {1,
       STBSP__COPYFP(bhi, bt);                                      \
       blo = yh - bhi;                                              \
       ol = ((ahi * bhi - oh) + ahi * blo + alo * bhi) + alo * blo; \
-   \
-}
+   }
 
 #define stbsp__ddtoS64(ob, xh, xl)          \
-   \
-{                                     \
+   {                                        \
       double ahi = 0, alo, vh, t;           \
       ob = (stbsp__int64)ph;                \
       vh = (double)ob;                      \
@@ -1530,8 +1544,7 @@ static stbsp__uint64 const stbsp__powten[20] = {1,
       t = (ahi - xh);                       \
       alo = (xh - (ahi - t)) - (vh + t);    \
       ob += (stbsp__int64)(ahi + alo + xl); \
-   \
-}
+   }
 
 #define stbsp__ddrenorm(oh, ol) \
    {                            \

--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -20,7 +20,7 @@
 /*
 Single file sprintf replacement.
 
-Originally written by Jeff Roberts at RAD Game Tools - 2015/10/20. 
+Originally written by Jeff Roberts at RAD Game Tools - 2015/10/20.
 Hereby placed in public domain.
 
 This is a full sprintf replacement that supports everything that
@@ -29,19 +29,19 @@ hex floats, field parameters (%*.*d stuff), length reads backs, etc.
 
 Why would you need this if sprintf already exists?  Well, first off,
 it's *much* faster (see below). It's also much smaller than the CRT
-versions code-space-wise. We've also added some simple improvements 
+versions code-space-wise. We've also added some simple improvements
 that are super handy (commas in thousands, callbacks at buffer full,
-for example). Finally, the format strings for MSVC and GCC differ 
-for 64-bit integers (among other small things), so this lets you use 
+for example). Finally, the format strings for MSVC and GCC differ
+for 64-bit integers (among other small things), so this lets you use
 the same format strings in cross platform code.
 
 It uses the standard single file trick of being both the header file
-and the source itself. If you just include it normally, you just get 
+and the source itself. If you just include it normally, you just get
 the header file function definitions. To get the code, you include
 it from a C or C++ file and define STB_SPRINTF_IMPLEMENTATION first.
 
 It only uses va_args macros from the C runtime to do it's work. It
-does cast doubles to S64s and shifts and divides U64s, which does 
+does cast doubles to S64s and shifts and divides U64s, which does
 drag in CRT code on most platforms.
 
 It compiles to roughly 8K with float support, and 4K without.
@@ -78,9 +78,9 @@ doubles with error correction (double-doubles, for ~105 bits of
 precision).  This conversion is round-trip perfect - that is, an atof
 of the values output here will give you the bit-exact double back.
 
-One difference is that our insignificant digits will be different than 
-with MSVC or GCC (but they don't match each other either).  We also 
-don't attempt to find the minimum length matching float (pre-MSVC15 
+One difference is that our insignificant digits will be different than
+with MSVC or GCC (but they don't match each other either).  We also
+don't attempt to find the minimum length matching float (pre-MSVC15
 doesn't either).
 
 If you don't need float or doubles at all, define STB_SPRINTF_NOFLOAT
@@ -95,18 +95,18 @@ for size_t and ptr_diff_t (%jd %zd) as well.
 EXTRAS:
 =======
 Like some GCCs, for integers and floats, you can use a ' (single quote)
-specifier and commas will be inserted on the thousands: "%'d" on 12345 
+specifier and commas will be inserted on the thousands: "%'d" on 12345
 would print 12,345.
 
-For integers and floats, you can use a "$" specifier and the number 
+For integers and floats, you can use a "$" specifier and the number
 will be converted to float and then divided to get kilo, mega, giga or
-tera and then printed, so "%$d" 1000 is "1.0 k", "%$.2d" 2536000 is 
-"2.53 M", etc. For byte values, use two $:s, like "%$$d" to turn 
+tera and then printed, so "%$d" 1000 is "1.0 k", "%$.2d" 2536000 is
+"2.53 M", etc. For byte values, use two $:s, like "%$$d" to turn
 2536000 to "2.42 Mi". If you prefer JEDEC suffixes to SI ones, use three
 $:s: "%$$$d" -> "2.42 M". To remove the space between the number and the
 suffix, add "_" specifier: "%_$d" -> "2.53M".
 
-In addition to octal and hexadecimal conversions, you can print 
+In addition to octal and hexadecimal conversions, you can print
 integers in binary: "%b" for 256 would print 100.
 
 PERFORMANCE vs MSVC 2008 32-/64-bit (GCC is even slower than MSVC):
@@ -131,9 +131,9 @@ PERFORMANCE vs MSVC 2008 32-/64-bit (GCC is even slower than MSVC):
 */
 
 #if defined(__has_feature)
- #if __has_feature(address_sanitizer)
-  #define STBI__ASAN __attribute__((no_sanitize("address")))
- #endif
+#if __has_feature(address_sanitizer)
+#define STBI__ASAN __attribute__((no_sanitize("address")))
+#endif
 #endif
 #ifndef STBI__ASAN
 #define STBI__ASAN
@@ -152,30 +152,30 @@ PERFORMANCE vs MSVC 2008 32-/64-bit (GCC is even slower than MSVC):
 #endif
 #endif
 
-#include <stdarg.h>  // for va_list()
+#include <stdarg.h> // for va_list()
 
 #ifndef STB_SPRINTF_MIN
 #define STB_SPRINTF_MIN 512 // how many characters per callback
 #endif
-typedef char * STBSP_SPRINTFCB( char * buf, void * user, int len );
+typedef char *STBSP_SPRINTFCB(char *buf, void *user, int len);
 
 #ifndef STB_SPRINTF_DECORATE
-#define STB_SPRINTF_DECORATE(name) stbsp_##name  // define this before including if you want to change the names
+#define STB_SPRINTF_DECORATE(name) stbsp_##name // define this before including if you want to change the names
 #endif
 
-STBSP__PUBLICDEF int STB_SPRINTF_DECORATE( vsprintf )( char * buf, char const * fmt, va_list va );
-STBSP__PUBLICDEF int STB_SPRINTF_DECORATE( vsnprintf )( char * buf, int count, char const * fmt, va_list va );
-STBSP__PUBLICDEF int STB_SPRINTF_DECORATE( sprintf ) ( char * buf, char const * fmt, ... );
-STBSP__PUBLICDEF int STB_SPRINTF_DECORATE( snprintf )( char * buf, int count, char const * fmt, ... );
+STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintf)(char *buf, char const *fmt, va_list va);
+STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsnprintf)(char *buf, int count, char const *fmt, va_list va);
+STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(sprintf)(char *buf, char const *fmt, ...);
+STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(snprintf)(char *buf, int count, char const *fmt, ...);
 
-STBSP__PUBLICDEF int STB_SPRINTF_DECORATE( vsprintfcb )( STBSP_SPRINTFCB * callback, void * user, char * buf, char const * fmt, va_list va );
-STBSP__PUBLICDEF void STB_SPRINTF_DECORATE( set_separators )( char comma, char period );
+STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback, void *user, char *buf, char const *fmt, va_list va);
+STBSP__PUBLICDEF void STB_SPRINTF_DECORATE(set_separators)(char comma, char period);
 
 #endif // STB_SPRINTF_H_INCLUDE
 
 #ifdef STB_SPRINTF_IMPLEMENTATION
 
-#include <stdlib.h>  // for va_arg()
+#include <stdlib.h> // for va_arg()
 
 #define stbsp__uint32 unsigned int
 #define stbsp__int32 signed int
@@ -189,7 +189,7 @@ STBSP__PUBLICDEF void STB_SPRINTF_DECORATE( set_separators )( char comma, char p
 #endif
 #define stbsp__uint16 unsigned short
 
-#ifndef stbsp__uintptr 
+#ifndef stbsp__uintptr
 #if defined(__ppc64__) || defined(__aarch64__) || defined(_M_X64) || defined(__x86_64__) || defined(__x86_64)
 #define stbsp__uintptr stbsp__uint64
 #else
@@ -197,13 +197,13 @@ STBSP__PUBLICDEF void STB_SPRINTF_DECORATE( set_separators )( char comma, char p
 #endif
 #endif
 
-#ifndef STB_SPRINTF_MSVC_MODE  // used for MSVC2013 and earlier (MSVC2015 matches GCC)
-#if defined(_MSC_VER) && (_MSC_VER<1900)
+#ifndef STB_SPRINTF_MSVC_MODE // used for MSVC2013 and earlier (MSVC2015 matches GCC)
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
 #define STB_SPRINTF_MSVC_MODE
 #endif
 #endif
 
-#ifdef STB_SPRINTF_NOUNALIGNED  // define this before inclusion to force stbsp_sprintf to always use aligned accesses
+#ifdef STB_SPRINTF_NOUNALIGNED // define this before inclusion to force stbsp_sprintf to always use aligned accesses
 #define STBSP__UNALIGNED(code)
 #else
 #define STBSP__UNALIGNED(code) code
@@ -211,19 +211,21 @@ STBSP__PUBLICDEF void STB_SPRINTF_DECORATE( set_separators )( char comma, char p
 
 #ifndef STB_SPRINTF_NOFLOAT
 // internal float utility functions
-static stbsp__int32 stbsp__real_to_str( char const * * start, stbsp__uint32 * len, char *out, stbsp__int32 * decimal_pos, double value, stbsp__uint32 frac_digits );
-static stbsp__int32 stbsp__real_to_parts( stbsp__int64 * bits, stbsp__int32 * expo, double value );
+static stbsp__int32 stbsp__real_to_str(char const **start, stbsp__uint32 *len, char *out, stbsp__int32 *decimal_pos, double value, stbsp__uint32 frac_digits);
+static stbsp__int32 stbsp__real_to_parts(stbsp__int64 *bits, stbsp__int32 *expo, double value);
 #define STBSP__SPECIAL 0x7000
 #endif
 
-static char stbsp__period='.';
-static char stbsp__comma=',';
-static char stbsp__digitpair[201]="00010203040506070809101112131415161718192021222324252627282930313233343536373839404142434445464748495051525354555657585960616263646566676869707172737475767778798081828384858687888990919293949596979899";
+static char stbsp__period = '.';
+static char stbsp__comma = ',';
+static char stbsp__digitpair[201] =
+   "0001020304050607080910111213141516171819202122232425262728293031323334353637383940414243444546474849505152535455565758596061626364656667686970717273747576"
+   "7778798081828384858687888990919293949596979899";
 
-STBSP__PUBLICDEF void STB_SPRINTF_DECORATE( set_separators )( char pcomma, char pperiod )
+STBSP__PUBLICDEF void STB_SPRINTF_DECORATE(set_separators)(char pcomma, char pperiod)
 {
-  stbsp__period=pperiod;
-  stbsp__comma=pcomma;
+   stbsp__period = pperiod;
+   stbsp__comma = pcomma;
 }
 
 #define STBSP__LEFTJUST 1
@@ -242,582 +244,1057 @@ STBSP__PUBLICDEF void STB_SPRINTF_DECORATE( set_separators )( char pcomma, char 
 
 static void stbsp__lead_sign(stbsp__uint32 fl, char *sign)
 {
-  sign[0] = 0;
-  if (fl&STBSP__NEGATIVE) {
-    sign[0]=1;
-    sign[1]='-';
-  } else if (fl&STBSP__LEADINGSPACE) {
-    sign[0]=1;
-    sign[1]=' ';
-  } else if (fl&STBSP__LEADINGPLUS) {
-    sign[0]=1;
-    sign[1]='+';
-  }
+   sign[0] = 0;
+   if (fl & STBSP__NEGATIVE) {
+      sign[0] = 1;
+      sign[1] = '-';
+   } else if (fl & STBSP__LEADINGSPACE) {
+      sign[0] = 1;
+      sign[1] = ' ';
+   } else if (fl & STBSP__LEADINGPLUS) {
+      sign[0] = 1;
+      sign[1] = '+';
+   }
 }
-  
-STBSP__PUBLICDEF int STB_SPRINTF_DECORATE( vsprintfcb )( STBSP_SPRINTFCB * callback, void * user, char * buf, char const * fmt, va_list va )
+
+STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback, void *user, char *buf, char const *fmt, va_list va)
 {
-  static char hex[]="0123456789abcdefxp";
-  static char hexu[]="0123456789ABCDEFXP";
-  char * bf;
-  char const * f;
-  int tlen = 0;
+   static char hex[] = "0123456789abcdefxp";
+   static char hexu[] = "0123456789ABCDEFXP";
+   char *bf;
+   char const *f;
+   int tlen = 0;
 
-  bf = buf;
-  f = fmt;
-  for(;;)
-  {
-    stbsp__int32 fw,pr,tz; stbsp__uint32 fl;
+   bf = buf;
+   f = fmt;
+   for (;;) {
+      stbsp__int32 fw, pr, tz;
+      stbsp__uint32 fl;
 
-    // macros for the callback buffer stuff
-    #define stbsp__chk_cb_bufL(bytes) { int len = (int)(bf-buf); if ((len+(bytes))>=STB_SPRINTF_MIN) { tlen+=len; if (0==(bf=buf=callback(buf,user,len))) goto done; } }
-    #define stbsp__chk_cb_buf(bytes) { if ( callback ) { stbsp__chk_cb_bufL(bytes); } }
-    #define stbsp__flush_cb() { stbsp__chk_cb_bufL(STB_SPRINTF_MIN-1); } //flush if there is even one byte in the buffer
-    #define stbsp__cb_buf_clamp(cl,v) cl = v; if ( callback ) { int lg = STB_SPRINTF_MIN-(int)(bf-buf); if (cl>lg) cl=lg; }
+// macros for the callback buffer stuff
+#define stbsp__chk_cb_bufL(bytes)                        \
+   {                                                     \
+      int len = (int)(bf - buf);                         \
+      if ((len + (bytes)) >= STB_SPRINTF_MIN) {          \
+         tlen += len;                                    \
+         if (0 == (bf = buf = callback(buf, user, len))) \
+            goto done;                                   \
+      }                                                  \
+   }
+#define stbsp__chk_cb_buf(bytes)    \
+   {                                \
+      if (callback) {               \
+         stbsp__chk_cb_bufL(bytes); \
+      }                             \
+   }
+#define stbsp__flush_cb()                      \
+   {                                           \
+      stbsp__chk_cb_bufL(STB_SPRINTF_MIN - 1); \
+   } // flush if there is even one byte in the buffer
+#define stbsp__cb_buf_clamp(cl, v)                \
+   cl = v;                                        \
+   if (callback) {                                \
+      int lg = STB_SPRINTF_MIN - (int)(bf - buf); \
+      if (cl > lg)                                \
+         cl = lg;                                 \
+   }
 
-    // fast copy everything up to the next % (or end of string)
-    for(;;)
-    { 
-      while (((stbsp__uintptr)f)&3)
-      {
-       schk1: if (f[0]=='%') goto scandd;
-       schk2: if (f[0]==0) goto endfmt;
-        stbsp__chk_cb_buf(1); *bf++=f[0]; ++f;
-      } 
-      for(;;)
-      { 
-        // Check if the next 4 bytes contain %(0x25) or end of string.
-        // Using the 'hasless' trick:
-        // https://graphics.stanford.edu/~seander/bithacks.html#HasLessInWord
-        stbsp__uint32 v,c;
-        v=*(stbsp__uint32*)f; c=(~v)&0x80808080;
-        if (((v^0x25252525)-0x01010101)&c) goto schk1;
-        if ((v-0x01010101)&c) goto schk2; 
-        if (callback) if ((STB_SPRINTF_MIN-(int)(bf-buf))<4) goto schk1;
-        *(stbsp__uint32*)bf=v; bf+=4; f+=4;
+      // fast copy everything up to the next % (or end of string)
+      for (;;) {
+         while (((stbsp__uintptr)f) & 3) {
+         schk1:
+            if (f[0] == '%')
+               goto scandd;
+         schk2:
+            if (f[0] == 0)
+               goto endfmt;
+            stbsp__chk_cb_buf(1);
+            *bf++ = f[0];
+            ++f;
+         }
+         for (;;) {
+            // Check if the next 4 bytes contain %(0x25) or end of string.
+            // Using the 'hasless' trick:
+            // https://graphics.stanford.edu/~seander/bithacks.html#HasLessInWord
+            stbsp__uint32 v, c;
+            v = *(stbsp__uint32 *)f;
+            c = (~v) & 0x80808080;
+            if (((v ^ 0x25252525) - 0x01010101) & c)
+               goto schk1;
+            if ((v - 0x01010101) & c)
+               goto schk2;
+            if (callback)
+               if ((STB_SPRINTF_MIN - (int)(bf - buf)) < 4)
+                  goto schk1;
+            *(stbsp__uint32 *)bf = v;
+            bf += 4;
+            f += 4;
+         }
       }
-    } scandd:
+   scandd:
 
-    ++f;
+      ++f;
 
-    // ok, we have a percent, read the modifiers first
-    fw = 0; pr = -1; fl = 0; tz = 0;
-    
-    // flags
-    for(;;)
-    {
-      switch(f[0])
-      {
-        // if we have left justify
-        case '-': fl|=STBSP__LEFTJUST; ++f; continue;
-        // if we have leading plus
-        case '+': fl|=STBSP__LEADINGPLUS; ++f; continue; 
-        // if we have leading space
-        case ' ': fl|=STBSP__LEADINGSPACE; ++f; continue; 
-        // if we have leading 0x
-        case '#': fl|=STBSP__LEADING_0X; ++f; continue; 
-        // if we have thousand commas
-        case '\'': fl|=STBSP__TRIPLET_COMMA; ++f; continue; 
-        // if we have kilo marker (none->kilo->kibi->jedec)
-        case '$': 
-            if (fl&STBSP__METRIC_SUFFIX)
-            {
-                if (fl&STBSP__METRIC_1024)
-                {
-                    fl|=STBSP__METRIC_JEDEC;
-                }
-                else
-                {
-                    fl|=STBSP__METRIC_1024;
-                }
+      // ok, we have a percent, read the modifiers first
+      fw = 0;
+      pr = -1;
+      fl = 0;
+      tz = 0;
+
+      // flags
+      for (;;) {
+         switch (f[0]) {
+         // if we have left justify
+         case '-':
+            fl |= STBSP__LEFTJUST;
+            ++f;
+            continue;
+         // if we have leading plus
+         case '+':
+            fl |= STBSP__LEADINGPLUS;
+            ++f;
+            continue;
+         // if we have leading space
+         case ' ':
+            fl |= STBSP__LEADINGSPACE;
+            ++f;
+            continue;
+         // if we have leading 0x
+         case '#':
+            fl |= STBSP__LEADING_0X;
+            ++f;
+            continue;
+         // if we have thousand commas
+         case '\'':
+            fl |= STBSP__TRIPLET_COMMA;
+            ++f;
+            continue;
+         // if we have kilo marker (none->kilo->kibi->jedec)
+         case '$':
+            if (fl & STBSP__METRIC_SUFFIX) {
+               if (fl & STBSP__METRIC_1024) {
+                  fl |= STBSP__METRIC_JEDEC;
+               } else {
+                  fl |= STBSP__METRIC_1024;
+               }
+            } else {
+               fl |= STBSP__METRIC_SUFFIX;
             }
-            else
-            {
-                fl|=STBSP__METRIC_SUFFIX; 
-            }
-            ++f; continue; 
-        // if we don't want space between metric suffix and number
-        case '_': fl|=STBSP__METRIC_NOSPACE; ++f; continue;
-        // if we have leading zero
-        case '0': fl|=STBSP__LEADINGZERO; ++f; goto flags_done; 
-        default: goto flags_done;
+            ++f;
+            continue;
+         // if we don't want space between metric suffix and number
+         case '_':
+            fl |= STBSP__METRIC_NOSPACE;
+            ++f;
+            continue;
+         // if we have leading zero
+         case '0':
+            fl |= STBSP__LEADINGZERO;
+            ++f;
+            goto flags_done;
+         default: goto flags_done;
+         }
       }
-    }
-    flags_done:
-   
-    // get the field width
-    if ( f[0] == '*' ) {fw = va_arg(va,stbsp__uint32); ++f;} else { while (( f[0] >= '0' ) && ( f[0] <= '9' )) { fw = fw * 10 + f[0] - '0'; f++; } }
-    // get the precision
-    if ( f[0]=='.' ) { ++f; if ( f[0] == '*' ) {pr = va_arg(va,stbsp__uint32); ++f;} else { pr = 0; while (( f[0] >= '0' ) && ( f[0] <= '9' )) { pr = pr * 10 + f[0] - '0'; f++; } } } 
-    
-    // handle integer size overrides
-    switch(f[0])
-    {
+   flags_done:
+
+      // get the field width
+      if (f[0] == '*') {
+         fw = va_arg(va, stbsp__uint32);
+         ++f;
+      } else {
+         while ((f[0] >= '0') && (f[0] <= '9')) {
+            fw = fw * 10 + f[0] - '0';
+            f++;
+         }
+      }
+      // get the precision
+      if (f[0] == '.') {
+         ++f;
+         if (f[0] == '*') {
+            pr = va_arg(va, stbsp__uint32);
+            ++f;
+         } else {
+            pr = 0;
+            while ((f[0] >= '0') && (f[0] <= '9')) {
+               pr = pr * 10 + f[0] - '0';
+               f++;
+            }
+         }
+      }
+
+      // handle integer size overrides
+      switch (f[0]) {
       // are we halfwidth?
-      case 'h': fl|=STBSP__HALFWIDTH; ++f; break;
+      case 'h':
+         fl |= STBSP__HALFWIDTH;
+         ++f;
+         break;
       // are we 64-bit (unix style)
-      case 'l': ++f; if ( f[0]=='l') { fl|=STBSP__INTMAX; ++f; } break;
+      case 'l':
+         ++f;
+         if (f[0] == 'l') {
+            fl |= STBSP__INTMAX;
+            ++f;
+         }
+         break;
       // are we 64-bit on intmax? (c99)
-      case 'j': fl|=STBSP__INTMAX; ++f; break; 
+      case 'j':
+         fl |= STBSP__INTMAX;
+         ++f;
+         break;
       // are we 64-bit on size_t or ptrdiff_t? (c99)
-      case 'z': case 't': fl|=((sizeof(char*)==8)?STBSP__INTMAX:0); ++f; break; 
+      case 'z':
+      case 't':
+         fl |= ((sizeof(char *) == 8) ? STBSP__INTMAX : 0);
+         ++f;
+         break;
       // are we 64-bit (msft style)
-      case 'I': if ( ( f[1]=='6') && ( f[2]=='4') ) { fl|=STBSP__INTMAX; f+=3; }
-                else if ( ( f[1]=='3') && ( f[2]=='2') ) { f+=3; }
-                else { fl|=((sizeof(void*)==8)?STBSP__INTMAX:0); ++f; } break;
+      case 'I':
+         if ((f[1] == '6') && (f[2] == '4')) {
+            fl |= STBSP__INTMAX;
+            f += 3;
+         } else if ((f[1] == '3') && (f[2] == '2')) {
+            f += 3;
+         } else {
+            fl |= ((sizeof(void *) == 8) ? STBSP__INTMAX : 0);
+            ++f;
+         }
+         break;
       default: break;
-    }
+      }
 
-    // handle each replacement
-    switch( f[0] )
-    {
-      #define STBSP__NUMSZ   512 // big enough for e308 (with commas) or e-307 
-      char num[STBSP__NUMSZ]; 
-      char lead[8]; 
-      char tail[8]; 
-      char *s;
-      char const *h;
-      stbsp__uint32 l,n,cs;
-      stbsp__uint64 n64;
-      #ifndef STB_SPRINTF_NOFLOAT      
-      double fv; 
-      #endif
-      stbsp__int32 dp; char const * sn;
+      // handle each replacement
+      switch (f[0]) {
+#define STBSP__NUMSZ 512 // big enough for e308 (with commas) or e-307
+         char num[STBSP__NUMSZ];
+         char lead[8];
+         char tail[8];
+         char *s;
+         char const *h;
+         stbsp__uint32 l, n, cs;
+         stbsp__uint64 n64;
+#ifndef STB_SPRINTF_NOFLOAT
+         double fv;
+#endif
+         stbsp__int32 dp;
+         char const *sn;
 
       case 's':
-        // get the string
-        s = va_arg(va,char*); if (s==0) s = (char*)"null";
-        // get the length
-        sn = s;
-        for(;;)
-        { 
-          if ((((stbsp__uintptr)sn)&3)==0) break;
+         // get the string
+         s = va_arg(va, char *);
+         if (s == 0)
+            s = (char *)"null";
+         // get the length
+         sn = s;
+         for (;;) {
+            if ((((stbsp__uintptr)sn) & 3) == 0)
+               break;
          lchk:
-          if (sn[0]==0) goto ld;
-          ++sn;
-        }
-        n = 0xffffffff;
-        if (pr>=0) { n=(stbsp__uint32)(sn-s); if (n>=(stbsp__uint32)pr) goto ld; n=((stbsp__uint32)(pr-n))>>2; }
-        while(n) 
-        { 
-          stbsp__uint32 v=*(stbsp__uint32*)sn;
-          if ((v-0x01010101)&(~v)&0x80808080UL) goto lchk; 
-          sn+=4; 
-          --n;
-        }
-        goto lchk;
-       ld:
+            if (sn[0] == 0)
+               goto ld;
+            ++sn;
+         }
+         n = 0xffffffff;
+         if (pr >= 0) {
+            n = (stbsp__uint32)(sn - s);
+            if (n >= (stbsp__uint32)pr)
+               goto ld;
+            n = ((stbsp__uint32)(pr - n)) >> 2;
+         }
+         while (n) {
+            stbsp__uint32 v = *(stbsp__uint32 *)sn;
+            if ((v - 0x01010101) & (~v) & 0x80808080UL)
+               goto lchk;
+            sn += 4;
+            --n;
+         }
+         goto lchk;
+      ld:
 
-        l = (stbsp__uint32) ( sn - s );
-        // clamp to precision
-        if ( l > (stbsp__uint32)pr ) l = pr;
-        lead[0]=0; tail[0]=0; pr = 0; dp = 0; cs = 0;
-        // copy the string in
-        goto scopy;
+         l = (stbsp__uint32)(sn - s);
+         // clamp to precision
+         if (l > (stbsp__uint32)pr)
+            l = pr;
+         lead[0] = 0;
+         tail[0] = 0;
+         pr = 0;
+         dp = 0;
+         cs = 0;
+         // copy the string in
+         goto scopy;
 
       case 'c': // char
-        // get the character
-        s = num + STBSP__NUMSZ -1; *s = (char)va_arg(va,int);
-        l = 1;
-        lead[0]=0; tail[0]=0; pr = 0; dp = 0; cs = 0;
-        goto scopy;
+         // get the character
+         s = num + STBSP__NUMSZ - 1;
+         *s = (char)va_arg(va, int);
+         l = 1;
+         lead[0] = 0;
+         tail[0] = 0;
+         pr = 0;
+         dp = 0;
+         cs = 0;
+         goto scopy;
 
       case 'n': // weird write-bytes specifier
-        { int * d = va_arg(va,int*);
-        *d = tlen + (int)( bf - buf ); }
-        break;
+      {
+         int *d = va_arg(va, int *);
+         *d = tlen + (int)(bf - buf);
+      } break;
 
 #ifdef STB_SPRINTF_NOFLOAT
-      case 'A': // float
-      case 'a': // hex float
-      case 'G': // float
-      case 'g': // float
-      case 'E': // float
-      case 'e': // float
-      case 'f': // float
-        va_arg(va,double); // eat it
-        s = (char*)"No float";
-        l = 8;
-        lead[0]=0; tail[0]=0; pr = 0; dp = 0; cs = 0;
-        goto scopy;
+      case 'A':              // float
+      case 'a':              // hex float
+      case 'G':              // float
+      case 'g':              // float
+      case 'E':              // float
+      case 'e':              // float
+      case 'f':              // float
+         va_arg(va, double); // eat it
+         s = (char *)"No float";
+         l = 8;
+         lead[0] = 0;
+         tail[0] = 0;
+         pr = 0;
+         dp = 0;
+         cs = 0;
+         goto scopy;
 #else
       case 'A': // float
-        h=hexu;  
-        goto hexfloat;
+         h = hexu;
+         goto hexfloat;
 
       case 'a': // hex float
-        h=hex;
-       hexfloat: 
-        fv = va_arg(va,double);
-        if (pr==-1) pr=6; // default is 6
-        // read the double into a string
-        if ( stbsp__real_to_parts( (stbsp__int64*)&n64, &dp, fv ) )
-          fl |= STBSP__NEGATIVE;
-  
-        s = num+64;
+         h = hex;
+      hexfloat:
+         fv = va_arg(va, double);
+         if (pr == -1)
+            pr = 6; // default is 6
+         // read the double into a string
+         if (stbsp__real_to_parts((stbsp__int64 *)&n64, &dp, fv))
+            fl |= STBSP__NEGATIVE;
 
-        stbsp__lead_sign(fl, lead);
+         s = num + 64;
 
-        if (dp==-1023) dp=(n64)?-1022:0; else n64|=(((stbsp__uint64)1)<<52);
-        n64<<=(64-56);
-        if (pr<15) n64+=((((stbsp__uint64)8)<<56)>>(pr*4));
-        // add leading chars
-        
-        #ifdef STB_SPRINTF_MSVC_MODE
-        *s++='0';*s++='x';
-        #else
-        lead[1+lead[0]]='0'; lead[2+lead[0]]='x'; lead[0]+=2;
-        #endif
-        *s++=h[(n64>>60)&15]; n64<<=4;
-        if ( pr ) *s++=stbsp__period;
-        sn = s;
+         stbsp__lead_sign(fl, lead);
 
-        // print the bits
-        n = pr; if (n>13) n = 13; if (pr>(stbsp__int32)n) tz=pr-n; pr = 0;
-        while(n--) { *s++=h[(n64>>60)&15]; n64<<=4; }
+         if (dp == -1023)
+            dp = (n64) ? -1022 : 0;
+         else
+            n64 |= (((stbsp__uint64)1) << 52);
+         n64 <<= (64 - 56);
+         if (pr < 15)
+            n64 += ((((stbsp__uint64)8) << 56) >> (pr * 4));
+// add leading chars
 
-        // print the expo
-        tail[1]=h[17];
-        if (dp<0) { tail[2]='-'; dp=-dp;} else tail[2]='+';
-        n = (dp>=1000)?6:((dp>=100)?5:((dp>=10)?4:3));
-        tail[0]=(char)n;
-        for(;;) { tail[n]='0'+dp%10; if (n<=3) break; --n; dp/=10; }
+#ifdef STB_SPRINTF_MSVC_MODE
+         *s++ = '0';
+         *s++ = 'x';
+#else
+         lead[1 + lead[0]] = '0';
+         lead[2 + lead[0]] = 'x';
+         lead[0] += 2;
+#endif
+         *s++ = h[(n64 >> 60) & 15];
+         n64 <<= 4;
+         if (pr)
+            *s++ = stbsp__period;
+         sn = s;
 
-        dp = (int)(s-sn);
-        l = (int)(s-(num+64));
-        s = num+64;
-        cs = 1 + (3<<24);
-        goto scopy;
+         // print the bits
+         n = pr;
+         if (n > 13)
+            n = 13;
+         if (pr > (stbsp__int32)n)
+            tz = pr - n;
+         pr = 0;
+         while (n--) {
+            *s++ = h[(n64 >> 60) & 15];
+            n64 <<= 4;
+         }
+
+         // print the expo
+         tail[1] = h[17];
+         if (dp < 0) {
+            tail[2] = '-';
+            dp = -dp;
+         } else
+            tail[2] = '+';
+         n = (dp >= 1000) ? 6 : ((dp >= 100) ? 5 : ((dp >= 10) ? 4 : 3));
+         tail[0] = (char)n;
+         for (;;) {
+            tail[n] = '0' + dp % 10;
+            if (n <= 3)
+               break;
+            --n;
+            dp /= 10;
+         }
+
+         dp = (int)(s - sn);
+         l = (int)(s - (num + 64));
+         s = num + 64;
+         cs = 1 + (3 << 24);
+         goto scopy;
 
       case 'G': // float
-        h=hexu;
-        goto dosmallfloat;
+         h = hexu;
+         goto dosmallfloat;
 
       case 'g': // float
-        h=hex;
-       dosmallfloat:   
-        fv = va_arg(va,double);
-        if (pr==-1) pr=6; else if (pr==0) pr = 1; // default is 6
-        // read the double into a string
-        if ( stbsp__real_to_str( &sn, &l, num, &dp, fv, (pr-1)|0x80000000 ) )
-          fl |= STBSP__NEGATIVE;
+         h = hex;
+      dosmallfloat:
+         fv = va_arg(va, double);
+         if (pr == -1)
+            pr = 6;
+         else if (pr == 0)
+            pr = 1; // default is 6
+         // read the double into a string
+         if (stbsp__real_to_str(&sn, &l, num, &dp, fv, (pr - 1) | 0x80000000))
+            fl |= STBSP__NEGATIVE;
 
-        // clamp the precision and delete extra zeros after clamp
-        n = pr;
-        if ( l > (stbsp__uint32)pr ) l = pr; while ((l>1)&&(pr)&&(sn[l-1]=='0')) { --pr; --l; }
+         // clamp the precision and delete extra zeros after clamp
+         n = pr;
+         if (l > (stbsp__uint32)pr)
+            l = pr;
+         while ((l > 1) && (pr) && (sn[l - 1] == '0')) {
+            --pr;
+            --l;
+         }
 
-        // should we use %e
-        if ((dp<=-4)||(dp>(stbsp__int32)n))
-        {
-          if ( pr > (stbsp__int32)l ) pr = l-1; else if ( pr ) --pr; // when using %e, there is one digit before the decimal
-          goto doexpfromg;
-        }
-        // this is the insane action to get the pr to match %g sematics for %f
-        if(dp>0) { pr=(dp<(stbsp__int32)l)?l-dp:0; } else { pr = -dp+((pr>(stbsp__int32)l)?l:pr); }
-        goto dofloatfromg;
+         // should we use %e
+         if ((dp <= -4) || (dp > (stbsp__int32)n)) {
+            if (pr > (stbsp__int32)l)
+               pr = l - 1;
+            else if (pr)
+               --pr; // when using %e, there is one digit before the decimal
+            goto doexpfromg;
+         }
+         // this is the insane action to get the pr to match %g sematics for %f
+         if (dp > 0) {
+            pr = (dp < (stbsp__int32)l) ? l - dp : 0;
+         } else {
+            pr = -dp + ((pr > (stbsp__int32)l) ? l : pr);
+         }
+         goto dofloatfromg;
 
       case 'E': // float
-        h=hexu;  
-        goto doexp;
+         h = hexu;
+         goto doexp;
 
       case 'e': // float
-        h=hex;
-       doexp:   
-        fv = va_arg(va,double);
-        if (pr==-1) pr=6; // default is 6
-        // read the double into a string
-        if ( stbsp__real_to_str( &sn, &l, num, &dp, fv, pr|0x80000000 ) )
-          fl |= STBSP__NEGATIVE;
-       doexpfromg: 
-        tail[0]=0; 
-        stbsp__lead_sign(fl, lead);
-        if ( dp == STBSP__SPECIAL ) { s=(char*)sn; cs=0; pr=0; goto scopy; }
-        s=num+64; 
-        // handle leading chars
-        *s++=sn[0];
+         h = hex;
+      doexp:
+         fv = va_arg(va, double);
+         if (pr == -1)
+            pr = 6; // default is 6
+         // read the double into a string
+         if (stbsp__real_to_str(&sn, &l, num, &dp, fv, pr | 0x80000000))
+            fl |= STBSP__NEGATIVE;
+      doexpfromg:
+         tail[0] = 0;
+         stbsp__lead_sign(fl, lead);
+         if (dp == STBSP__SPECIAL) {
+            s = (char *)sn;
+            cs = 0;
+            pr = 0;
+            goto scopy;
+         }
+         s = num + 64;
+         // handle leading chars
+         *s++ = sn[0];
 
-        if (pr) *s++=stbsp__period;
+         if (pr)
+            *s++ = stbsp__period;
 
-        // handle after decimal
-        if ((l-1)>(stbsp__uint32)pr) l=pr+1;
-        for(n=1;n<l;n++) *s++=sn[n];
-        // trailing zeros
-        tz = pr-(l-1); pr=0;
-        // dump expo
-        tail[1]=h[0xe];
-        dp -= 1;
-        if (dp<0) { tail[2]='-'; dp=-dp;} else tail[2]='+';
-        #ifdef STB_SPRINTF_MSVC_MODE
-        n = 5;
-        #else
-        n = (dp>=100)?5:4;
-        #endif
-        tail[0]=(char)n;
-        for(;;) { tail[n]='0'+dp%10; if (n<=3) break; --n; dp/=10; }
-        cs = 1 + (3<<24); // how many tens
-        goto flt_lead;   
+         // handle after decimal
+         if ((l - 1) > (stbsp__uint32)pr)
+            l = pr + 1;
+         for (n = 1; n < l; n++)
+            *s++ = sn[n];
+         // trailing zeros
+         tz = pr - (l - 1);
+         pr = 0;
+         // dump expo
+         tail[1] = h[0xe];
+         dp -= 1;
+         if (dp < 0) {
+            tail[2] = '-';
+            dp = -dp;
+         } else
+            tail[2] = '+';
+#ifdef STB_SPRINTF_MSVC_MODE
+         n = 5;
+#else
+         n = (dp >= 100) ? 5 : 4;
+#endif
+         tail[0] = (char)n;
+         for (;;) {
+            tail[n] = '0' + dp % 10;
+            if (n <= 3)
+               break;
+            --n;
+            dp /= 10;
+         }
+         cs = 1 + (3 << 24); // how many tens
+         goto flt_lead;
 
       case 'f': // float
-        fv = va_arg(va,double);
-       doafloat: 
-        // do kilos
-        if (fl&STBSP__METRIC_SUFFIX) 
-        {
+         fv = va_arg(va, double);
+      doafloat:
+         // do kilos
+         if (fl & STBSP__METRIC_SUFFIX) {
             double divisor;
-            divisor=1000.0f;
-            if (fl&STBSP__METRIC_1024) divisor = 1024.0;
-            while(fl<0x4000000) { if ((fv<divisor) && (fv>-divisor)) break; fv/=divisor; fl+=0x1000000; }
-        }
-        if (pr==-1) pr=6; // default is 6
-        // read the double into a string
-        if ( stbsp__real_to_str( &sn, &l, num, &dp, fv, pr ) )
-          fl |= STBSP__NEGATIVE;
-        dofloatfromg:
-        tail[0]=0;
-        stbsp__lead_sign(fl, lead);
-        if ( dp == STBSP__SPECIAL ) { s=(char*)sn; cs=0; pr=0; goto scopy; }
-        s=num+64; 
-
-        // handle the three decimal varieties
-        if (dp<=0) 
-        { 
-          stbsp__int32 i;
-          // handle 0.000*000xxxx
-          *s++='0'; if (pr) *s++=stbsp__period; 
-          n=-dp; if((stbsp__int32)n>pr) n=pr; i=n; while(i) { if ((((stbsp__uintptr)s)&3)==0) break; *s++='0'; --i; } while(i>=4) { *(stbsp__uint32*)s=0x30303030; s+=4; i-=4; } while(i) { *s++='0'; --i; }
-          if ((stbsp__int32)(l+n)>pr) l=pr-n; i=l; while(i) { *s++=*sn++; --i; }
-          tz = pr-(n+l);
-          cs = 1 + (3<<24); // how many tens did we write (for commas below)
-        }
-        else
-        {
-          cs = (fl&STBSP__TRIPLET_COMMA)?((600-(stbsp__uint32)dp)%3):0;
-          if ((stbsp__uint32)dp>=l)
-          {
-            // handle xxxx000*000.0
-            n=0; for(;;) { if ((fl&STBSP__TRIPLET_COMMA) && (++cs==4)) { cs = 0; *s++=stbsp__comma; } else { *s++=sn[n]; ++n; if (n>=l) break; } }
-            if (n<(stbsp__uint32)dp)
-            {
-              n = dp - n;
-              if ((fl&STBSP__TRIPLET_COMMA)==0) { while(n) { if ((((stbsp__uintptr)s)&3)==0) break; *s++='0'; --n; }  while(n>=4) { *(stbsp__uint32*)s=0x30303030; s+=4; n-=4; } }
-              while(n) { if ((fl&STBSP__TRIPLET_COMMA) && (++cs==4)) { cs = 0; *s++=stbsp__comma; } else { *s++='0'; --n; } }
+            divisor = 1000.0f;
+            if (fl & STBSP__METRIC_1024)
+               divisor = 1024.0;
+            while (fl < 0x4000000) {
+               if ((fv < divisor) && (fv > -divisor))
+                  break;
+               fv /= divisor;
+               fl += 0x1000000;
             }
-            cs = (int)(s-(num+64)) + (3<<24); // cs is how many tens
-            if (pr) { *s++=stbsp__period; tz=pr;}
-          }
-          else
-          {
-            // handle xxxxx.xxxx000*000
-            n=0; for(;;) { if ((fl&STBSP__TRIPLET_COMMA) && (++cs==4)) { cs = 0; *s++=stbsp__comma; } else { *s++=sn[n]; ++n; if (n>=(stbsp__uint32)dp) break; } }
-            cs = (int)(s-(num+64)) + (3<<24); // cs is how many tens
-            if (pr) *s++=stbsp__period;
-            if ((l-dp)>(stbsp__uint32)pr) l=pr+dp;
-            while(n<l) { *s++=sn[n]; ++n; }
-            tz = pr-(l-dp);
-          }
-        }
-        pr = 0;
-        
-        // handle k,m,g,t
-        if (fl&STBSP__METRIC_SUFFIX) 
-        { 
-            char idx;
-            idx=1;
-            if (fl&STBSP__METRIC_NOSPACE)
-                idx=0;
-            tail[0]=idx; 
-            tail[1]=' '; 
-            { 
-                if (fl>>24) 
-                {   // SI kilo is 'k', JEDEC and SI kibits are 'K'.
-                    if (fl&STBSP__METRIC_1024)
-                        tail[idx+1]="_KMGT"[fl>>24]; 
-                    else
-                        tail[idx+1]="_kMGT"[fl>>24]; 
-                    idx++;
-                    // If printing kibits and not in jedec, add the 'i'.
-                    if (fl&STBSP__METRIC_1024&&!(fl&STBSP__METRIC_JEDEC))
-                    {
-                        tail[idx+1]='i';
-                        idx++;
-                    }
-                    tail[0]=idx;
-                } 
-            } 
-        };
+         }
+         if (pr == -1)
+            pr = 6; // default is 6
+         // read the double into a string
+         if (stbsp__real_to_str(&sn, &l, num, &dp, fv, pr))
+            fl |= STBSP__NEGATIVE;
+      dofloatfromg:
+         tail[0] = 0;
+         stbsp__lead_sign(fl, lead);
+         if (dp == STBSP__SPECIAL) {
+            s = (char *)sn;
+            cs = 0;
+            pr = 0;
+            goto scopy;
+         }
+         s = num + 64;
 
-        flt_lead:
-        // get the length that we copied
-        l = (stbsp__uint32) ( s-(num+64) );
-        s=num+64; 
-        goto scopy;
+         // handle the three decimal varieties
+         if (dp <= 0) {
+            stbsp__int32 i;
+            // handle 0.000*000xxxx
+            *s++ = '0';
+            if (pr)
+               *s++ = stbsp__period;
+            n = -dp;
+            if ((stbsp__int32)n > pr)
+               n = pr;
+            i = n;
+            while (i) {
+               if ((((stbsp__uintptr)s) & 3) == 0)
+                  break;
+               *s++ = '0';
+               --i;
+            }
+            while (i >= 4) {
+               *(stbsp__uint32 *)s = 0x30303030;
+               s += 4;
+               i -= 4;
+            }
+            while (i) {
+               *s++ = '0';
+               --i;
+            }
+            if ((stbsp__int32)(l + n) > pr)
+               l = pr - n;
+            i = l;
+            while (i) {
+               *s++ = *sn++;
+               --i;
+            }
+            tz = pr - (n + l);
+            cs = 1 + (3 << 24); // how many tens did we write (for commas below)
+         } else {
+            cs = (fl & STBSP__TRIPLET_COMMA) ? ((600 - (stbsp__uint32)dp) % 3) : 0;
+            if ((stbsp__uint32)dp >= l) {
+               // handle xxxx000*000.0
+               n = 0;
+               for (;;) {
+                  if ((fl & STBSP__TRIPLET_COMMA) && (++cs == 4)) {
+                     cs = 0;
+                     *s++ = stbsp__comma;
+                  } else {
+                     *s++ = sn[n];
+                     ++n;
+                     if (n >= l)
+                        break;
+                  }
+               }
+               if (n < (stbsp__uint32)dp) {
+                  n = dp - n;
+                  if ((fl & STBSP__TRIPLET_COMMA) == 0) {
+                     while (n) {
+                        if ((((stbsp__uintptr)s) & 3) == 0)
+                           break;
+                        *s++ = '0';
+                        --n;
+                     }
+                     while (n >= 4) {
+                        *(stbsp__uint32 *)s = 0x30303030;
+                        s += 4;
+                        n -= 4;
+                     }
+                  }
+                  while (n) {
+                     if ((fl & STBSP__TRIPLET_COMMA) && (++cs == 4)) {
+                        cs = 0;
+                        *s++ = stbsp__comma;
+                     } else {
+                        *s++ = '0';
+                        --n;
+                     }
+                  }
+               }
+               cs = (int)(s - (num + 64)) + (3 << 24); // cs is how many tens
+               if (pr) {
+                  *s++ = stbsp__period;
+                  tz = pr;
+               }
+            } else {
+               // handle xxxxx.xxxx000*000
+               n = 0;
+               for (;;) {
+                  if ((fl & STBSP__TRIPLET_COMMA) && (++cs == 4)) {
+                     cs = 0;
+                     *s++ = stbsp__comma;
+                  } else {
+                     *s++ = sn[n];
+                     ++n;
+                     if (n >= (stbsp__uint32)dp)
+                        break;
+                  }
+               }
+               cs = (int)(s - (num + 64)) + (3 << 24); // cs is how many tens
+               if (pr)
+                  *s++ = stbsp__period;
+               if ((l - dp) > (stbsp__uint32)pr)
+                  l = pr + dp;
+               while (n < l) {
+                  *s++ = sn[n];
+                  ++n;
+               }
+               tz = pr - (l - dp);
+            }
+         }
+         pr = 0;
+
+         // handle k,m,g,t
+         if (fl & STBSP__METRIC_SUFFIX) {
+            char idx;
+            idx = 1;
+            if (fl & STBSP__METRIC_NOSPACE)
+               idx = 0;
+            tail[0] = idx;
+            tail[1] = ' ';
+            {
+               if (fl >> 24) { // SI kilo is 'k', JEDEC and SI kibits are 'K'.
+                  if (fl & STBSP__METRIC_1024)
+                     tail[idx + 1] = "_KMGT"[fl >> 24];
+                  else
+                     tail[idx + 1] = "_kMGT"[fl >> 24];
+                  idx++;
+                  // If printing kibits and not in jedec, add the 'i'.
+                  if (fl & STBSP__METRIC_1024 && !(fl & STBSP__METRIC_JEDEC)) {
+                     tail[idx + 1] = 'i';
+                     idx++;
+                  }
+                  tail[0] = idx;
+               }
+            }
+         };
+
+      flt_lead:
+         // get the length that we copied
+         l = (stbsp__uint32)(s - (num + 64));
+         s = num + 64;
+         goto scopy;
 #endif
 
       case 'B': // upper binary
-        h = hexu;
-        goto binary;
+         h = hexu;
+         goto binary;
 
       case 'b': // lower binary
-        h = hex;
-        binary:
-        lead[0]=0;
-        if (fl&STBSP__LEADING_0X) { lead[0]=2;lead[1]='0';lead[2]=h[0xb]; }
-        l=(8<<4)|(1<<8);
-        goto radixnum;
+         h = hex;
+      binary:
+         lead[0] = 0;
+         if (fl & STBSP__LEADING_0X) {
+            lead[0] = 2;
+            lead[1] = '0';
+            lead[2] = h[0xb];
+         }
+         l = (8 << 4) | (1 << 8);
+         goto radixnum;
 
       case 'o': // octal
-        h = hexu;
-        lead[0]=0;
-        if (fl&STBSP__LEADING_0X) { lead[0]=1;lead[1]='0'; }
-        l=(3<<4)|(3<<8);
-        goto radixnum;
+         h = hexu;
+         lead[0] = 0;
+         if (fl & STBSP__LEADING_0X) {
+            lead[0] = 1;
+            lead[1] = '0';
+         }
+         l = (3 << 4) | (3 << 8);
+         goto radixnum;
 
       case 'p': // pointer
-        fl |= (sizeof(void*)==8)?STBSP__INTMAX:0;
-        pr = sizeof(void*)*2;
-        fl &= ~STBSP__LEADINGZERO; // 'p' only prints the pointer with zeros
-        // drop through to X
-      
+         fl |= (sizeof(void *) == 8) ? STBSP__INTMAX : 0;
+         pr = sizeof(void *) * 2;
+         fl &= ~STBSP__LEADINGZERO; // 'p' only prints the pointer with zeros
+                                    // drop through to X
+
       case 'X': // upper binary
-        h = hexu;
-        goto dohexb;
+         h = hexu;
+         goto dohexb;
 
       case 'x': // lower binary
-        h = hex; dohexb:
-        l=(4<<4)|(4<<8);
-        lead[0]=0;
-        if (fl&STBSP__LEADING_0X) { lead[0]=2;lead[1]='0';lead[2]=h[16]; }
-       radixnum: 
-        // get the number
-        if ( fl&STBSP__INTMAX )
-          n64 = va_arg(va,stbsp__uint64);
-        else
-          n64 = va_arg(va,stbsp__uint32);
+         h = hex;
+      dohexb:
+         l = (4 << 4) | (4 << 8);
+         lead[0] = 0;
+         if (fl & STBSP__LEADING_0X) {
+            lead[0] = 2;
+            lead[1] = '0';
+            lead[2] = h[16];
+         }
+      radixnum:
+         // get the number
+         if (fl & STBSP__INTMAX)
+            n64 = va_arg(va, stbsp__uint64);
+         else
+            n64 = va_arg(va, stbsp__uint32);
 
-        s = num + STBSP__NUMSZ; dp = 0;
-        // clear tail, and clear leading if value is zero
-        tail[0]=0; if (n64==0) { lead[0]=0; if (pr==0) { l=0; cs = ( ((l>>4)&15)) << 24; goto scopy; } }
-        // convert to string
-        for(;;) { *--s = h[n64&((1<<(l>>8))-1)]; n64>>=(l>>8); if ( ! ( (n64) || ((stbsp__int32) ( (num+STBSP__NUMSZ) - s ) < pr ) ) ) break; if ( fl&STBSP__TRIPLET_COMMA) { ++l; if ((l&15)==((l>>4)&15)) { l&=~15; *--s=stbsp__comma; } } };
-        // get the tens and the comma pos
-        cs = (stbsp__uint32) ( (num+STBSP__NUMSZ) - s ) + ( ( ((l>>4)&15)) << 24 );
-        // get the length that we copied
-        l = (stbsp__uint32) ( (num+STBSP__NUMSZ) - s );
-        // copy it
-        goto scopy;
+         s = num + STBSP__NUMSZ;
+         dp = 0;
+         // clear tail, and clear leading if value is zero
+         tail[0] = 0;
+         if (n64 == 0) {
+            lead[0] = 0;
+            if (pr == 0) {
+               l = 0;
+               cs = (((l >> 4) & 15)) << 24;
+               goto scopy;
+            }
+         }
+         // convert to string
+         for (;;) {
+            *--s = h[n64 & ((1 << (l >> 8)) - 1)];
+            n64 >>= (l >> 8);
+            if (!((n64) || ((stbsp__int32)((num + STBSP__NUMSZ) - s) < pr)))
+               break;
+            if (fl & STBSP__TRIPLET_COMMA) {
+               ++l;
+               if ((l & 15) == ((l >> 4) & 15)) {
+                  l &= ~15;
+                  *--s = stbsp__comma;
+               }
+            }
+         };
+         // get the tens and the comma pos
+         cs = (stbsp__uint32)((num + STBSP__NUMSZ) - s) + ((((l >> 4) & 15)) << 24);
+         // get the length that we copied
+         l = (stbsp__uint32)((num + STBSP__NUMSZ) - s);
+         // copy it
+         goto scopy;
 
       case 'u': // unsigned
       case 'i':
       case 'd': // integer
-        // get the integer and abs it
-        if ( fl&STBSP__INTMAX )
-        {
-          stbsp__int64 i64 = va_arg(va,stbsp__int64); n64 = (stbsp__uint64)i64; if ((f[0]!='u') && (i64<0)) { n64=(stbsp__uint64)-i64; fl|=STBSP__NEGATIVE; }
-        }
-        else
-        {
-          stbsp__int32 i = va_arg(va,stbsp__int32); n64 = (stbsp__uint32)i; if ((f[0]!='u') && (i<0)) { n64=(stbsp__uint32)-i; fl|=STBSP__NEGATIVE; }
-        }
+         // get the integer and abs it
+         if (fl & STBSP__INTMAX) {
+            stbsp__int64 i64 = va_arg(va, stbsp__int64);
+            n64 = (stbsp__uint64)i64;
+            if ((f[0] != 'u') && (i64 < 0)) {
+               n64 = (stbsp__uint64)-i64;
+               fl |= STBSP__NEGATIVE;
+            }
+         } else {
+            stbsp__int32 i = va_arg(va, stbsp__int32);
+            n64 = (stbsp__uint32)i;
+            if ((f[0] != 'u') && (i < 0)) {
+               n64 = (stbsp__uint32)-i;
+               fl |= STBSP__NEGATIVE;
+            }
+         }
 
-        #ifndef STB_SPRINTF_NOFLOAT
-        if (fl&STBSP__METRIC_SUFFIX) { if (n64<1024) pr=0; else if (pr==-1) pr=1; fv=(double)(stbsp__int64)n64; goto doafloat; } 
-        #endif
+#ifndef STB_SPRINTF_NOFLOAT
+         if (fl & STBSP__METRIC_SUFFIX) {
+            if (n64 < 1024)
+               pr = 0;
+            else if (pr == -1)
+               pr = 1;
+            fv = (double)(stbsp__int64)n64;
+            goto doafloat;
+         }
+#endif
 
-        // convert to string
-        s = num+STBSP__NUMSZ; l=0; 
-        
-        for(;;)
-        {
-          // do in 32-bit chunks (avoid lots of 64-bit divides even with constant denominators)
-          char * o=s-8;
-          if (n64>=100000000) { n = (stbsp__uint32)( n64 % 100000000);  n64 /= 100000000; } else {n = (stbsp__uint32)n64; n64 = 0; }
-          if((fl&STBSP__TRIPLET_COMMA)==0) { while(n) { s-=2; *(stbsp__uint16*)s=*(stbsp__uint16*)&stbsp__digitpair[(n%100)*2]; n/=100; } }
-          while (n) { if ( ( fl&STBSP__TRIPLET_COMMA) && (l++==3) ) { l=0; *--s=stbsp__comma; --o; } else { *--s=(char)(n%10)+'0'; n/=10; } }
-          if (n64==0) { if ((s[0]=='0') && (s!=(num+STBSP__NUMSZ))) ++s; break; }
-          while (s!=o) if ( ( fl&STBSP__TRIPLET_COMMA) && (l++==3) ) { l=0; *--s=stbsp__comma; --o; } else { *--s='0'; }
-        }
+         // convert to string
+         s = num + STBSP__NUMSZ;
+         l = 0;
 
-        tail[0]=0;
-        stbsp__lead_sign(fl, lead);
+         for (;;) {
+            // do in 32-bit chunks (avoid lots of 64-bit divides even with constant denominators)
+            char *o = s - 8;
+            if (n64 >= 100000000) {
+               n = (stbsp__uint32)(n64 % 100000000);
+               n64 /= 100000000;
+            } else {
+               n = (stbsp__uint32)n64;
+               n64 = 0;
+            }
+            if ((fl & STBSP__TRIPLET_COMMA) == 0) {
+               while (n) {
+                  s -= 2;
+                  *(stbsp__uint16 *)s = *(stbsp__uint16 *)&stbsp__digitpair[(n % 100) * 2];
+                  n /= 100;
+               }
+            }
+            while (n) {
+               if ((fl & STBSP__TRIPLET_COMMA) && (l++ == 3)) {
+                  l = 0;
+                  *--s = stbsp__comma;
+                  --o;
+               } else {
+                  *--s = (char)(n % 10) + '0';
+                  n /= 10;
+               }
+            }
+            if (n64 == 0) {
+               if ((s[0] == '0') && (s != (num + STBSP__NUMSZ)))
+                  ++s;
+               break;
+            }
+            while (s != o)
+               if ((fl & STBSP__TRIPLET_COMMA) && (l++ == 3)) {
+                  l = 0;
+                  *--s = stbsp__comma;
+                  --o;
+               } else {
+                  *--s = '0';
+               }
+         }
 
-        // get the length that we copied
-        l = (stbsp__uint32) ( (num+STBSP__NUMSZ) - s ); if ( l == 0 ) { *--s='0'; l = 1; }
-        cs = l + (3<<24);
-        if (pr<0) pr = 0;
+         tail[0] = 0;
+         stbsp__lead_sign(fl, lead);
 
-       scopy: 
-        // get fw=leading/trailing space, pr=leading zeros
-        if (pr<(stbsp__int32)l) pr = l;
-        n = pr + lead[0] + tail[0] + tz;
-        if (fw<(stbsp__int32)n) fw = n;
-        fw -= n;
-        pr -= l;
+         // get the length that we copied
+         l = (stbsp__uint32)((num + STBSP__NUMSZ) - s);
+         if (l == 0) {
+            *--s = '0';
+            l = 1;
+         }
+         cs = l + (3 << 24);
+         if (pr < 0)
+            pr = 0;
 
-        // handle right justify and leading zeros
-        if ( (fl&STBSP__LEFTJUST)==0 )
-        {
-          if (fl&STBSP__LEADINGZERO) // if leading zeros, everything is in pr
-          { 
-            pr = (fw>pr)?fw:pr;
-            fw = 0;
-          }
-          else
-          {
-            fl &= ~STBSP__TRIPLET_COMMA; // if no leading zeros, then no commas
-          }
-        }
+      scopy:
+         // get fw=leading/trailing space, pr=leading zeros
+         if (pr < (stbsp__int32)l)
+            pr = l;
+         n = pr + lead[0] + tail[0] + tz;
+         if (fw < (stbsp__int32)n)
+            fw = n;
+         fw -= n;
+         pr -= l;
 
-        // copy the spaces and/or zeros
-        if (fw+pr)
-        {
-          stbsp__int32 i; stbsp__uint32 c; 
+         // handle right justify and leading zeros
+         if ((fl & STBSP__LEFTJUST) == 0) {
+            if (fl & STBSP__LEADINGZERO) // if leading zeros, everything is in pr
+            {
+               pr = (fw > pr) ? fw : pr;
+               fw = 0;
+            } else {
+               fl &= ~STBSP__TRIPLET_COMMA; // if no leading zeros, then no commas
+            }
+         }
 
-          // copy leading spaces (or when doing %8.4d stuff)
-          if ( (fl&STBSP__LEFTJUST)==0 ) while(fw>0) { stbsp__cb_buf_clamp(i,fw); fw -= i; while(i) { if ((((stbsp__uintptr)bf)&3)==0) break; *bf++=' '; --i; } while(i>=4) { *(stbsp__uint32*)bf=0x20202020; bf+=4; i-=4; } while (i) {*bf++=' '; --i;} stbsp__chk_cb_buf(1); }
-        
-          // copy leader
-          sn=lead+1; while(lead[0]) { stbsp__cb_buf_clamp(i,lead[0]); lead[0] -= (char)i; while (i) {*bf++=*sn++; --i;} stbsp__chk_cb_buf(1); }
-          
-          // copy leading zeros
-          c = cs >> 24; cs &= 0xffffff;
-          cs = (fl&STBSP__TRIPLET_COMMA)?((stbsp__uint32)(c-((pr+cs)%(c+1)))):0;
-          while(pr>0) { stbsp__cb_buf_clamp(i,pr); pr -= i; if((fl&STBSP__TRIPLET_COMMA)==0) { while(i) { if ((((stbsp__uintptr)bf)&3)==0) break; *bf++='0'; --i; } while(i>=4) { *(stbsp__uint32*)bf=0x30303030; bf+=4; i-=4; } } while (i) { if((fl&STBSP__TRIPLET_COMMA) && (cs++==c)) { cs = 0; *bf++=stbsp__comma; } else *bf++='0'; --i; } stbsp__chk_cb_buf(1); }
-        }
+         // copy the spaces and/or zeros
+         if (fw + pr) {
+            stbsp__int32 i;
+            stbsp__uint32 c;
 
-        // copy leader if there is still one
-        sn=lead+1; while(lead[0]) { stbsp__int32 i; stbsp__cb_buf_clamp(i,lead[0]); lead[0] -= (char)i; while (i) {*bf++=*sn++; --i;} stbsp__chk_cb_buf(1); }
+            // copy leading spaces (or when doing %8.4d stuff)
+            if ((fl & STBSP__LEFTJUST) == 0)
+               while (fw > 0) {
+                  stbsp__cb_buf_clamp(i, fw);
+                  fw -= i;
+                  while (i) {
+                     if ((((stbsp__uintptr)bf) & 3) == 0)
+                        break;
+                     *bf++ = ' ';
+                     --i;
+                  }
+                  while (i >= 4) {
+                     *(stbsp__uint32 *)bf = 0x20202020;
+                     bf += 4;
+                     i -= 4;
+                  }
+                  while (i) {
+                     *bf++ = ' ';
+                     --i;
+                  }
+                  stbsp__chk_cb_buf(1);
+               }
 
-        // copy the string
-        n = l; while (n) { stbsp__int32 i; stbsp__cb_buf_clamp(i,n); n-=i; STBSP__UNALIGNED( while(i>=4) { *(stbsp__uint32*)bf=*(stbsp__uint32*)s; bf+=4; s+=4; i-=4; } ) while (i) {*bf++=*s++; --i;} stbsp__chk_cb_buf(1); }
+            // copy leader
+            sn = lead + 1;
+            while (lead[0]) {
+               stbsp__cb_buf_clamp(i, lead[0]);
+               lead[0] -= (char)i;
+               while (i) {
+                  *bf++ = *sn++;
+                  --i;
+               }
+               stbsp__chk_cb_buf(1);
+            }
 
-        // copy trailing zeros
-        while(tz) { stbsp__int32 i; stbsp__cb_buf_clamp(i,tz); tz -= i; while(i) { if ((((stbsp__uintptr)bf)&3)==0) break; *bf++='0'; --i; } while(i>=4) { *(stbsp__uint32*)bf=0x30303030; bf+=4; i-=4; } while (i) {*bf++='0'; --i;} stbsp__chk_cb_buf(1); }
+            // copy leading zeros
+            c = cs >> 24;
+            cs &= 0xffffff;
+            cs = (fl & STBSP__TRIPLET_COMMA) ? ((stbsp__uint32)(c - ((pr + cs) % (c + 1)))) : 0;
+            while (pr > 0) {
+               stbsp__cb_buf_clamp(i, pr);
+               pr -= i;
+               if ((fl & STBSP__TRIPLET_COMMA) == 0) {
+                  while (i) {
+                     if ((((stbsp__uintptr)bf) & 3) == 0)
+                        break;
+                     *bf++ = '0';
+                     --i;
+                  }
+                  while (i >= 4) {
+                     *(stbsp__uint32 *)bf = 0x30303030;
+                     bf += 4;
+                     i -= 4;
+                  }
+               }
+               while (i) {
+                  if ((fl & STBSP__TRIPLET_COMMA) && (cs++ == c)) {
+                     cs = 0;
+                     *bf++ = stbsp__comma;
+                  } else
+                     *bf++ = '0';
+                  --i;
+               }
+               stbsp__chk_cb_buf(1);
+            }
+         }
 
-        // copy tail if there is one
-        sn=tail+1; while(tail[0]) { stbsp__int32 i; stbsp__cb_buf_clamp(i,tail[0]); tail[0] -= (char)i; while (i) {*bf++=*sn++; --i;} stbsp__chk_cb_buf(1); }
+         // copy leader if there is still one
+         sn = lead + 1;
+         while (lead[0]) {
+            stbsp__int32 i;
+            stbsp__cb_buf_clamp(i, lead[0]);
+            lead[0] -= (char)i;
+            while (i) {
+               *bf++ = *sn++;
+               --i;
+            }
+            stbsp__chk_cb_buf(1);
+         }
 
-        // handle the left justify
-        if (fl&STBSP__LEFTJUST) if (fw>0) { while (fw) { stbsp__int32 i; stbsp__cb_buf_clamp(i,fw); fw-=i; while(i) { if ((((stbsp__uintptr)bf)&3)==0) break; *bf++=' '; --i; } while(i>=4) { *(stbsp__uint32*)bf=0x20202020; bf+=4; i-=4; } while (i--) *bf++=' '; stbsp__chk_cb_buf(1); } }
-        break;
+         // copy the string
+         n = l;
+         while (n) {
+            stbsp__int32 i;
+            stbsp__cb_buf_clamp(i, n);
+            n -= i;
+            STBSP__UNALIGNED(while (i >= 4) {
+               *(stbsp__uint32 *)bf = *(stbsp__uint32 *)s;
+               bf += 4;
+               s += 4;
+               i -= 4;
+            })
+            while (i) {
+               *bf++ = *s++;
+               --i;
+            }
+            stbsp__chk_cb_buf(1);
+         }
+
+         // copy trailing zeros
+         while (tz) {
+            stbsp__int32 i;
+            stbsp__cb_buf_clamp(i, tz);
+            tz -= i;
+            while (i) {
+               if ((((stbsp__uintptr)bf) & 3) == 0)
+                  break;
+               *bf++ = '0';
+               --i;
+            }
+            while (i >= 4) {
+               *(stbsp__uint32 *)bf = 0x30303030;
+               bf += 4;
+               i -= 4;
+            }
+            while (i) {
+               *bf++ = '0';
+               --i;
+            }
+            stbsp__chk_cb_buf(1);
+         }
+
+         // copy tail if there is one
+         sn = tail + 1;
+         while (tail[0]) {
+            stbsp__int32 i;
+            stbsp__cb_buf_clamp(i, tail[0]);
+            tail[0] -= (char)i;
+            while (i) {
+               *bf++ = *sn++;
+               --i;
+            }
+            stbsp__chk_cb_buf(1);
+         }
+
+         // handle the left justify
+         if (fl & STBSP__LEFTJUST)
+            if (fw > 0) {
+               while (fw) {
+                  stbsp__int32 i;
+                  stbsp__cb_buf_clamp(i, fw);
+                  fw -= i;
+                  while (i) {
+                     if ((((stbsp__uintptr)bf) & 3) == 0)
+                        break;
+                     *bf++ = ' ';
+                     --i;
+                  }
+                  while (i >= 4) {
+                     *(stbsp__uint32 *)bf = 0x20202020;
+                     bf += 4;
+                     i -= 4;
+                  }
+                  while (i--)
+                     *bf++ = ' ';
+                  stbsp__chk_cb_buf(1);
+               }
+            }
+         break;
 
       default: // unknown, just copy code
-        s = num + STBSP__NUMSZ -1; *s = f[0];
-        l = 1;
-        fw=pr=fl=0;
-        lead[0]=0; tail[0]=0; pr = 0; dp = 0; cs = 0;
-        goto scopy;
-    }
-    ++f;
-  }
- endfmt:
+         s = num + STBSP__NUMSZ - 1;
+         *s = f[0];
+         l = 1;
+         fw = pr = fl = 0;
+         lead[0] = 0;
+         tail[0] = 0;
+         pr = 0;
+         dp = 0;
+         cs = 0;
+         goto scopy;
+      }
+      ++f;
+   }
+endfmt:
 
-  if (!callback) 
-    *bf = 0;
-  else
-    stbsp__flush_cb();
- 
- done:
-  return tlen + (int)(bf-buf);
+   if (!callback)
+      *bf = 0;
+   else
+      stbsp__flush_cb();
+
+done:
+   return tlen + (int)(bf - buf);
 }
 
 // cleanup
@@ -839,82 +1316,85 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE( vsprintfcb )( STBSP_SPRINTFCB * callb
 // ============================================================================
 //   wrapper functions
 
-STBSP__PUBLICDEF int STB_SPRINTF_DECORATE( sprintf )( char * buf, char const * fmt, ... )
+STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(sprintf)(char *buf, char const *fmt, ...)
 {
-  int result;
-  va_list va;
-  va_start( va, fmt );
-  result = STB_SPRINTF_DECORATE( vsprintfcb )( 0, 0, buf, fmt, va );
-  va_end(va);
-  return result;
+   int result;
+   va_list va;
+   va_start(va, fmt);
+   result = STB_SPRINTF_DECORATE(vsprintfcb)(0, 0, buf, fmt, va);
+   va_end(va);
+   return result;
 }
 
-typedef struct stbsp__context
-{
-  char * buf;
-  int count;
-  char tmp[ STB_SPRINTF_MIN ];
+typedef struct stbsp__context {
+   char *buf;
+   int count;
+   char tmp[STB_SPRINTF_MIN];
 } stbsp__context;
 
-static char * stbsp__clamp_callback( char * buf, void * user, int len )
+static char *stbsp__clamp_callback(char *buf, void *user, int len)
 {
-  stbsp__context * c = (stbsp__context*)user;
+   stbsp__context *c = (stbsp__context *)user;
 
-  if ( len > c->count ) len = c->count;
+   if (len > c->count)
+      len = c->count;
 
-  if (len)
-  {
-    if ( buf != c->buf )
-    {
-      char * s, * d, * se;
-      d = c->buf; s = buf; se = buf+len;
-      do{ *d++ = *s++; } while (s<se);
-    }
-    c->buf += len;
-    c->count -= len;
-  }
-  
-  if ( c->count <= 0 ) return 0;
-  return ( c->count >= STB_SPRINTF_MIN ) ? c->buf : c->tmp; // go direct into buffer if you can
+   if (len) {
+      if (buf != c->buf) {
+         char *s, *d, *se;
+         d = c->buf;
+         s = buf;
+         se = buf + len;
+         do {
+            *d++ = *s++;
+         } while (s < se);
+      }
+      c->buf += len;
+      c->count -= len;
+   }
+
+   if (c->count <= 0)
+      return 0;
+   return (c->count >= STB_SPRINTF_MIN) ? c->buf : c->tmp; // go direct into buffer if you can
 }
 
-STBSP__PUBLICDEF int STB_SPRINTF_DECORATE( vsnprintf )( char * buf, int count, char const * fmt, va_list va )
+STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsnprintf)(char *buf, int count, char const *fmt, va_list va)
 {
-  stbsp__context c;
-  int l;
+   stbsp__context c;
+   int l;
 
-  if ( count == 0 )
-    return 0;
+   if (count == 0)
+      return 0;
 
-  c.buf = buf;
-  c.count = count;
+   c.buf = buf;
+   c.count = count;
 
-  STB_SPRINTF_DECORATE( vsprintfcb )( stbsp__clamp_callback, &c, stbsp__clamp_callback(0,&c,0), fmt, va );
-  
-  // zero-terminate
-  l = (int)( c.buf - buf );
-  if ( l >= count ) // should never be greater, only equal (or less) than count
-    l = count - 1;
-  buf[l] = 0;
+   STB_SPRINTF_DECORATE(vsprintfcb)(stbsp__clamp_callback, &c, stbsp__clamp_callback(0, &c, 0), fmt, va);
 
-  return l;
+   // zero-terminate
+   l = (int)(c.buf - buf);
+   if (l >= count) // should never be greater, only equal (or less) than count
+      l = count - 1;
+   buf[l] = 0;
+
+   return l;
 }
 
-STBSP__PUBLICDEF int STB_SPRINTF_DECORATE( snprintf )( char * buf, int count, char const * fmt, ... )
+STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(snprintf)(char *buf, int count, char const *fmt, ...)
 {
-  int result;
-  va_list va;
-  va_start( va, fmt );
+   int result;
+   va_list va;
+   va_start(va, fmt);
 
-  result = STB_SPRINTF_DECORATE( vsnprintf )( buf, count, fmt, va );
-  va_end(va);
+   result = STB_SPRINTF_DECORATE(vsnprintf)(buf, count, fmt, va);
+   va_end(va);
 
-  return result;
+   return result;
 }
 
-STBSP__PUBLICDEF int STB_SPRINTF_DECORATE( vsprintf )( char * buf, char const * fmt, va_list va )
+STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintf)(char *buf, char const *fmt, va_list va)
 {
-  return STB_SPRINTF_DECORATE( vsprintfcb )( 0, 0, buf, fmt, va );
+   return STB_SPRINTF_DECORATE(vsprintfcb)(0, 0, buf, fmt, va);
 }
 
 // =======================================================================
@@ -923,241 +1403,375 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE( vsprintf )( char * buf, char const * 
 #ifndef STB_SPRINTF_NOFLOAT
 
 // copies d to bits w/ strict aliasing (this compiles to nothing on /Ox)
-#define STBSP__COPYFP(dest,src) { int cn; for(cn=0;cn<8;cn++) ((char*)&dest)[cn]=((char*)&src)[cn]; }
- 
+#define STBSP__COPYFP(dest, src)                   \
+   {                                               \
+      int cn;                                      \
+      for (cn = 0; cn < 8; cn++)                   \
+         ((char *)&dest)[cn] = ((char *)&src)[cn]; \
+   }
+
 // get float info
-static stbsp__int32 stbsp__real_to_parts( stbsp__int64 * bits, stbsp__int32 * expo, double value )
+static stbsp__int32 stbsp__real_to_parts(stbsp__int64 *bits, stbsp__int32 *expo, double value)
 {
-  double d;
-  stbsp__int64 b = 0;
+   double d;
+   stbsp__int64 b = 0;
 
-  // load value and round at the frac_digits
-  d = value;
+   // load value and round at the frac_digits
+   d = value;
 
-  STBSP__COPYFP( b, d );
+   STBSP__COPYFP(b, d);
 
-  *bits = b & ((((stbsp__uint64)1)<<52)-1);
-  *expo = (stbsp__int32) (((b >> 52) & 2047)-1023);
-    
-  return (stbsp__int32)(b >> 63);
+   *bits = b & ((((stbsp__uint64)1) << 52) - 1);
+   *expo = (stbsp__int32)(((b >> 52) & 2047) - 1023);
+
+   return (stbsp__int32)(b >> 63);
 }
 
-static double const stbsp__bot[23]={1e+000,1e+001,1e+002,1e+003,1e+004,1e+005,1e+006,1e+007,1e+008,1e+009,1e+010,1e+011,1e+012,1e+013,1e+014,1e+015,1e+016,1e+017,1e+018,1e+019,1e+020,1e+021,1e+022};
-static double const stbsp__negbot[22]={1e-001,1e-002,1e-003,1e-004,1e-005,1e-006,1e-007,1e-008,1e-009,1e-010,1e-011,1e-012,1e-013,1e-014,1e-015,1e-016,1e-017,1e-018,1e-019,1e-020,1e-021,1e-022};
-static double const stbsp__negboterr[22]={-5.551115123125783e-018,-2.0816681711721684e-019,-2.0816681711721686e-020,-4.7921736023859299e-021,-8.1803053914031305e-022,4.5251888174113741e-023,4.5251888174113739e-024,-2.0922560830128471e-025,-6.2281591457779853e-026,-3.6432197315497743e-027,6.0503030718060191e-028,2.0113352370744385e-029,-3.0373745563400371e-030,1.1806906454401013e-032,-7.7705399876661076e-032,2.0902213275965398e-033,-7.1542424054621921e-034,-7.1542424054621926e-035,2.4754073164739869e-036,5.4846728545790429e-037,9.2462547772103625e-038,-4.8596774326570872e-039};
-static double const stbsp__top[13]={1e+023,1e+046,1e+069,1e+092,1e+115,1e+138,1e+161,1e+184,1e+207,1e+230,1e+253,1e+276,1e+299};
-static double const stbsp__negtop[13]={1e-023,1e-046,1e-069,1e-092,1e-115,1e-138,1e-161,1e-184,1e-207,1e-230,1e-253,1e-276,1e-299};
-static double const stbsp__toperr[13]={8388608,6.8601809640529717e+028,-7.253143638152921e+052,-4.3377296974619174e+075,-1.5559416129466825e+098,-3.2841562489204913e+121,-3.7745893248228135e+144,-1.7356668416969134e+167,-3.8893577551088374e+190,-9.9566444326005119e+213,6.3641293062232429e+236,-5.2069140800249813e+259,-5.2504760255204387e+282};
-static double const stbsp__negtoperr[13]={3.9565301985100693e-040,-2.299904345391321e-063,3.6506201437945798e-086,1.1875228833981544e-109,-5.0644902316928607e-132,-6.7156837247865426e-155,-2.812077463003139e-178,-5.7778912386589953e-201,7.4997100559334532e-224,-4.6439668915134491e-247,-6.3691100762962136e-270,-9.436808465446358e-293,8.0970921678014997e-317};
+static double const stbsp__bot[23] = {1e+000, 1e+001, 1e+002, 1e+003, 1e+004, 1e+005, 1e+006, 1e+007, 1e+008, 1e+009, 1e+010, 1e+011,
+                                      1e+012, 1e+013, 1e+014, 1e+015, 1e+016, 1e+017, 1e+018, 1e+019, 1e+020, 1e+021, 1e+022};
+static double const stbsp__negbot[22] = {1e-001, 1e-002, 1e-003, 1e-004, 1e-005, 1e-006, 1e-007, 1e-008, 1e-009, 1e-010, 1e-011,
+                                         1e-012, 1e-013, 1e-014, 1e-015, 1e-016, 1e-017, 1e-018, 1e-019, 1e-020, 1e-021, 1e-022};
+static double const stbsp__negboterr[22] = {
+   -5.551115123125783e-018,  -2.0816681711721684e-019, -2.0816681711721686e-020, -4.7921736023859299e-021, -8.1803053914031305e-022, 4.5251888174113741e-023,
+   4.5251888174113739e-024,  -2.0922560830128471e-025, -6.2281591457779853e-026, -3.6432197315497743e-027, 6.0503030718060191e-028,  2.0113352370744385e-029,
+   -3.0373745563400371e-030, 1.1806906454401013e-032,  -7.7705399876661076e-032, 2.0902213275965398e-033,  -7.1542424054621921e-034, -7.1542424054621926e-035,
+   2.4754073164739869e-036,  5.4846728545790429e-037,  9.2462547772103625e-038,  -4.8596774326570872e-039};
+static double const stbsp__top[13] = {1e+023, 1e+046, 1e+069, 1e+092, 1e+115, 1e+138, 1e+161, 1e+184, 1e+207, 1e+230, 1e+253, 1e+276, 1e+299};
+static double const stbsp__negtop[13] = {1e-023, 1e-046, 1e-069, 1e-092, 1e-115, 1e-138, 1e-161, 1e-184, 1e-207, 1e-230, 1e-253, 1e-276, 1e-299};
+static double const stbsp__toperr[13] = {8388608,
+                                         6.8601809640529717e+028,
+                                         -7.253143638152921e+052,
+                                         -4.3377296974619174e+075,
+                                         -1.5559416129466825e+098,
+                                         -3.2841562489204913e+121,
+                                         -3.7745893248228135e+144,
+                                         -1.7356668416969134e+167,
+                                         -3.8893577551088374e+190,
+                                         -9.9566444326005119e+213,
+                                         6.3641293062232429e+236,
+                                         -5.2069140800249813e+259,
+                                         -5.2504760255204387e+282};
+static double const stbsp__negtoperr[13] = {3.9565301985100693e-040,  -2.299904345391321e-063,  3.6506201437945798e-086,  1.1875228833981544e-109,
+                                            -5.0644902316928607e-132, -6.7156837247865426e-155, -2.812077463003139e-178,  -5.7778912386589953e-201,
+                                            7.4997100559334532e-224,  -4.6439668915134491e-247, -6.3691100762962136e-270, -9.436808465446358e-293,
+                                            8.0970921678014997e-317};
 
-#if defined(_MSC_VER) && (_MSC_VER<=1200)                                                                                                                                                                                       
-static stbsp__uint64 const stbsp__powten[20]={1,10,100,1000, 10000,100000,1000000,10000000, 100000000,1000000000,10000000000,100000000000,  1000000000000,10000000000000,100000000000000,1000000000000000,  10000000000000000,100000000000000000,1000000000000000000,10000000000000000000U };
+#if defined(_MSC_VER) && (_MSC_VER <= 1200)
+static stbsp__uint64 const stbsp__powten[20] = {1,
+                                                10,
+                                                100,
+                                                1000,
+                                                10000,
+                                                100000,
+                                                1000000,
+                                                10000000,
+                                                100000000,
+                                                1000000000,
+                                                10000000000,
+                                                100000000000,
+                                                1000000000000,
+                                                10000000000000,
+                                                100000000000000,
+                                                1000000000000000,
+                                                10000000000000000,
+                                                100000000000000000,
+                                                1000000000000000000,
+                                                10000000000000000000U};
 #define stbsp__tento19th ((stbsp__uint64)1000000000000000000)
 #else
-static stbsp__uint64 const stbsp__powten[20]={1,10,100,1000, 10000,100000,1000000,10000000, 100000000,1000000000,10000000000ULL,100000000000ULL,  1000000000000ULL,10000000000000ULL,100000000000000ULL,1000000000000000ULL,  10000000000000000ULL,100000000000000000ULL,1000000000000000000ULL,10000000000000000000ULL };
+static stbsp__uint64 const stbsp__powten[20] = {1,
+                                                10,
+                                                100,
+                                                1000,
+                                                10000,
+                                                100000,
+                                                1000000,
+                                                10000000,
+                                                100000000,
+                                                1000000000,
+                                                10000000000ULL,
+                                                100000000000ULL,
+                                                1000000000000ULL,
+                                                10000000000000ULL,
+                                                100000000000000ULL,
+                                                1000000000000000ULL,
+                                                10000000000000000ULL,
+                                                100000000000000000ULL,
+                                                1000000000000000000ULL,
+                                                10000000000000000000ULL};
 #define stbsp__tento19th (1000000000000000000ULL)
 #endif
 
-#define stbsp__ddmulthi(oh,ol,xh,yh) \
-{ \
-  double ahi=0,alo,bhi=0,blo; \
-  stbsp__int64 bt; \
-  oh = xh * yh; \
-  STBSP__COPYFP(bt,xh); bt&=((~(stbsp__uint64)0)<<27); STBSP__COPYFP(ahi,bt); alo = xh-ahi; \
-  STBSP__COPYFP(bt,yh); bt&=((~(stbsp__uint64)0)<<27); STBSP__COPYFP(bhi,bt); blo = yh-bhi; \
-  ol = ((ahi*bhi-oh)+ahi*blo+alo*bhi)+alo*blo; \
+#define stbsp__ddmulthi(oh, ol, xh, yh)                            \
+   \
+{                                                            \
+      double ahi = 0, alo, bhi = 0, blo;                           \
+      stbsp__int64 bt;                                             \
+      oh = xh * yh;                                                \
+      STBSP__COPYFP(bt, xh);                                       \
+      bt &= ((~(stbsp__uint64)0) << 27);                           \
+      STBSP__COPYFP(ahi, bt);                                      \
+      alo = xh - ahi;                                              \
+      STBSP__COPYFP(bt, yh);                                       \
+      bt &= ((~(stbsp__uint64)0) << 27);                           \
+      STBSP__COPYFP(bhi, bt);                                      \
+      blo = yh - bhi;                                              \
+      ol = ((ahi * bhi - oh) + ahi * blo + alo * bhi) + alo * blo; \
+   \
 }
 
-#define stbsp__ddtoS64(ob,xh,xl) \
-{ \
-  double ahi=0,alo,vh,t;\
-  ob = (stbsp__int64)ph;\
-  vh=(double)ob;\
-  ahi = ( xh - vh );\
-  t = ( ahi - xh );\
-  alo = (xh-(ahi-t))-(vh+t);\
-  ob += (stbsp__int64)(ahi+alo+xl);\
+#define stbsp__ddtoS64(ob, xh, xl)          \
+   \
+{                                     \
+      double ahi = 0, alo, vh, t;           \
+      ob = (stbsp__int64)ph;                \
+      vh = (double)ob;                      \
+      ahi = (xh - vh);                      \
+      t = (ahi - xh);                       \
+      alo = (xh - (ahi - t)) - (vh + t);    \
+      ob += (stbsp__int64)(ahi + alo + xl); \
+   \
 }
 
+#define stbsp__ddrenorm(oh, ol) \
+   {                            \
+      double s;                 \
+      s = oh + ol;              \
+      ol = ol - (s - oh);       \
+      oh = s;                   \
+   }
 
-#define stbsp__ddrenorm(oh,ol) { double s; s=oh+ol; ol=ol-(s-oh); oh=s; }
+#define stbsp__ddmultlo(oh, ol, xh, xl, yh, yl) ol = ol + (xh * yl + xl * yh);
 
-#define stbsp__ddmultlo(oh,ol,xh,xl,yh,yl) \
-  ol = ol + ( xh*yl + xl*yh ); \
+#define stbsp__ddmultlos(oh, ol, xh, yl) ol = ol + (xh * yl);
 
-#define stbsp__ddmultlos(oh,ol,xh,yl) \
-  ol = ol + ( xh*yl ); \
-
-static void stbsp__raise_to_power10( double *ohi, double *olo, double d, stbsp__int32 power )  // power can be -323 to +350
+static void stbsp__raise_to_power10(double *ohi, double *olo, double d, stbsp__int32 power) // power can be -323 to +350
 {
-  double ph, pl;
-  if ((power>=0) && (power<=22))
-  {
-    stbsp__ddmulthi(ph,pl,d,stbsp__bot[power]);
-  }
-  else
-  {
-    stbsp__int32 e,et,eb;
-    double p2h,p2l;
+   double ph, pl;
+   if ((power >= 0) && (power <= 22)) {
+      stbsp__ddmulthi(ph, pl, d, stbsp__bot[power]);
+   } else {
+      stbsp__int32 e, et, eb;
+      double p2h, p2l;
 
-    e=power; if (power<0) e=-e; 
-    et = (e*0x2c9)>>14;/* %23 */ if (et>13) et=13; eb = e-(et*23);
+      e = power;
+      if (power < 0)
+         e = -e;
+      et = (e * 0x2c9) >> 14; /* %23 */
+      if (et > 13)
+         et = 13;
+      eb = e - (et * 23);
 
-    ph = d; pl = 0.0;
-    if (power<0)
-    {
-      if (eb) { --eb; stbsp__ddmulthi(ph,pl,d,stbsp__negbot[eb]); stbsp__ddmultlos(ph,pl,d,stbsp__negboterr[eb]); }
-      if (et)
-      { 
-        stbsp__ddrenorm(ph,pl);
-        --et; stbsp__ddmulthi(p2h,p2l,ph,stbsp__negtop[et]); stbsp__ddmultlo(p2h,p2l,ph,pl,stbsp__negtop[et],stbsp__negtoperr[et]); ph=p2h;pl=p2l;
+      ph = d;
+      pl = 0.0;
+      if (power < 0) {
+         if (eb) {
+            --eb;
+            stbsp__ddmulthi(ph, pl, d, stbsp__negbot[eb]);
+            stbsp__ddmultlos(ph, pl, d, stbsp__negboterr[eb]);
+         }
+         if (et) {
+            stbsp__ddrenorm(ph, pl);
+            --et;
+            stbsp__ddmulthi(p2h, p2l, ph, stbsp__negtop[et]);
+            stbsp__ddmultlo(p2h, p2l, ph, pl, stbsp__negtop[et], stbsp__negtoperr[et]);
+            ph = p2h;
+            pl = p2l;
+         }
+      } else {
+         if (eb) {
+            e = eb;
+            if (eb > 22)
+               eb = 22;
+            e -= eb;
+            stbsp__ddmulthi(ph, pl, d, stbsp__bot[eb]);
+            if (e) {
+               stbsp__ddrenorm(ph, pl);
+               stbsp__ddmulthi(p2h, p2l, ph, stbsp__bot[e]);
+               stbsp__ddmultlos(p2h, p2l, stbsp__bot[e], pl);
+               ph = p2h;
+               pl = p2l;
+            }
+         }
+         if (et) {
+            stbsp__ddrenorm(ph, pl);
+            --et;
+            stbsp__ddmulthi(p2h, p2l, ph, stbsp__top[et]);
+            stbsp__ddmultlo(p2h, p2l, ph, pl, stbsp__top[et], stbsp__toperr[et]);
+            ph = p2h;
+            pl = p2l;
+         }
       }
-    }
-    else
-    {
-      if (eb) 
-      { 
-        e = eb; if (eb>22) eb=22; e -= eb;
-        stbsp__ddmulthi(ph,pl,d,stbsp__bot[eb]); 
-        if ( e ) { stbsp__ddrenorm(ph,pl); stbsp__ddmulthi(p2h,p2l,ph,stbsp__bot[e]); stbsp__ddmultlos(p2h,p2l,stbsp__bot[e],pl); ph=p2h;pl=p2l; }
-      }
-      if (et)
-      {
-        stbsp__ddrenorm(ph,pl);
-        --et; stbsp__ddmulthi(p2h,p2l,ph,stbsp__top[et]); stbsp__ddmultlo(p2h,p2l,ph,pl,stbsp__top[et],stbsp__toperr[et]); ph=p2h;pl=p2l;
-      }
-    }
-  }
-  stbsp__ddrenorm(ph,pl);
-  *ohi = ph; *olo = pl;
+   }
+   stbsp__ddrenorm(ph, pl);
+   *ohi = ph;
+   *olo = pl;
 }
 
 // given a float value, returns the significant bits in bits, and the position of the
 //   decimal point in decimal_pos.  +/-INF and NAN are specified by special values
 //   returned in the decimal_pos parameter.
 // frac_digits is absolute normally, but if you want from first significant digits (got %g and %e), or in 0x80000000
-static stbsp__int32 stbsp__real_to_str( char const * * start, stbsp__uint32 * len, char *out, stbsp__int32 * decimal_pos, double value, stbsp__uint32 frac_digits )
+static stbsp__int32 stbsp__real_to_str(char const **start, stbsp__uint32 *len, char *out, stbsp__int32 *decimal_pos, double value, stbsp__uint32 frac_digits)
 {
-  double d;
-  stbsp__int64 bits = 0;
-  stbsp__int32 expo, e, ng, tens;
+   double d;
+   stbsp__int64 bits = 0;
+   stbsp__int32 expo, e, ng, tens;
 
-  d = value;
-  STBSP__COPYFP(bits,d);
-  expo = (stbsp__int32) ((bits >> 52) & 2047);
-  ng = (stbsp__int32)(bits >> 63);
-  if (ng) d=-d;
+   d = value;
+   STBSP__COPYFP(bits, d);
+   expo = (stbsp__int32)((bits >> 52) & 2047);
+   ng = (stbsp__int32)(bits >> 63);
+   if (ng)
+      d = -d;
 
-  if ( expo == 2047 ) // is nan or inf?
-  {
-    *start = (bits&((((stbsp__uint64)1)<<52)-1)) ? "NaN" : "Inf";
-    *decimal_pos =  STBSP__SPECIAL;
-    *len = 3;
-    return ng;
-  } 
-
-  if ( expo == 0 ) // is zero or denormal
-  {
-    if ((bits<<1)==0) // do zero
-    {
-      *decimal_pos = 1; 
-      *start = out;
-      out[0] = '0'; *len = 1;
+   if (expo == 2047) // is nan or inf?
+   {
+      *start = (bits & ((((stbsp__uint64)1) << 52) - 1)) ? "NaN" : "Inf";
+      *decimal_pos = STBSP__SPECIAL;
+      *len = 3;
       return ng;
-    }
-    // find the right expo for denormals
-    {
-      stbsp__int64 v = ((stbsp__uint64)1)<<51;
-      while ((bits&v)==0) { --expo; v >>= 1; }
-    }
-  }
+   }
 
-  // find the decimal exponent as well as the decimal bits of the value
-  {
-    double ph,pl;
+   if (expo == 0) // is zero or denormal
+   {
+      if ((bits << 1) == 0) // do zero
+      {
+         *decimal_pos = 1;
+         *start = out;
+         out[0] = '0';
+         *len = 1;
+         return ng;
+      }
+      // find the right expo for denormals
+      {
+         stbsp__int64 v = ((stbsp__uint64)1) << 51;
+         while ((bits & v) == 0) {
+            --expo;
+            v >>= 1;
+         }
+      }
+   }
 
-    // log10 estimate - very specifically tweaked to hit or undershoot by no more than 1 of log10 of all expos 1..2046
-    tens=expo-1023; tens = (tens<0)?((tens*617)/2048):(((tens*1233)/4096)+1);
+   // find the decimal exponent as well as the decimal bits of the value
+   {
+      double ph, pl;
 
-    // move the significant bits into position and stick them into an int 
-    stbsp__raise_to_power10( &ph, &pl, d, 18-tens );
+      // log10 estimate - very specifically tweaked to hit or undershoot by no more than 1 of log10 of all expos 1..2046
+      tens = expo - 1023;
+      tens = (tens < 0) ? ((tens * 617) / 2048) : (((tens * 1233) / 4096) + 1);
 
-    // get full as much precision from double-double as possible
-    stbsp__ddtoS64( bits, ph,pl );
+      // move the significant bits into position and stick them into an int
+      stbsp__raise_to_power10(&ph, &pl, d, 18 - tens);
 
-    // check if we undershot
-    if ( ((stbsp__uint64)bits) >= stbsp__tento19th ) ++tens; 
-  }
+      // get full as much precision from double-double as possible
+      stbsp__ddtoS64(bits, ph, pl);
 
-  // now do the rounding in integer land
-  frac_digits = ( frac_digits & 0x80000000 ) ? ( (frac_digits&0x7ffffff) + 1 ) : ( tens + frac_digits );
-  if ( ( frac_digits < 24 ) )
-  {
-    stbsp__uint32 dg = 1; if ((stbsp__uint64)bits >= stbsp__powten[9] ) dg=10; while( (stbsp__uint64)bits >= stbsp__powten[dg] ) { ++dg; if (dg==20) goto noround; }
-    if ( frac_digits < dg )
-    {
-      stbsp__uint64 r;
-      // add 0.5 at the right position and round
-      e = dg - frac_digits;
-      if ( (stbsp__uint32)e >= 24 ) goto noround;
-      r = stbsp__powten[e];
-      bits = bits + (r/2);
-      if ( (stbsp__uint64)bits >= stbsp__powten[dg] ) ++tens;
-      bits /= r;
-    } 
-    noround:;
-  }
+      // check if we undershot
+      if (((stbsp__uint64)bits) >= stbsp__tento19th)
+         ++tens;
+   }
 
-  // kill long trailing runs of zeros
-  if ( bits )
-  {
-    stbsp__uint32 n;
-    for(;;) { if ( bits<=0xffffffff ) break; if (bits%1000) goto donez; bits/=1000; }
-    n = (stbsp__uint32)bits;
-    while ((n%1000)==0) n/=1000;
-    bits=n;
-    donez:;
-  }
+   // now do the rounding in integer land
+   frac_digits = (frac_digits & 0x80000000) ? ((frac_digits & 0x7ffffff) + 1) : (tens + frac_digits);
+   if ((frac_digits < 24)) {
+      stbsp__uint32 dg = 1;
+      if ((stbsp__uint64)bits >= stbsp__powten[9])
+         dg = 10;
+      while ((stbsp__uint64)bits >= stbsp__powten[dg]) {
+         ++dg;
+         if (dg == 20)
+            goto noround;
+      }
+      if (frac_digits < dg) {
+         stbsp__uint64 r;
+         // add 0.5 at the right position and round
+         e = dg - frac_digits;
+         if ((stbsp__uint32)e >= 24)
+            goto noround;
+         r = stbsp__powten[e];
+         bits = bits + (r / 2);
+         if ((stbsp__uint64)bits >= stbsp__powten[dg])
+            ++tens;
+         bits /= r;
+      }
+   noround:;
+   }
 
-  // convert to string
-  out += 64;
-  e = 0; 
-  for(;;)
-  {
-    stbsp__uint32 n;
-    char * o = out-8;
-    // do the conversion in chunks of U32s (avoid most 64-bit divides, worth it, constant denomiators be damned)
-    if (bits>=100000000) { n = (stbsp__uint32)( bits % 100000000);  bits /= 100000000; } else {n = (stbsp__uint32)bits; bits = 0; }
-    while(n) { out-=2; *(stbsp__uint16*)out=*(stbsp__uint16*)&stbsp__digitpair[(n%100)*2]; n/=100; e+=2; }
-    if (bits==0) { if ((e) && (out[0]=='0')) { ++out; --e; } break; }
-    while( out!=o ) { *--out ='0'; ++e; }
-  }
-  
-  *decimal_pos = tens;
-  *start = out;
-  *len = e;
-  return ng;
+   // kill long trailing runs of zeros
+   if (bits) {
+      stbsp__uint32 n;
+      for (;;) {
+         if (bits <= 0xffffffff)
+            break;
+         if (bits % 1000)
+            goto donez;
+         bits /= 1000;
+      }
+      n = (stbsp__uint32)bits;
+      while ((n % 1000) == 0)
+         n /= 1000;
+      bits = n;
+   donez:;
+   }
+
+   // convert to string
+   out += 64;
+   e = 0;
+   for (;;) {
+      stbsp__uint32 n;
+      char *o = out - 8;
+      // do the conversion in chunks of U32s (avoid most 64-bit divides, worth it, constant denomiators be damned)
+      if (bits >= 100000000) {
+         n = (stbsp__uint32)(bits % 100000000);
+         bits /= 100000000;
+      } else {
+         n = (stbsp__uint32)bits;
+         bits = 0;
+      }
+      while (n) {
+         out -= 2;
+         *(stbsp__uint16 *)out = *(stbsp__uint16 *)&stbsp__digitpair[(n % 100) * 2];
+         n /= 100;
+         e += 2;
+      }
+      if (bits == 0) {
+         if ((e) && (out[0] == '0')) {
+            ++out;
+            --e;
+         }
+         break;
+      }
+      while (out != o) {
+         *--out = '0';
+         ++e;
+      }
+   }
+
+   *decimal_pos = tens;
+   *start = out;
+   *len = e;
+   return ng;
 }
 
 #undef stbsp__ddmulthi
 #undef stbsp__ddrenorm
 #undef stbsp__ddmultlo
 #undef stbsp__ddmultlos
-#undef STBSP__SPECIAL 
+#undef STBSP__SPECIAL
 #undef STBSP__COPYFP
- 
+
 #endif // STB_SPRINTF_NOFLOAT
 
 // clean up
 #undef stbsp__uint16
-#undef stbsp__uint32 
-#undef stbsp__int32 
+#undef stbsp__uint32
+#undef stbsp__int32
 #undef stbsp__uint64
 #undef stbsp__int64
 #undef STBSP__UNALIGNED
 
 #endif // STB_SPRINTF_IMPLEMENTATION
-
 
 /*
 ------------------------------------------------------------------------------
@@ -1165,38 +1779,38 @@ This software is available under 2 licenses -- choose whichever you prefer.
 ------------------------------------------------------------------------------
 ALTERNATIVE A - MIT License
 Copyright (c) 2017 Sean Barrett
-Permission is hereby granted, free of charge, to any person obtaining a copy of 
-this software and associated documentation files (the "Software"), to deal in 
-the Software without restriction, including without limitation the rights to 
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
-of the Software, and to permit persons to whom the Software is furnished to do 
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
 so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included in all 
+The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ------------------------------------------------------------------------------
 ALTERNATIVE B - Public Domain (www.unlicense.org)
 This is free and unencumbered software released into the public domain.
-Anyone is free to copy, modify, publish, use, compile, sell, or distribute this 
-software, either in source code form or as a compiled binary, for any purpose, 
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
 commercial or non-commercial, and by any means.
-In jurisdictions that recognize copyright laws, the author or authors of this 
-software dedicate any and all copyright interest in the software to the public 
-domain. We make this dedication for the benefit of the public at large and to 
-the detriment of our heirs and successors. We intend this dedication to be an 
-overt act of relinquishment in perpetuity of all present and future rights to 
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
 this software under copyright law.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN 
-ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ------------------------------------------------------------------------------
 */


### PR DESCRIPTION
This is an attempt to make stb_sprintf at least a bit more readable.

Start with clang-format configured to produce a reasonable semblance of "normal" stb style, then manually fix up a few dodgy pieces of formatting in the result, and finally remove some *really* gratuitous gotos.
