### PR TITLE
Fix warning on unused stbi__sse2_available when skipping JPEG support.

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -612,20 +612,20 @@ typedef unsigned char validate_uint32[sizeof(stbi__uint32)==4 ? 1 : -1];
 #endif
 
 #if !defined(STBI_NO_SIMD) && (defined(STBI__X86_TARGET) || defined(STBI__X64_TARGET))
-#define STBI_SSE2
-#include <emmintrin.h>
+#	define STBI_SSE2
+#	include <emmintrin.h>
 
-#ifdef _MSC_VER
+#	ifdef _MSC_VER
 
-#if _MSC_VER >= 1400  // not VC6
-#include <intrin.h> // __cpuid
+#		if _MSC_VER >= 1400  // not VC6
+#			include <intrin.h> // __cpuid
 static int stbi__cpuid3(void)
 {
    int info[4];
    __cpuid(info,1);
    return info[3];
 }
-#else
+#		else
 static int stbi__cpuid3(void)
 {
    int res;
@@ -636,18 +636,20 @@ static int stbi__cpuid3(void)
    }
    return res;
 }
-#endif
+#		endif
 
-#define STBI_SIMD_ALIGN(type, name) __declspec(align(16)) type name
+#		define STBI_SIMD_ALIGN(type, name) __declspec(align(16)) type name
 
+#		ifndef STBI_NO_JPEG
 static int stbi__sse2_available(void)
 {
    int info3 = stbi__cpuid3();
    return ((info3 >> 26) & 1) != 0;
 }
-#else // assume GCC-style if not VC++
-#define STBI_SIMD_ALIGN(type, name) type name __attribute__((aligned(16)))
-
+#		endif
+#	else // assume GCC-style if not VC++
+#		define STBI_SIMD_ALIGN(type, name) type name __attribute__((aligned(16)))
+#		ifndef STBI_NO_JPEG
 static int stbi__sse2_available(void)
 {
    // If we're even attempting to compile this on GCC/Clang, that means
@@ -655,7 +657,8 @@ static int stbi__sse2_available(void)
    // instructions at will, and so are we.
    return 1;
 }
-#endif
+#		endif
+#	endif
 #endif
 
 // ARM NEON


### PR DESCRIPTION
If you use stb_image.h without the JPEG support, then the compiler will warn:

```
/home/bram/src/stb/stb_image.h:651:12: warning: unused function 'stbi__sse2_available'
      [-Wunused-function]
static int stbi__sse2_available(void)
```

This function is only needed if you use the JPEG support.

