### PR TITLE
Fix double multiplication by width in write_hdr_core

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -694,7 +694,7 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
       s->func(s->context, buffer, len);
 
       for(i=0; i < y; i++)
-         stbiw__write_hdr_scanline(s, x, comp, scratch, data + comp*x*(stbi__flip_vertically_on_write ? y-1-i : i)*x);
+         stbiw__write_hdr_scanline(s, x, comp, scratch, data + comp*x*(stbi__flip_vertically_on_write ? y-1-i : i));
       STBIW_FREE(scratch);
       return 1;
    }


### PR DESCRIPTION
`stbiw__write_hdr_scanline` was overrunning the buffer due to multiplying by the width twice when calculating the row address.