### PR TITLE
stb_image_write optimization for faster uncompressed writes with zlib define override

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -923,6 +923,9 @@ unsigned char * stbi_zlib_compress(unsigned char *data, int data_len, int *out_l
 
 static unsigned int stbiw__crc32(unsigned char *buffer, int len)
 {
+#ifdef STBIW_CRC32
+    return STBIW_CRC32(buffer, len);
+#else
    static unsigned int crc_table[256] =
    {
       0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA, 0x076DC419, 0x706AF48F, 0xE963A535, 0x9E6495A3,
@@ -964,6 +967,7 @@ static unsigned int stbiw__crc32(unsigned char *buffer, int len)
    for (i=0; i < len; ++i)
       crc = (crc >> 8) ^ crc_table[buffer[i] ^ (crc & 0xff)];
    return ~crc;
+#endif
 }
 
 #define stbiw__wpng4(o,a,b,c,d) ((o)[0]=STBIW_UCHAR(a),(o)[1]=STBIW_UCHAR(b),(o)[2]=STBIW_UCHAR(c),(o)[3]=STBIW_UCHAR(d),(o)+=4)

--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -998,6 +998,14 @@ static void stbiw__encode_png_line(unsigned char *pixels, int stride_bytes, int 
    int type = mymap[filter_type];
    unsigned char *z = pixels + stride_bytes * (stbi__flip_vertically_on_write ? height-1-y : y);
    int signed_stride = stbi__flip_vertically_on_write ? -stride_bytes : stride_bytes;
+    
+   // sorry for not optimizing the other paths
+   if(type==0)
+   {
+      memcpy(line_buffer, z, width*n);
+      return;
+   }
+    
    for (i = 0; i < n; ++i) {
       switch (type) {
          case 0: line_buffer[i] = z[i]; break;


### PR DESCRIPTION
I've been writing uncompressed PNG files, but I after timing my renders, I noticed that writing the actual files is still slow, even when I use zlib (with STBIW_ZLIB_COMPRESS) and set stbi_write_force_png_filter=0 and stbi_write_png_compression_level=0.  (note that for uncompressed data you want to have zlib 1.2.11, there is a huge performance benefit compared to 1.2.8)

I profiled my use case and most of the time was spent computing crc32 checksums.  stb_image_write's internal crc32 function is pretty oldschool, so I added new define STBIW_CRC32 which makes it possible to override it. zlib's crc32 function is 35x faster, and it is now simple to integrate it if you need the speed.

Another optimization is to skip loops when PNG is encoded with type=0 and just use memcpy.  Doesn't look like the current generation of compilers can optimize the switch case inside for loop, at least Xcode 9 does not do it.

With these changes, my use case (uncompressed PNG, zlib for compression and crc32) is now 4x faster, saving 4 megapixels image is down from 100ms per file to 25ms.