### PR TITLE
stb_rect_pack: Silence gcc warning by removing always-true assert

### DIFF
--- a/stb_rect_pack.h
+++ b/stb_rect_pack.h
@@ -544,9 +544,6 @@ STBRP_DEF int stbrp_pack_rects(stbrp_context *context, stbrp_rect *rects, int nu
    // we use the 'was_packed' field internally to allow sorting/unsorting
    for (i=0; i < num_rects; ++i) {
       rects[i].was_packed = i;
-      #ifndef STBRP_LARGE_RECTS
-      STBRP_ASSERT(rects[i].w <= 0xffff && rects[i].h <= 0xffff);
-      #endif
    }
 
    // sort according to heuristic


### PR DESCRIPTION
I removed an assert that was always true, since it was just asserting that a value was within its data type's normal numeric limits (a uint16 is always <= 0xffff). The comparison tripped gcc's `-Wtype-limits` warning (also enabled by `-Wextra`).

Related issue: #558.