### PR TITLE
Remove argument from STBD_MEMSET macro

### DIFF
--- a/stb_dxt.h
+++ b/stb_dxt.h
@@ -88,7 +88,7 @@ STBDDEF void stb_compress_bc5_block(unsigned char *dest, const unsigned char *sr
 
 #ifndef STBD_MEMSET
 #include <string.h>
-#define STBD_MEMSET(x)        memset(x)
+#define STBD_MEMSET           memset
 #endif
 
 static unsigned char stb__Expand5[32];


### PR DESCRIPTION
My clang doesn't like the macro defined this way, choking at the callsite on line 195 with "too many arguments provided to function-like macro invocation"

This change matches what is done for STBTT_memset in stb_truetype.h