### PR TITLE
Add functions with wchar_t to stb_image.h and stb_image_write.h

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -1115,22 +1115,21 @@ static void stbi__float_postprocess(float *result, int *x, int *y, int *comp, in
 
 #ifndef STBI_NO_STDIO
 
-static FILE *stbi__fopen(char const *filename, char const *mode)
+static FILE *stbi__fopen_rb(char const *filename)
 {
    FILE *f;
 #if defined(_MSC_VER) && _MSC_VER >= 1400
-   if (0 != fopen_s(&f, filename, mode))
+   if (0 != fopen_s(&f, filename, "rb"))
       f=0;
 #else
-   f = fopen(filename, mode);
+   f = fopen(filename, "rb");
 #endif
    return f;
 }
 
-
 STBIDEF stbi_uc *stbi_load(char const *filename, int *x, int *y, int *comp, int req_comp)
 {
-   FILE *f = stbi__fopen(filename, "rb");
+   FILE *f = stbi__fopen_rb(filename);
    unsigned char *result;
    if (!f) return stbi__errpuc("can't fopen", "Unable to open file");
    result = stbi_load_from_file(f,x,y,comp,req_comp);
@@ -1166,14 +1165,13 @@ STBIDEF stbi__uint16 *stbi_load_from_file_16(FILE *f, int *x, int *y, int *comp,
 
 STBIDEF stbi_us *stbi_load_16(char const *filename, int *x, int *y, int *comp, int req_comp)
 {
-   FILE *f = stbi__fopen(filename, "rb");
+   FILE *f = stbi__fopen_rb(filename);
    stbi__uint16 *result;
    if (!f) return (stbi_us *) stbi__errpuc("can't fopen", "Unable to open file");
    result = stbi_load_from_file_16(f,x,y,comp,req_comp);
    fclose(f);
    return result;
 }
-
 
 #endif //!STBI_NO_STDIO
 
@@ -1241,8 +1239,8 @@ STBIDEF float *stbi_loadf_from_callbacks(stbi_io_callbacks const *clbk, void *us
 #ifndef STBI_NO_STDIO
 STBIDEF float *stbi_loadf(char const *filename, int *x, int *y, int *comp, int req_comp)
 {
+   FILE *f = stbi__fopen_rb(filename);
    float *result;
-   FILE *f = stbi__fopen(filename, "rb");
    if (!f) return stbi__errpf("can't fopen", "Unable to open file");
    result = stbi_loadf_from_file(f,x,y,comp,req_comp);
    fclose(f);
@@ -1277,9 +1275,9 @@ STBIDEF int stbi_is_hdr_from_memory(stbi_uc const *buffer, int len)
 }
 
 #ifndef STBI_NO_STDIO
-STBIDEF int      stbi_is_hdr          (char const *filename)
+STBIDEF int stbi_is_hdr(char const *filename)
 {
-   FILE *f = stbi__fopen(filename, "rb");
+   FILE *f = stbi__fopen_rb(filename);
    int result=0;
    if (f) {
       result = stbi_is_hdr_from_file(f);
@@ -6931,7 +6929,7 @@ static int stbi__info_main(stbi__context *s, int *x, int *y, int *comp)
 #ifndef STBI_NO_STDIO
 STBIDEF int stbi_info(char const *filename, int *x, int *y, int *comp)
 {
-    FILE *f = stbi__fopen(filename, "rb");
+    FILE *f = stbi__fopen_rb(filename);
     int result;
     if (!f) return stbi__err("can't fopen", "Unable to open file");
     result = stbi_info_from_file(f, x, y, comp);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,7 +28,13 @@ if(MSVC)
 	#  PRIVATE "/W4"
 	PRIVATE "/W3"
 	)
+else()
+  target_compile_options(
+	image_test
+	PRIVATE "-std=gnu90"
+	)
 endif()
+
 
 set_target_properties(
   image_test
@@ -42,6 +48,29 @@ if(UNIX)
 	-lm
     )
 endif()
+
+############
+# image_test_wchar
+if(MSVC)
+  add_executable(
+	image_test_wchar
+	image_test_wchar.c
+	../stb_image.h
+	../stb_image_write.h
+	)
+
+  target_compile_options(
+	image_test
+	#  PRIVATE "/W4"
+	PRIVATE "/W3"
+	)
+
+  set_target_properties(
+	image_test_wchar
+	PROPERTIES
+	VS_DEBUGGER_WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	)
+endif(MSVC)
 
 ############
 # herringbone

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,175 @@
+# -*- coding: utf-8-unix -*-
+
+cmake_minimum_required(VERSION 3.4.1)
+
+project(stb_test C CXX)
+
+include_directories(
+  .
+  ..
+  )
+
+if(MSVC)
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS=1)
+endif()
+
+############
+# image_test
+add_executable(
+  image_test
+  image_test.c
+  ../stb_image.h
+  ../stb_image_write.h
+  )
+
+if(MSVC)
+  target_compile_options(
+	image_test
+	#  PRIVATE "/W4"
+	PRIVATE "/W3"
+	)
+endif()
+
+set_target_properties(
+  image_test
+  PROPERTIES
+  VS_DEBUGGER_WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+
+if(UNIX)
+  target_link_libraries(
+	image_test
+	-lm
+    )
+endif()
+
+############
+# herringbone
+add_executable(
+  herringbone
+  herringbone_generator.c
+  ../stb_herringbone_wang_tile.h
+  ../stb_image_write.h
+  )
+
+############
+# herringbone_map
+add_executable(
+  herringbone_map
+  herringbone_map.c
+  ../stb_herringbone_wang_tile.h
+  ../stb_image.h
+  ../stb_image_write.h
+  )
+
+############
+# resize
+add_executable(
+  resize
+  resample_test.cpp
+  ../stb_image_resize.h
+  ../stb_image.h
+  ../stb_image_write.h
+  )
+
+############
+# stb
+add_executable(
+  stb
+  grid_reachability.c
+  stb.c
+  stretchy_buffer_test.c
+  test_c_compilation.c
+  test_truetype.c
+  test_vorbis.c
+  textedit_sample.c
+  ../stb.h
+  ../stb_c_lexer.h
+  ../stb_connected_components.h
+  ../stb_divide.h
+  ../stb_dxt.h
+  ../stb_easy_font.h
+  ../stb_herringbone_wang_tile.h
+  ../stb_image.h
+  ../stb_image_resize.h
+  ../stb_image_write.h
+  ../stb_leakcheck.h
+#  ../stb_malloc.h
+  ../stb_perlin.h
+#  ../stb_pg.h
+  ../stb_rect_pack.h
+  ../stb_sprintf.h
+  ../stb_textedit.h
+  ../stb_tilemap_editor.h
+  ../stb_truetype.h
+  ../stb_vorbis.c
+  ../stb_voxel_render.h
+  ../stretchy_buffer.h
+  )
+
+if(MSVC)
+  target_compile_options(
+	stb
+	PRIVATE "/W0"
+	)
+endif()
+
+############
+# stretch_test
+add_executable(
+  stretch_test
+  stretch_test.c
+  ../stretchy_buffer.h
+  ../stb_truetype.h
+  )
+
+############
+# stb_cpp
+add_executable(
+  stb_cpp
+  stb_cpp.cpp
+  test_cpp_compilation.cpp
+  ../stb_vorbis.c
+  ../stb.h
+  ../stb_c_lexer.h
+  ../stb_connected_components.h
+  ../stb_divide.h
+  ../stb_dxt.h
+  ../stb_easy_font.h
+  ../stb_herringbone_wang_tile.h
+  ../stb_image.h
+  ../stb_image_resize.h
+  ../stb_image_write.h
+  ../stb_leakcheck.h
+  ../stb_perlin.h
+  ../stb_rect_pack.h
+  ../stb_sprintf.h
+  ../stb_textedit.h
+  ../stb_tilemap_editor.h
+  ../stb_truetype.h
+  ../stb_voxel_render.h
+  ../stretchy_buffer.h
+  )
+
+if(MSVC)
+  target_compile_options(
+	stb_cpp
+	PRIVATE "/W0"
+	)
+endif()
+
+############
+# stb_borbis from Makefile
+if(0)
+  add_executable(
+	stb_borbis
+	../stb_vorbis.c
+	test_c_compilation.c
+	test_cpp_compilation.cpp
+	)
+
+  target_link_libraries(
+	stb_borbis
+	-lm
+	)
+endif()

--- a/tests/image_test.c
+++ b/tests/image_test.c
@@ -1,8 +1,13 @@
+
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
 
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
+
+//#define WCHAR_TEST
+
+#if !defined(WCHAR_TEST)
 
 #define STB_DEFINE
 #include "stb.h"
@@ -164,3 +169,60 @@ int main(int argc, char **argv)
    }
    return 0;
 }
+
+#else	// WCHAR_TEST
+
+#include <string.h>
+#include <wchar.h>
+
+int wmain(int argc, wchar_t **argv)
+{
+   int w,h;
+   int i, n;
+
+   printf("test wchar edition\n");
+   if (argc <= 1) {
+	   printf("%ls [filename] ...\n", argv[0]);
+	   return 0;
+   }
+
+   for (i=1; i < argc; ++i) {
+	   const wchar_t *fn_src = argv[i];
+	   int res;
+	   int w2,h2,n2;
+	   unsigned char *data;
+	   wprintf(L"%s\n", fn_src);
+	   res = stbi_infoW(fn_src, &w2, &h2, &n2);
+	   data = stbi_loadW(fn_src, &w, &h, &n, 4); if (data) free(data); else printf("Failed &n\n");
+	   data = stbi_loadW(fn_src, &w, &h,  0, 1); if (data) free(data); else printf("Failed 1\n");
+	   data = stbi_loadW(fn_src, &w, &h,  0, 2); if (data) free(data); else printf("Failed 2\n");
+	   data = stbi_loadW(fn_src, &w, &h,  0, 3); if (data) free(data); else printf("Failed 3\n");
+	   data = stbi_loadW(fn_src, &w, &h, &n, 4);
+	   assert(data);
+	   assert(w == w2 && h == h2 && n == n2);
+	   assert(res);
+	   if (data) {
+		   wchar_t fname[512];
+		   wchar_t *p = wcsrchr(fn_src, L'\\');
+		   if (p == NULL) p = wcsrchr(fn_src, L'/');
+		   p++;
+		   wcscpy(fname, p);
+		   p = wcsrchr(fname, L'.');
+		   *p = L'\0';
+		   const wchar_t *fn_out = fname;
+		   wchar_t fnamep[512];
+		   swprintf(fnamep, sizeof(fnamep), L"output/%s.png", fn_out);
+		   stbi_write_pngW(fnamep, w, h, 4, data, w*4);
+		   swprintf(fnamep, sizeof(fnamep), L"output/%s.bmp", fn_out);
+		   stbi_write_bmpW(fnamep, w, h, 4, data);
+		   swprintf(fnamep, sizeof(fnamep), L"output/%s.tga", fn_out);
+		   stbi_write_tgaW(fnamep, w, h, 4, data);
+		   swprintf(fnamep, sizeof(fnamep), L"output/%s.jpg", fn_out);
+		   stbi_write_jpgW(fnamep, w, h, 4, data, 90);
+		   free(data);
+	   } else
+		   printf("FAILED 4\n");
+   }
+}
+
+#endif	// WCHAR_TEST

--- a/tests/image_test.c
+++ b/tests/image_test.c
@@ -5,10 +5,6 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
-//#define WCHAR_TEST
-
-#if !defined(WCHAR_TEST)
-
 #define STB_DEFINE
 #include "stb.h"
 
@@ -169,60 +165,3 @@ int main(int argc, char **argv)
    }
    return 0;
 }
-
-#else	// WCHAR_TEST
-
-#include <string.h>
-#include <wchar.h>
-
-int wmain(int argc, wchar_t **argv)
-{
-   int w,h;
-   int i, n;
-
-   printf("test wchar edition\n");
-   if (argc <= 1) {
-	   printf("%ls [filename] ...\n", argv[0]);
-	   return 0;
-   }
-
-   for (i=1; i < argc; ++i) {
-	   const wchar_t *fn_src = argv[i];
-	   int res;
-	   int w2,h2,n2;
-	   unsigned char *data;
-	   wprintf(L"%s\n", fn_src);
-	   res = stbi_infoW(fn_src, &w2, &h2, &n2);
-	   data = stbi_loadW(fn_src, &w, &h, &n, 4); if (data) free(data); else printf("Failed &n\n");
-	   data = stbi_loadW(fn_src, &w, &h,  0, 1); if (data) free(data); else printf("Failed 1\n");
-	   data = stbi_loadW(fn_src, &w, &h,  0, 2); if (data) free(data); else printf("Failed 2\n");
-	   data = stbi_loadW(fn_src, &w, &h,  0, 3); if (data) free(data); else printf("Failed 3\n");
-	   data = stbi_loadW(fn_src, &w, &h, &n, 4);
-	   assert(data);
-	   assert(w == w2 && h == h2 && n == n2);
-	   assert(res);
-	   if (data) {
-		   wchar_t fname[512];
-		   wchar_t *p = wcsrchr(fn_src, L'\\');
-		   if (p == NULL) p = wcsrchr(fn_src, L'/');
-		   p++;
-		   wcscpy(fname, p);
-		   p = wcsrchr(fname, L'.');
-		   *p = L'\0';
-		   const wchar_t *fn_out = fname;
-		   wchar_t fnamep[512];
-		   swprintf(fnamep, sizeof(fnamep), L"output/%s.png", fn_out);
-		   stbi_write_pngW(fnamep, w, h, 4, data, w*4);
-		   swprintf(fnamep, sizeof(fnamep), L"output/%s.bmp", fn_out);
-		   stbi_write_bmpW(fnamep, w, h, 4, data);
-		   swprintf(fnamep, sizeof(fnamep), L"output/%s.tga", fn_out);
-		   stbi_write_tgaW(fnamep, w, h, 4, data);
-		   swprintf(fnamep, sizeof(fnamep), L"output/%s.jpg", fn_out);
-		   stbi_write_jpgW(fnamep, w, h, 4, data, 90);
-		   free(data);
-	   } else
-		   printf("FAILED 4\n");
-   }
-}
-
-#endif	// WCHAR_TEST

--- a/tests/image_test_wchar.c
+++ b/tests/image_test_wchar.c
@@ -1,0 +1,162 @@
+
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
+
+#include <string.h>
+#include <wchar.h>
+
+static FILE *stbi__wfopen_wb(wchar_t const *filename)
+{
+   FILE *f;
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+   if (0 != _wfopen_s(&f, filename, L"wb"))
+      f=0;
+#else
+   f = wfopen(filename, L"wb");
+#endif
+   return f;
+}
+
+static FILE *stbi__wfopen_rb(wchar_t const *filename)
+{
+   FILE *f;
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+   if (0 != _wfopen_s(&f, filename, L"rb"))
+      f=0;
+#else
+   f = _wfopen(filename, L"rb");
+#endif
+   return f;
+}
+
+stbi_uc *stbi_loadW(wchar_t const *filename, int *x, int *y, int *comp, int req_comp)
+{
+   FILE *f = stbi__wfopen_rb(filename);
+   if (!f) return stbi__errpuc("can't fopen", "Unable to open file");
+   unsigned char *result = stbi_load_from_file(f,x,y,comp,req_comp);
+   fclose(f);
+   return result;
+}
+
+stbi_us *stbi_load_16W(wchar_t const *filename, int *x, int *y, int *comp, int req_comp)
+{
+   FILE *f = stbi__wfopen_rb(filename);
+   if (!f) return (stbi_us *) stbi__errpuc("can't fopen", "Unable to open file");
+   stbi__uint16 *result = stbi_load_from_file_16(f,x,y,comp,req_comp);
+   fclose(f);
+   return result;
+}
+
+int stbi_infoW(wchar_t const *filename, int *x, int *y, int *comp)
+{
+    FILE *f = stbi__wfopen_rb(filename);
+    if (!f) return stbi__err("can't fopen", "Unable to open file");
+    int result = stbi_info_from_file(f, x, y, comp);
+    fclose(f);
+    return result;
+}
+
+int stbi_write_bmpW(wchar_t const *filename, int x, int y, int comp, const void *data)
+{
+   FILE *f = stbi__wfopen_wb(filename);
+   int result;
+   if (!f) return 0;
+   result = stbi_write_bmp_to_file(f, x, y, comp, data);
+   fclose(f);
+   return result;
+   return stbi_write_bmp_to_file(stbi__wfopen_wb(filename),x, y, comp, data);
+}
+
+int stbi_write_tgaW(wchar_t const *filename, int x, int y, int comp, const void *data)
+{
+   FILE *f = stbi__wfopen_wb(filename);
+   int result;
+   if (!f) return 0;
+   result = stbi_write_tga_to_file(f, x, y, comp, data);
+   fclose(f);
+   return result;
+}
+
+int stbi_write_hdrW(wchar_t const *filename, int x, int y, int comp, const float *data)
+{
+   FILE *f = stbi__wfopen_wb(filename);
+   int result;
+   if (!f) return 0;
+   result = stbi_write_hdr_to_file(f, x, y, comp, data);
+   fclose(f);
+   return result;
+}
+
+int stbi_write_pngW(wchar_t const *filename, int x, int y, int comp, const void *data, int stride_bytes)
+{
+   FILE *f = stbi__wfopen_wb(filename);
+   int result;
+   if (!f) return 0;
+   result = stbi_write_png_to_file(f, x, y, comp, data, stride_bytes);
+   fclose(f);
+   return result;
+}
+
+int stbi_write_jpgW(wchar_t const *filename, int x, int y, int comp, const void *data, int quality)
+{
+   FILE *f = stbi__wfopen_wb(filename);
+   int result;
+   if (!f) return 0;
+   result = stbi_write_jpg_to_file(f, x, y, comp, data, quality);
+   fclose(f);
+   return result;
+}
+
+int wmain(int argc, wchar_t **argv)
+{
+   int w,h;
+   int i, n;
+
+   printf("test wchar edition\n");
+   if (argc <= 1) {
+	   printf("%ls [filename] ...\n", argv[0]);
+	   return 0;
+   }
+
+   for (i=1; i < argc; ++i) {
+	   const wchar_t *fn_src = argv[i];
+	   int res;
+	   int w2,h2,n2;
+	   unsigned char *data;
+	   wprintf(L"%s\n", fn_src);
+	   res = stbi_infoW(fn_src, &w2, &h2, &n2);
+	   data = stbi_loadW(fn_src, &w, &h, &n, 4); if (data) free(data); else printf("Failed &n\n");
+	   data = stbi_loadW(fn_src, &w, &h,  0, 1); if (data) free(data); else printf("Failed 1\n");
+	   data = stbi_loadW(fn_src, &w, &h,  0, 2); if (data) free(data); else printf("Failed 2\n");
+	   data = stbi_loadW(fn_src, &w, &h,  0, 3); if (data) free(data); else printf("Failed 3\n");
+	   data = stbi_loadW(fn_src, &w, &h, &n, 4);
+	   assert(data);
+	   assert(w == w2 && h == h2 && n == n2);
+	   assert(res);
+	   if (data) {
+		   wchar_t fname[512];
+		   wchar_t *p = wcsrchr(fn_src, L'\\');
+		   if (p == NULL) p = wcsrchr(fn_src, L'/');
+		   p++;
+		   wcscpy(fname, p);
+		   p = wcsrchr(fname, L'.');
+		   *p = L'\0';
+		   const wchar_t *fn_out = fname;
+		   wchar_t fnamep[512];
+		   swprintf(fnamep, sizeof(fnamep), L"output/%s.png", fn_out);
+		   stbi_write_pngW(fnamep, w, h, 4, data, w*4);
+		   swprintf(fnamep, sizeof(fnamep), L"output/%s.bmp", fn_out);
+		   stbi_write_bmpW(fnamep, w, h, 4, data);
+		   swprintf(fnamep, sizeof(fnamep), L"output/%s.tga", fn_out);
+		   stbi_write_tgaW(fnamep, w, h, 4, data);
+		   swprintf(fnamep, sizeof(fnamep), L"output/%s.jpg", fn_out);
+		   stbi_write_jpgW(fnamep, w, h, 4, data, 90);
+		   free(data);
+	   } else
+		   printf("FAILED 4\n");
+   }
+}
+


### PR DESCRIPTION
wfopen (UNICODE,wchar_t) version will use UNICODE version (CreateW) API.

- CJK support
In CJK environment wchar_t support is important.
ex. (CP932)
"C:\Documents and Settings\佐藤\デスクトップ\可能性の表.txt"
hex dump
```
00000000: 433a 5c44 6f63 756d 656e 7473 2061 6e64  C:\Documents and
00000010: 2053 6574 7469 6e67 735c 8db2 93a1 5c83   Settings\....\.
00000020: 6683 5883 4e83 6783 6283 765c 89c2 945c  f.X.N.g.b.v\...\
00000030: 90ab 82cc 955c 2e74 7874                 .....\.txt
```
filename includes path separator charactor(`'\'`). it's dangerous.

- UNC
"\\server\share\.."
"\\server@SSL\path\.."

- MAX_PATH limit
MAX_PATH -> 32767 

- see
https://msdn.microsoft.com/ja-jp/library/windows/desktop/aa365247(v=vs.85).aspx