### PR TITLE
stb_reck_pack: Removed unused assigned variables warnings

### DIFF
--- a/stb_rect_pack.h
+++ b/stb_rect_pack.h
@@ -492,17 +492,14 @@ static stbrp__findresult stbrp__skyline_pack_rectangle(stbrp_context *context, i
    STBRP_ASSERT(cur->next == NULL);
 
    {
-      stbrp_node *L1 = NULL, *L2 = NULL;
       int count=0;
       cur = context->active_head;
       while (cur) {
-         L1 = cur;
          cur = cur->next;
          ++count;
       }
       cur = context->free_head;
       while (cur) {
-         L2 = cur;
          cur = cur->next;
          ++count;
       }


### PR DESCRIPTION
There's a block of code under `#ifdef _DEBUG` wrap that has those two unused variables.
The full block prior to the patch is copied below. `L1`/`L2` are assigned in the loop but never read.

It's possible that they are frequently useful to have when using a debugger, then instead of merging this patch you could perhaps comment the three lines out?

Copied the patch reported here:
https://github.com/bkaradzic/imgui/commit/1496d97bf62dff1c738ad941c33824ef7c2fc72a#commitcomment-27523479

```
#ifdef _DEBUG
   cur = context->active_head;
   while (cur->x < context->width) {
      STBRP_ASSERT(cur->x < cur->next->x);
      cur = cur->next;
   }
   STBRP_ASSERT(cur->next == NULL);

   {
      stbrp_node *L1 = NULL, *L2 = NULL;
      int count=0;
      cur = context->active_head;
      while (cur) {
         L1 = cur;
         cur = cur->next;
         ++count;
      }
      cur = context->free_head;
      while (cur) {
         L2 = cur;
         cur = cur->next;
         ++count;
      }
      STBRP_ASSERT(count == context->num_nodes+2);
   }
#endif
```

Thank you!

