### PR TITLE
stb_dxt: fix constant color check

### DIFF
--- a/stb_dxt.h
+++ b/stb_dxt.h
@@ -24,6 +24,7 @@
 // contributors: 
 //   Kevin Schmidt (#defines for "freestanding" compilation)
 //   github:ppiastucki (BC4 support)
+//   Pavel Pavlov (constant color check)
 // 
 // LICENSE
 //
@@ -517,7 +518,7 @@ static void stb__CompressColorBlock(unsigned char *dest, unsigned char *block, i
 
    // check if block is constant
    for (i=1;i<16;i++)
-      if (((unsigned int *) block)[i] != ((unsigned int *) block)[0])
+      if ((((unsigned int *) block)[i] & 0xffffff) != (((unsigned int *) block)[0] & 0xffffff))
          break;
 
    if(i == 16) { // constant color
@@ -651,7 +652,6 @@ static void stb__InitDXT()
 
 void stb_compress_dxt_block(unsigned char *dest, const unsigned char *src, int alpha, int mode)
 {
-   unsigned char data[16][4];
    static int init=1;
    if (init) {
       stb__InitDXT();
@@ -659,15 +659,8 @@ void stb_compress_dxt_block(unsigned char *dest, const unsigned char *src, int a
    }
 
    if (alpha) {
-      int i;
       stb__CompressAlphaBlock(dest,(unsigned char*) src+3, 4);
       dest += 8;
-      // make a new copy of the data in which alpha is opaque,
-      // because code uses a fast test for color constancy
-      memcpy(data, src, 4*16);
-      for (i=0; i < 16; ++i)
-         data[i][3] = 255;
-      src = &data[0][0];
    }
 
    stb__CompressColorBlock(dest,(unsigned char*) src,mode);

--- a/stb_dxt.h
+++ b/stb_dxt.h
@@ -80,6 +80,9 @@ STBDDEF void stb_compress_bc5_block(unsigned char *dest, const unsigned char *sr
 #if !defined(STBD_ABS) || !defined(STBI_FABS)
 #include <math.h>
 #endif
+#if !defined(STBD_MEMSET) || !defined(STBD_MEMCPY)
+#include <string.h>
+#endif
 
 #ifndef STBD_ABS
 #define STBD_ABS(i)           abs(i)
@@ -90,8 +93,11 @@ STBDDEF void stb_compress_bc5_block(unsigned char *dest, const unsigned char *sr
 #endif
 
 #ifndef STBD_MEMSET
-#include <string.h>
 #define STBD_MEMSET           memset
+#endif
+
+#ifndef STBD_MEMCPY
+#define STBD_MEMCPY           memcpy
 #endif
 
 static unsigned char stb__Expand5[32];
@@ -593,9 +599,15 @@ static void stb__CompressAlphaBlock(unsigned char *dest,unsigned char *src, int 
    }
 
    // encode them
-   ((unsigned char *)dest)[0] = mx;
-   ((unsigned char *)dest)[1] = mn;
+   dest[0] = mx;
+   dest[1] = mn;
    dest += 2;
+   if (mx == mn)
+   {
+      static const unsigned char const_alpha_block[] = { 0x49, 0x92, 0x24, 0x49, 0x92, 0x24 };
+      STBD_MEMCPY(dest, const_alpha_block, sizeof(const_alpha_block));
+      return;
+   }
 
    // determine bias and emit color indices
    // given the choice of mx/mn, these indices are optimal:


### PR DESCRIPTION
original constant color check fix obviously didn't work when request was to compress without alpha.
Code is updated to fix the issue and avoid creating temporary copy of the input buffer.
Spurious spaces were also picked up by my editor, if you prefer I may update Cl to remove them.
Thanks for stb.