### PR TITLE
stb_sprintf: fix return value to follow libc spec

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -15,6 +15,7 @@
 //    Rohit Nirmal
 //    Marcin Wojdyr
 //    Leonard Ritter
+//    Arvid Gerstmann
 //
 // LICENSE:
 //
@@ -1315,12 +1316,14 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(sprintf)(char *buf, char const *fmt, .
 typedef struct stbsp__context {
    char *buf;
    int count;
+   int length;
    char tmp[STB_SPRINTF_MIN];
 } stbsp__context;
 
 static char *stbsp__clamp_callback(char *buf, void *user, int len)
 {
    stbsp__context *c = (stbsp__context *)user;
+   c->length += len;
 
    if (len > c->count)
       len = c->count;
@@ -1340,7 +1343,7 @@ static char *stbsp__clamp_callback(char *buf, void *user, int len)
    }
 
    if (c->count <= 0)
-      return 0;
+      return c->tmp;
    return (c->count >= STB_SPRINTF_MIN) ? c->buf : c->tmp; // go direct into buffer if you can
 }
 
@@ -1348,29 +1351,27 @@ static char * stbsp__count_clamp_callback( char * buf, void * user, int len )
 {
    stbsp__context * c = (stbsp__context*)user;
 
-   c->count += len;
+   c->length += len;
    return c->tmp; // go direct into buffer if you can
 }
 
 STBSP__PUBLICDEF int STB_SPRINTF_DECORATE( vsnprintf )( char * buf, int count, char const * fmt, va_list va )
 {
    stbsp__context c;
-   int l;
 
    if ( (count == 0) && !buf )
    {
-      c.count = 0;
+      c.length = 0;
 
       STB_SPRINTF_DECORATE( vsprintfcb )( stbsp__count_clamp_callback, &c, c.tmp, fmt, va );
-      l = c.count;
    }
    else
    {
-      if ( count == 0 )
-         return 0;
+      int l;
 
       c.buf = buf;
       c.count = count;
+      c.length = 0;
 
       STB_SPRINTF_DECORATE( vsprintfcb )( stbsp__clamp_callback, &c, stbsp__clamp_callback(0,&c,0), fmt, va );
 
@@ -1381,7 +1382,7 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE( vsnprintf )( char * buf, int count, c
       buf[l] = 0;
    }
 
-   return l;
+   return c.length;
 }
 
 STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(snprintf)(char *buf, int count, char const *fmt, ...)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,14 @@
 INCLUDES = -I..
-CFLAGS = -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast -DSTB_DIVIDE_TEST
-CPPFLAGS = -Wno-write-strings -DSTB_DIVIDE_TEST
+CFLAGS = $(INCLUDES) -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast -DSTB_DIVIDE_TEST -Wall -Wextra -Wstrict-aliasing
+CPPFLAGS = $(INCLUDES) -Wno-write-strings -DSTB_DIVIDE_TEST -Wall -Wextra
 
 all:
-	$(CC) $(INCLUDES) $(CFLAGS) ../stb_vorbis.c test_c_compilation.c -lm
-	$(CC) $(INCLUDES) $(CPPFLAGS) test_cpp_compilation.cpp -lm -lstdc++
+	$(CC) $(CFLAGS) ../stb_vorbis.c test_c_compilation.c -lm
+	$(CC) $(CPPFLAGS) test_cpp_compilation.cpp -lm -lstdc++
+
+sprintf: test_sprintf.o
+	$(CC) $(CFLAGS) $^ -o $@
+
+.PHONY: clean
+clean:
+	rm -f sprintf test_sprintf.o

--- a/tests/test_sprintf.c
+++ b/tests/test_sprintf.c
@@ -1,1 +1,75 @@
+#define STB_SPRINTF_IMPLEMENTATION
 #include "stb_sprintf.h"
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int main()
+{
+    char buf[1024];
+    memset(buf, 0xFF, sizeof(buf));
+    buf[sizeof(buf) - 1] = 0;
+
+    {
+        char const *s = "hello, world";
+        int len = stbsp_snprintf(buf, 1024, s);
+        assert(len == (int)strlen(s));
+        assert(strcmp(buf, s) == 0);
+        len = stbsp_snprintf(NULL, 0, s);
+        assert(len == (int)strlen(s));
+    }
+
+    memset(buf, 0xFF, sizeof(buf));
+    buf[sizeof(buf) - 1] = 0;
+
+    {
+        char const *s = "hello, world";
+        int size = stbsp_snprintf(buf, 8, s);
+        assert(size == (int)strlen(s));
+        assert(strlen(buf) == 7);
+        assert(buf[7] == 0);
+        assert(buf[8] == -1);
+        assert(buf[9] == -1);
+        assert(strncmp(buf, s, strlen(buf)) == 0);
+    }
+
+    memset(buf, 0xFF, sizeof(buf));
+    buf[sizeof(buf) - 1] = 0;
+
+    {
+        char const *s = "hello, world";
+        int size = stbsp_snprintf(buf, 3, "%d", 10000);
+        assert(size == 5);
+        assert(strlen(buf) == 2);
+        assert(buf[0] == '1');
+        assert(buf[1] == '0');
+        assert(buf[2] == '\0');
+        assert(strcmp(buf, "10") == 0);
+
+        size = stbsp_snprintf(buf, 5, "%.*s", (int)strlen(s), s);
+        assert(size == (int)strlen(s));
+        assert(strlen(buf) == 4);
+        assert(strcmp(buf, "hell") == 0);
+    }
+
+    memset(buf, 0xFF, sizeof(buf));
+    buf[sizeof(buf) - 1] = 0;
+
+    {
+        char *lbuf = malloc(2048);
+        int i, size;
+        for (i = 0; i < 2047; ++i)
+            lbuf[i] = 'a';
+        lbuf[2047] = 0;
+
+        size = stbsp_snprintf(buf, 1024, "%s", lbuf);
+        assert(size == (int)strlen(lbuf));
+        assert(strlen(buf) == 1023);
+        assert(strncmp(buf, lbuf, strlen(buf)) == 0);
+    }
+
+    puts("ok");
+    return 0;
+}
+


### PR DESCRIPTION
Pull request to fix #612. This is achieved by simply continuing to write into the temporary buffer, and counting the length in another variable.