### PR TITLE
stb_truetype: fix unused variable warning when asserts are disabled.

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -2463,6 +2463,7 @@ static stbtt_int32  stbtt__GetGlyphGPOSInfoAdvance(const stbtt_fontinfo *info, i
                             if (valueFormat2 != 0) return 0;
 
                             STBTT_assert(coverageIndex < pairSetCount);
+                            STBTT__NOTUSED(pairSetCount);
 
                             needle=glyph2;
                             r=pairValueCount-1;


### PR DESCRIPTION
Minor warning fix when asserts are off, `pairSetCount` is only used for an assert.
(reported to me here https://github.com/ocornut/imgui/issues/1642)
