### PR TITLE
stb_sprintf: fix unaligned access

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -332,7 +332,17 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
             if (callback)
                if ((STB_SPRINTF_MIN - (int)(bf - buf)) < 4)
                   goto schk1;
-            *(stbsp__uint32 *)bf = v;
+            #ifdef STB_SPRINTF_NOUNALIGNED
+                if(((stbsp__uintptr)bf) & 3) {
+                    bf[0] = f[0];
+                    bf[1] = f[1];
+                    bf[2] = f[2];
+                    bf[3] = f[3];
+                } else
+            #endif
+            {
+                *(stbsp__uint32 *)bf = v;
+            }
             bf += 4;
             f += 4;
          }


### PR DESCRIPTION
Fix an unaligned 32-bit access even if STB_SPRINTF_NOUNALIGNED was defined.

STB_SPRINTF_NOUNALIGNED prevented unaligned accesses to the format string but not to the destination buffer.
The bug (and crash) appears only when a sequence of 4 or more chars is to be copied from the format string to the destination buffer, and the current pointer into the format string is aligned, and the current pointer into the destination buffer is not aligned.

Exactly three of the following calls produced an unaligned access to 'buf':

<pre>
#define STB_SPRINTF_IMPLEMENTATION
#define STB_SPRINTF_NOUNALIGNED
#include "stb_sprintf.h"

int main(void) {
    char buf[8];
    stbsp_sprintf(buf + 0, "1234");
    stbsp_sprintf(buf + 1, "1234");
    stbsp_sprintf(buf + 2, "1234");
    stbsp_sprintf(buf + 3, "1234");
}
</pre>

The proposed fix is just the simplest working fix; I have no idea what impact it has on performance since it messes with the innermost loop of the function; however, it has no effect if STB_SPRINTF_NOUNALIGNED is not defined.