### PR TITLE
Fix syntactic errors when compiling stb_image_write statically

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -233,8 +233,8 @@ STBIWDEF void stbi_flip_vertically_on_write(int flip_boolean);
 #define STBIW_UCHAR(x) (unsigned char) ((x) & 0xff)
 
 #ifdef STB_IMAGE_WRITE_STATIC
-static stbi__flip_vertically_on_write=0;
-static int stbi_write_png_compression level = 8;
+static int stbi_write_png_compression_level = 8;
+static int stbi__flip_vertically_on_write=0;
 static int stbi_write_tga_with_rle = 1;
 static int stbi_write_force_png_filter = -1;
 #else


### PR DESCRIPTION
Compiling stb_image_write.h with #define STB_IMAGE_WRITE_STATIC does not work. The reason are accidentally botched declarations inside of ifdef block. This particular problem is not present in dev branch as it was totally rewritten.

```
+ gcc -std=gnu99 -g -Wall -Werror -Wno-unused-function ...
In file included from splines.c:47:0:
stb_image_write.h:236:8: error: type defaults to ‘int’ in declaration of ‘stbi__flip_vertically_on_write’ [-Werror=implicit-int]
 static stbi__flip_vertically_on_write=0;
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
stb_image_write.h:237:39: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘level’
 static int stbi_write_png_compression level = 8;
                                       ^~~~~
In file included from splines.c:47:0:
stb_image_write.h: In function ‘stbi_write_png_to_mem’:
stb_image_write.h:1062:55: error: ‘stbi_write_png_compression_level’ undeclared (first use in this function); did you mean ‘stbi_write_png_comperssion_level’?
    zlib = stbi_zlib_compress(filt, y*( x*n+1), &zlen, stbi_write_png_compression_level);
                                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                       stbi_write_png_comperssion_level
stb_image_write.h:1062:55: note: each undeclared identifier is reported only once for each function it appears in
In file included from splines.c:47:0:
At top level:
stb_image_write.h:157:14: error: ‘stbi_write_png_comperssion_level’ defined but not used [-Werror=unused-variable]
 STBIWDEF int stbi_write_png_comperssion_level;
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```