### PR TITLE
Optimize stbi  ldr to hdr

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -1623,7 +1623,11 @@ static float   *stbi__ldr_to_hdr(stbi_uc *data, int x, int y, int comp)
       for (k=0; k < n; ++k) {
          output[i*comp + k] = (float) (pow(data[i*comp+k]/255.0f, stbi__l2h_gamma) * stbi__l2h_scale);
       }
-      if (k < comp) output[i*comp + k] = data[i*comp+k]/255.0f;
+   }
+   if (n < comp) {
+      for (i=0; i < x*y; ++i) {
+         output[i*comp + n] = data[i*comp + n]/255.0f;
+      }
    }
    STBI_FREE(data);
    return output;

--- a/stb_image.h
+++ b/stb_image.h
@@ -84,6 +84,7 @@ RECENT REVISION HISTORY:
     Fabian "ryg" Giesen                    Anael Seghezzi (is-16-bit query)
     Arseny Kapoulkine
     John-Mark Allen
+    Carmelo J Fdez-Agüera
 
  Bug & warning fixes
     Marc LeBlanc            David Woo          Guillaume George   Martins Mozeiko


### PR DESCRIPTION
Optimize stbi__ldr_to_ldr.
Break a for loop into two parts, and extract an if out of it #622 
