### PR TITLE
Using secure CRT calls to avoid MSVC compile errors

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -10,8 +10,8 @@
 
    Will probably not work correctly with strict-aliasing optimizations.
 
-   If using a modern Microsoft Compiler non-safe versions of CRT calls may cause 
-   compilation warnings or even errors. To avoid this, aldo before #including,
+   If using a modern Microsoft Compiler, non-safe versions of CRT calls may cause 
+   compilation warnings or even errors. To avoid this, also before #including,
 
        #define STBI_MSC_SECURE_CRT
 

--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -10,6 +10,11 @@
 
    Will probably not work correctly with strict-aliasing optimizations.
 
+   If using a modern Microsoft Compiler non-safe versions of CRT calls may cause 
+   compilation warnings or even errors. To avoid this, aldo before #including,
+
+       #define STBI_MSC_SECURE_CRT
+
 ABOUT:
 
    This header file is a library for writing images to C stdio. It could be
@@ -231,7 +236,7 @@ static void stbi__stdio_write(void *context, void *data, int size)
 static int stbi__start_write_file(stbi__write_context *s, const char *filename)
 {
    FILE *f;
-#ifdef _MSC_VER
+#ifdef STBI_MSC_SECURE_CRT
    fopen_s(&f, filename, "wb");
 #else
    f = fopen(filename, "wb");
@@ -631,7 +636,7 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
       char header[] = "#?RADIANCE\n# Written by stb_image_write.h\nFORMAT=32-bit_rle_rgbe\n";
       s->func(s->context, header, sizeof(header)-1);
 
-#ifdef _MSC_VER
+#ifdef STBI_MSC_SECURE_CRT
       len = sprintf_s(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #else
       len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
@@ -1019,7 +1024,7 @@ STBIWDEF int stbi_write_png(char const *filename, int x, int y, int comp, const 
    int len;
    unsigned char *png = stbi_write_png_to_mem((unsigned char *) data, stride_bytes, x, y, comp, &len);
    if (png == NULL) return 0;
-#ifdef _MSC_VER
+#ifdef STBI_MSC_SECURE_CRT
    fopen_s(&f, filename, "wb");
 #else
    f = fopen(filename, "wb");

--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -230,7 +230,12 @@ static void stbi__stdio_write(void *context, void *data, int size)
 
 static int stbi__start_write_file(stbi__write_context *s, const char *filename)
 {
-   FILE *f = fopen(filename, "wb");
+   FILE *f;
+#ifdef _MSC_VER
+   fopen_s(&f, filename, "wb");
+#else
+   f = fopen(filename, "wb");
+#endif
    stbi__start_write_callbacks(s, stbi__stdio_write, (void *) f);
    return f != NULL;
 }
@@ -626,7 +631,11 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
       char header[] = "#?RADIANCE\n# Written by stb_image_write.h\nFORMAT=32-bit_rle_rgbe\n";
       s->func(s->context, header, sizeof(header)-1);
 
+#ifdef _MSC_VER
+      len = sprintf_s(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
+#else
       len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
+#endif
       s->func(s->context, buffer, len);
 
       for(i=0; i < y; i++)
@@ -1010,7 +1019,11 @@ STBIWDEF int stbi_write_png(char const *filename, int x, int y, int comp, const 
    int len;
    unsigned char *png = stbi_write_png_to_mem((unsigned char *) data, stride_bytes, x, y, comp, &len);
    if (png == NULL) return 0;
+#ifdef _MSC_VER
+   fopen_s(&f, filename, "wb");
+#else
    f = fopen(filename, "wb");
+#endif
    if (!f) { STBIW_FREE(png); return 0; }
    fwrite(png, 1, len, f);
    fclose(f);


### PR DESCRIPTION
Fixes #533 for CRT calls that the Microsoft C/C++ compiler considers deprecated and errors when used. The proposed changes are to use the secure versions of these calls if a Microsoft compiler is being used. For this fix, namely, fopen and sprintf.

If you're using an extremely old version of a Microsoft compiler this might be a problem without being more detailed about the _MSC_VER macro.
