### PR TITLE
Added appveyor support for Windows builds.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,51 @@
+image: Visual Studio 2015
+
+platform:
+- x64
+- x86
+
+environment:
+  matrix:
+
+  - VS_VERSION: Visual Studio 2008
+    VSINSTALL: "Microsoft Visual Studio 9.0\\VC"
+
+  - VS_VERSION: Visual Studio 2010
+    VSINSTALL: "Microsoft Visual Studio 10.0\\VC"
+
+  - VS_VERSION: Visual Studio 2012
+    VSINSTALL: "Microsoft Visual Studio 11.0\\VC"
+
+  - VS_VERSION: Visual Studio 2013
+    VSINSTALL: "Microsoft Visual Studio 12.0\\VC"
+
+  - VS_VERSION: Visual Studio 2015
+    VSINSTALL: "Microsoft Visual Studio 14.0\\VC"
+
+  - VS_VERSION: Visual Studio 2017
+    VSINSTALL: "Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build"
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+build_script:
+  - echo build_script
+  - echo platform %platform%
+  - call "C:\\Program Files (x86)\\%VSINSTALL%\vcvarsall.bat" %platform%
+  - cd tests
+  - nmake /f Makefile.nmake
+
+test_script:
+  - test_cpp_compilation.exe
+  - stb_vorbis.exe
+
+matrix:
+  exclude:
+    - VS_VERSION: Visual Studio 2008
+      platform: x64
+    - VS_VERSION: Visual Studio 2010
+      platform: x64
+    - VS_VERSION: Visual Studio 2012
+      platform: x64
+
+deploy: off
+
+shallow_clone: true

--- a/tests/Makefile.nmake
+++ b/tests/Makefile.nmake
@@ -1,0 +1,7 @@
+INCLUDES = -I..
+CFLAGS = -DSTB_DIVIDE_TEST
+CPPFLAGS = -DSTB_DIVIDE_TEST
+
+all:
+	$(CC) $(INCLUDES) $(CFLAGS) ../stb_vorbis.c test_c_compilation.c
+	$(CC) $(INCLUDES) $(CPPFLAGS) test_cpp_compilation.cpp


### PR DESCRIPTION
This adds appveyor.com support for VS2008 - VS2017. This works similarly to travis-ci, giving build success reports any time someone submits a PR. You can see what it looks like here:
https://ci.appveyor.com/project/AndrewJDR/stb/build/1.0.24

And on my fork (see green checkmark): https://github.com/AndrewJDR/stb/commits/add_appveyor_windows

It also runs the test executables just to make sure they don't crash or whatever. Not sure if that's necessary, but why not.

You'll have to sign up for it to work, similar to travis-ci. Signup is free, and straightforward for OSS projects. Build-wise, I used nmake for now by making a copy of the original tests/Makefile and removing a few flags that cl doesn't understand, but you can replace nmake with whatever you want later by changing these lines in appveyor.yml:
```
  - call "C:\\Program Files (x86)\\%VSINSTALL%\vcvarsall.bat" %platform%
  - cd tests
  - nmake /f Makefile.nmake
```

I don't think travis supports windows, or I would have just used that. travis + appveyor seems to be a common combination on OSS projects for this reason.