### PR TITLE
stb_truetype: stbtt_PackFontRanges skip missing glyphs.

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -3967,13 +3967,17 @@ STBTT_DEF int stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, const stb
          int x0,y0,x1,y1;
          int codepoint = ranges[i].array_of_unicode_codepoints == NULL ? ranges[i].first_unicode_codepoint_in_range + j : ranges[i].array_of_unicode_codepoints[j];
          int glyph = stbtt_FindGlyphIndex(info, codepoint);
-         stbtt_GetGlyphBitmapBoxSubpixel(info,glyph,
-                                         scale * spc->h_oversample,
-                                         scale * spc->v_oversample,
-                                         0,0,
-                                         &x0,&y0,&x1,&y1);
-         rects[k].w = (stbrp_coord) (x1-x0 + spc->padding + spc->h_oversample-1);
-         rects[k].h = (stbrp_coord) (y1-y0 + spc->padding + spc->v_oversample-1);
+         if (glyph != 0) {
+            stbtt_GetGlyphBitmapBoxSubpixel(info,glyph,
+                                            scale * spc->h_oversample,
+                                            scale * spc->v_oversample,
+                                            0,0,
+                                            &x0,&y0,&x1,&y1);
+            rects[k].w = (stbrp_coord) (x1-x0 + spc->padding + spc->h_oversample-1);
+            rects[k].h = (stbrp_coord) (y1-y0 + spc->padding + spc->v_oversample-1);
+         } else {
+            rects[k].w = rects[k].h = 0;
+         }
          ++k;
       }
    }
@@ -4026,7 +4030,7 @@ STBTT_DEF int stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, const
       sub_y = stbtt__oversample_shift(spc->v_oversample);
       for (j=0; j < ranges[i].num_chars; ++j) {
          stbrp_rect *r = &rects[k];
-         if (r->was_packed) {
+         if (r->was_packed && r->w != 0 && r->h != 0) {
             stbtt_packedchar *bc = &ranges[i].chardata_for_range[j];
             int advance, lsb, x0,y0,x1,y1;
             int codepoint = ranges[i].array_of_unicode_codepoints == NULL ? ranges[i].first_unicode_codepoint_in_range + j : ranges[i].array_of_unicode_codepoints[j];


### PR DESCRIPTION
The functions used by `stbtt_PackFontRanges()` don't skip glyphs that are missing in the font, which result in packing and rasterizing whatever the "fallback" font glyph is. I am using the word "fallback" but I am not sure I really understand if `stbtt_FindGlyphIndex()` returning 0 could _also_ be a valid glyph. 
See #575 about `stbtt_FindGlyphIndex()` documentation.

If I'm taking "Arial Unicode.ttf" and trying to e.g. 32 to 255, notice the squares about 127:
![image](https://user-images.githubusercontent.com/8225057/39704450-a252b4d2-520b-11e8-8ce3-5f73ed3321fd.png)

Notice they take space in the font atlas:

![image](https://user-images.githubusercontent.com/8225057/39704484-ca291ea6-520b-11e8-98e8-9daa54f73122.png)
(I disabled oversampling here to make this more readable)

While this extraneous space is bearable for a typical ASCII set, when you work with larger sizes, international font ranges, icon font ranges it can be taking more space.

Additionally, this also means that `stbtt_PackFontRanges()` provide no information on whether a character was successfully found/packed/rasterized: from the user's point of view, all of the glyphs packing are successful.

As an explicit problematic case: FontAwesome version 5 (latest version of a very popular icon font) recently started shipping over multiple font files instead of a single one, which makes is more difficult to use those icons by specifying a single font range (as all the fonts files are now sharing the same range, but each individual font file only cover some of the codepoint within that range).

One workaround right now is for the user to call `stbtt_FindGlyphIndex()` and recreate font ranges manually from the input font ranges. It's possible but not really trivial for a casual end-user application, and the number of holes may easily turn a single range into hundreds of ranges (this would be the case for the icon fonts mentioned above).

**PROPOSED SOLUTION**

The proposed PR skips missing glyphs.
This requires the end-user to check that the output `stbtt_packedchar` are valid by testing positions, e.g.

```cpp
            for (int char_idx = 0; char_idx < range.num_chars; char_idx += 1)
            {
                const stbtt_packedchar* pc = &range.chardata_for_range[char_idx];
                if (!pc->x0 && !pc->x1 && !pc->y0 && !pc->y1)
                    continue;
```

This was in theory _already_ required in the past but I think it would only happen on actual packing failure (no room) which arguably is rarer, so it's possible that some code didn't test for it. I don't imagine it to make much of a difference.

Note that the "square" shown in Arial Unicode above is a glyph itself and not all font show something that looks like a square at all.

**HOWEVER**

This is reliant on `stbtt_FindGlyphIndex() == 0` being _always_ an error value. It's unclear to me if some legit glyph could return 0, since the data is being pulled from font files and there are various code paths. I would expect that for something called "index" the value is 0 would be valid, and perhaps `stbtt_FindGlyphIndex()` should/could have be designed to return -1 on error. The only documentation I have is Sean's tweet in #575. I added asserts in `stbtt_FindGlyphIndex()` to verify that non-error return values are != 0 but I'm not hitting all return paths and either way it could depend on the font data. Perhaps `stbtt_FindGlyphIndex()` should be changed to return -1 instead of 0 (and maybe the public facing version would turn -1 into 0 for compatibility?). Or maybe 0 is always an error and then this is a non-issue.

**OPTIONAL?**

Perhaps still should be added as an option? e.g.

```STBTT_DEF void stbtt_PackSetSkipMissingGlyphs(stbtt_pack_context *spc, int skip);```

Which would set a flag in `stbtt_pack_context` and checked by the `stbtt_PackFontRanges**` function?

I'll change the PR to become that if you think it would be better this way. 

( Ref https://github.com/ocornut/imgui/issues/1703 https://github.com/ocornut/imgui/issues/1671 )


Thank you for reading and considering this.