### PR TITLE
Avoid warning about unused stbi__float_postprocess

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -1103,7 +1103,7 @@ static stbi__uint16 *stbi__load_and_postprocess_16bit(stbi__context *s, int *x, 
    return (stbi__uint16 *) result;
 }
 
-#ifndef STBI_NO_HDR
+#if !defined(STBI_NO_HDR) && !defined(STBI_NO_LINEAR)
 static void stbi__float_postprocess(float *result, int *x, int *y, int *comp, int req_comp)
 {
    if (stbi__vertically_flip_on_load && result != NULL) {


### PR DESCRIPTION
This is similar in spirit to https://github.com/nothings/stb/pull/502

`stbi__float_postprocess` is only used when both `STBI_NO_HDR` and `STBI_NO_LINEAR` are undefined. If I compile stb_image with only `STBI_NO_LINEAR` but without `STBI_NO_HDR`, Xcode (8/9) complains about the now-unused function.