### PR TITLE
Correct function signature in stbi_write_jpg usage documentation.

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -35,7 +35,7 @@ USAGE:
      int stbi_write_bmp(char const *filename, int w, int h, int comp, const void *data);
      int stbi_write_tga(char const *filename, int w, int h, int comp, const void *data);
      int stbi_write_hdr(char const *filename, int w, int h, int comp, const float *data);
-     int stbi_write_jpg(char const *filename, int w, int h, int comp, const float *data);
+     int stbi_write_jpg(char const *filename, int w, int h, int comp, const float *data, int quality);
 
    There are also four equivalent functions that use an arbitrary write function. You are
    expected to open/close your file-equivalent before and after calling these:


### PR DESCRIPTION
Previously, the usage documentation stbi_write_jpg did not include the quality parameter. This PR simply adds it into the usage docs at the top of the file.