### PR TITLE
stb_textedit: remove double initialization

### DIFF
--- a/stb_textedit.h
+++ b/stb_textedit.h
@@ -558,7 +558,6 @@ static void stb_textedit_find_charpos(StbFindState *find, STB_TEXTEDIT_STRING *s
 
    // now scan to find xpos
    find->x = r.x0;
-   i = 0;
    for (i=0; first+i < n; ++i)
       find->x += STB_TEXTEDIT_GETWIDTH(str, first, i);
 }


### PR DESCRIPTION
clang's `scan-build` found this