### PR TITLE
Replace raw math calls with STBTT_* decorated variants

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -44,6 +44,7 @@
 //       Rob Loach                  Cort Stratton
 //       Kenney Phillis Jr.         github:oyvindjam
 //       Brian Costabile            github:vassvik
+//       github:pmttavara
 //       
 // VERSION HISTORY
 //
@@ -3932,7 +3933,7 @@ static int stbtt__ray_intersect_bezier(float orig[2], float ray[2], float q0[2],
       float discr = b*b - a*c;
       if (discr > 0.0) {
          float rcpna = -1 / a;
-         float d = (float) sqrt(discr);
+         float d = (float) STBTT_sqrt(discr);
          s0 = (b+d) * rcpna;
          s1 = (b-d) * rcpna;
          if (s0 >= 0.0 && s0 <= 1.0)
@@ -3994,7 +3995,7 @@ static int stbtt__compute_crossings_x(float x, float y, int nverts, stbtt_vertex
    orig[1] = y;
 
    // make sure y never passes through a vertex of the shape
-   y_frac = (float) fmod(y, 1.0f);
+   y_frac = (float) STBTT_fmod(y, 1.0f);
    if (y_frac < 0.01f)
       y += 0.01f;
    else if (y_frac > 0.99f)

--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -441,6 +441,11 @@ int main(int arg, char **argv)
    #define STBTT_pow(x,y)     pow(x,y)
    #endif
 
+   #ifndef STBTT_fmod
+   #include <math.h>
+   #define STBTT_fmod(x,y)    fmod(x,y)
+   #endif
+
    #ifndef STBTT_cos
    #include <math.h>
    #define STBTT_cos(x)       cos(x)


### PR DESCRIPTION
Also, adds STBTT_fmod(x,y) to the list of define-able math functions.
This lets the lib be able to build without the CRT, as (I assume) was intended.
This is not hard to fix user-side, but I thought it might as well work out of the box.
I put my name in the contributors because the rules said so, but this is a pretty trivial change.