### PR TITLE
stb_truetype.h: Fixes

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -3318,6 +3318,11 @@ STBTT_DEF unsigned char *stbtt_GetCodepointBitmapSubpixel(const stbtt_fontinfo *
    return stbtt_GetGlyphBitmapSubpixel(info, scale_x, scale_y,shift_x,shift_y, stbtt_FindGlyphIndex(info,codepoint), width,height,xoff,yoff);
 }   
 
+STBTT_DEF void stbtt_MakeCodepointBitmapSubpixelPrefilter(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int oversample_x, int oversample_y, float *sub_x, float *sub_y, int codepoint)
+{
+   stbtt_MakeGlyphBitmapSubpixelPrefilter(info, output, out_w, out_h, out_stride, scale_x, scale_y, shift_x, shift_y, oversample_x, oversample_y, sub_x, sub_y, stbtt_FindGlyphIndex(info,codepoint));
+}
+
 STBTT_DEF void stbtt_MakeCodepointBitmapSubpixel(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int codepoint)
 {
    stbtt_MakeGlyphBitmapSubpixel(info, output, out_w, out_h, out_stride, scale_x, scale_y, shift_x, shift_y, stbtt_FindGlyphIndex(info,codepoint));

--- a/tests/test_truetype.c
+++ b/tests/test_truetype.c
@@ -1,13 +1,20 @@
+#ifndef _CRT_SECURE_NO_WARNINGS
+// Fixes Compile Errors for Visual Studio 2005 or newer
+  #define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#define STB_RECT_PACK_IMPLEMENTATION
 #include "stb_rect_pack.h"
 #define STB_TRUETYPE_IMPLEMENTATION
 #include "stb_truetype.h"
+#define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
 
 #ifdef TT_TEST
 
 #include <stdio.h>
 
-char ttf_buffer[1<<25];
+unsigned char ttf_buffer[1 << 25];
 unsigned char output[512*100];
 
 void debug(void)
@@ -66,12 +73,14 @@ int main(int argc, char **argv)
       stbtt_PackBegin(&pc, temp_bitmap[0], BITMAP_W, BITMAP_H, 0, 1, NULL);
 
       pr[0].chardata_for_range = pdata;
-      pr[0].first_unicode_char_in_range = 32;
-      pr[0].num_chars_in_range = 95;
+      pr[0].array_of_unicode_codepoints = NULL;
+      pr[0].first_unicode_codepoint_in_range = 32;
+      pr[0].num_chars = 95;
       pr[0].font_size = 20.0f;
       pr[1].chardata_for_range = pdata+256;
-      pr[1].first_unicode_char_in_range = 0xa0;
-      pr[1].num_chars_in_range = 0x100 - 0xa0;
+      pr[1].array_of_unicode_codepoints = NULL;
+      pr[1].first_unicode_codepoint_in_range = 0xa0;
+      pr[1].num_chars = 0x100 - 0xa0;
       pr[1].font_size = 20.0f;
 
       stbtt_PackSetOversampling(&pc, 2, 2);


### PR DESCRIPTION
This is fixes for the stb_truetype header and tests.

- stb_truetype.h - Fix missing function as per bug report #516.
- tests/test_truetype.c: Fix Compiler error on MSVC 2015 or newer.
- tests/test_truetype.c: Fix compiler warning about unsigned/signed conversion.
- tests/test_truetype.c: Fix the png writer. 

