### PR TITLE
stb_image: Relax raw_len validation for non-interlaced PNGs.

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -4297,11 +4297,10 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
 
    img_width_bytes = (((img_n * x * depth) + 7) >> 3);
    img_len = (img_width_bytes + 1) * y;
-   if (s->img_x == x && s->img_y == y) {
-      if (raw_len != img_len) return stbi__err("not enough pixels","Corrupt PNG");
-   } else { // interlaced:
-      if (raw_len < img_len) return stbi__err("not enough pixels","Corrupt PNG");
-   }
+   // we used to check for exact match between raw_len and img_len on non-interlaced PNGs,
+   // but issue #276 reported a PNG in the wild that had extra data at the end (all zeros),
+   // so just check for raw_len < img_len always.
+   if (raw_len < img_len) return stbi__err("not enough pixels","Corrupt PNG");
 
    for (j=0; j < y; ++j) {
       stbi_uc *cur = a->out + stride*j;


### PR DESCRIPTION
We used to require exact match between img_len and raw_len for
non-interlaced PNGs, but the PNG in issue #276 has extra bytes
(all zeros) at the end of the compressed DEFLATE stream.

The PNG spec doesn't have anything to say about it (that I
can tell), and if libpng accepts this, who are we to judge.

Fixes issue #276.