### PR TITLE
stb_truetype: Added comment about stbtt_FindGlyphIndex() return value.

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -733,6 +733,7 @@ STBTT_DEF int stbtt_FindGlyphIndex(const stbtt_fontinfo *info, int unicode_codep
 // and you want a speed-up, call this function with the character you're
 // going to process, then use glyph-based functions instead of the
 // codepoint-based functions.
+// Returns 0 if the character codepoint is not defined in the font.
 
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Added a simple comment:
`Returns 0 if the character codepoint is not defined in the font.`

Based on this thread:
https://twitter.com/ocornut/status/971757064983924742

Looking at the implementation for `stbtt_FindGlyphIndex`, it's clearly intended at the error value, but it is not obvious to me that that 0 isn't also valid index. 