### PR TITLE
Convert stb_vorbis to header-only library

### DIFF
--- a/stb_vorbis.h
+++ b/stb_vorbis.h
@@ -30,14 +30,14 @@
 //    Tom Beaumont       Ingo Leitgeb        Nicolas Guillemot
 //    Phillip Bennefall  Rohit               Thiago Goulart
 //    manxorist@github   saga musix          github:infatum
-//    Timur Gagiev
+//    Timur Gagiev       BareRose
 //
 // Partial history:
 //    1.14    - 2018-02-11 - delete bogus dealloca usage
 //    1.13    - 2018-01-29 - fix truncation of last frame (hopefully)
 //    1.12    - 2017-11-21 - limit residue begin/end to blocksize/2 to avoid large temp allocs in bad/corrupt files
 //    1.11    - 2017-07-23 - fix MinGW compilation 
-//    1.10    - 2017-03-03 - more robust seeking; fix negative ilog(); clear error in open_memory
+//    1.10    - 2017-03-03 - more robust seeking; fix negative stbv_ilog(); clear error in open_memory
 //    1.09    - 2016-04-04 - back out 'truncation of last frame' fix from previous version
 //    1.08    - 2016-04-02 - warnings; setup memory leaks; truncation of last frame
 //    1.07    - 2015-01-16 - fixes for crashes on invalid files; warning fixes; const
@@ -64,7 +64,7 @@
 #define STB_VORBIS_INCLUDE_STB_VORBIS_H
 
 #if defined(STB_VORBIS_NO_CRT) && !defined(STB_VORBIS_NO_STDIO)
-#define STB_VORBIS_NO_STDIO 1
+#define STB_VORBIS_NO_STDIO
 #endif
 
 #ifndef STB_VORBIS_NO_STDIO
@@ -73,6 +73,12 @@
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+#ifdef STB_VORBIS_STATIC
+#define STBVDEF static
+#else
+#define STBVDEF extern
 #endif
 
 ///////////   THREAD SAFETY
@@ -90,8 +96,8 @@ extern "C" {
 // data in the file and how you set the compile flags for speed
 // vs. size. In my test files the maximal-size usage is ~150KB.)
 //
-// You can modify the wrapper functions in the source (setup_malloc,
-// setup_temp_malloc, temp_malloc) to change this behavior, or you
+// You can modify the wrapper functions in the source (stbv_setup_malloc,
+// stbv_setup_temp_malloc, temp_malloc) to change this behavior, or you
 // can use a simpler allocation model: you pass in a buffer from
 // which stb_vorbis will allocate _all_ its memory (including the
 // temp memory). "open" may fail with a VORBIS_outofmem if you
@@ -128,24 +134,24 @@ typedef struct
 } stb_vorbis_info;
 
 // get general information about the file
-extern stb_vorbis_info stb_vorbis_get_info(stb_vorbis *f);
+STBVDEF stb_vorbis_info stb_vorbis_get_info(stb_vorbis *f);
 
 // get the last error detected (clears it, too)
-extern int stb_vorbis_get_error(stb_vorbis *f);
+STBVDEF int stb_vorbis_get_error(stb_vorbis *f);
 
 // close an ogg vorbis file and free all memory in use
-extern void stb_vorbis_close(stb_vorbis *f);
+STBVDEF void stb_vorbis_close(stb_vorbis *f);
 
 // this function returns the offset (in samples) from the beginning of the
 // file that will be returned by the next decode, if it is known, or -1
 // otherwise. after a flush_pushdata() call, this may take a while before
 // it becomes valid again.
 // NOT WORKING YET after a seek with PULLDATA API
-extern int stb_vorbis_get_sample_offset(stb_vorbis *f);
+STBVDEF int stb_vorbis_get_sample_offset(stb_vorbis *f);
 
 // returns the current seek point within the file, or offset from the beginning
 // of the memory buffer. In pushdata mode it returns 0.
-extern unsigned int stb_vorbis_get_file_offset(stb_vorbis *f);
+STBVDEF unsigned int stb_vorbis_get_file_offset(stb_vorbis *f);
 
 ///////////   PUSHDATA API
 
@@ -158,7 +164,7 @@ extern unsigned int stb_vorbis_get_file_offset(stb_vorbis *f);
 // need to give it the same data again PLUS more. Note that the Vorbis
 // specification does not bound the size of an individual frame.
 
-extern stb_vorbis *stb_vorbis_open_pushdata(
+STBVDEF stb_vorbis *stb_vorbis_open_pushdata(
          const unsigned char * datablock, int datablock_length_in_bytes,
          int *datablock_memory_consumed_in_bytes,
          int *error,
@@ -172,7 +178,7 @@ extern stb_vorbis *stb_vorbis_open_pushdata(
 // if returns NULL and *error is VORBIS_need_more_data, then the input block was
 //       incomplete and you need to pass in a larger block from the start of the file
 
-extern int stb_vorbis_decode_frame_pushdata(
+STBVDEF int stb_vorbis_decode_frame_pushdata(
          stb_vorbis *f,
          const unsigned char *datablock, int datablock_length_in_bytes,
          int *channels,             // place to write number of float * buffers
@@ -202,7 +208,7 @@ extern int stb_vorbis_decode_frame_pushdata(
 // the first channel, and (*output)[1][0] contains the first sample from
 // the second channel.
 
-extern void stb_vorbis_flush_pushdata(stb_vorbis *f);
+STBVDEF void stb_vorbis_flush_pushdata(stb_vorbis *f);
 // inform stb_vorbis that your next datablock will not be contiguous with
 // previous ones (e.g. you've seeked in the data); future attempts to decode
 // frames will cause stb_vorbis to resynchronize (as noted above), and
@@ -227,28 +233,28 @@ extern void stb_vorbis_flush_pushdata(stb_vorbis *f);
 // just want to go ahead and use pushdata.)
 
 #if !defined(STB_VORBIS_NO_STDIO) && !defined(STB_VORBIS_NO_INTEGER_CONVERSION)
-extern int stb_vorbis_decode_filename(const char *filename, int *channels, int *sample_rate, short **output);
+STBVDEF int stb_vorbis_decode_filename(const char *filename, int *channels, int *sample_rate, short **output);
 #endif
-#if !defined(STB_VORBIS_NO_INTEGER_CONVERSION)
-extern int stb_vorbis_decode_memory(const unsigned char *mem, int len, int *channels, int *sample_rate, short **output);
+#ifndef STB_VORBIS_NO_INTEGER_CONVERSION
+STBVDEF int stb_vorbis_decode_memory(const unsigned char *mem, int len, int *channels, int *sample_rate, short **output);
 #endif
 // decode an entire file and output the data interleaved into a malloc()ed
 // buffer stored in *output. The return value is the number of samples
 // decoded, or -1 if the file could not be opened or was not an ogg vorbis file.
 // When you're done with it, just free() the pointer returned in *output.
 
-extern stb_vorbis * stb_vorbis_open_memory(const unsigned char *data, int len,
+STBVDEF stb_vorbis * stb_vorbis_open_memory(const unsigned char *data, int len,
                                   int *error, const stb_vorbis_alloc *alloc_buffer);
 // create an ogg vorbis decoder from an ogg vorbis stream in memory (note
 // this must be the entire stream!). on failure, returns NULL and sets *error
 
 #ifndef STB_VORBIS_NO_STDIO
-extern stb_vorbis * stb_vorbis_open_filename(const char *filename,
+STBVDEF stb_vorbis * stb_vorbis_open_filename(const char *filename,
                                   int *error, const stb_vorbis_alloc *alloc_buffer);
 // create an ogg vorbis decoder from a filename via fopen(). on failure,
 // returns NULL and sets *error (possibly to VORBIS_file_open_failure).
 
-extern stb_vorbis * stb_vorbis_open_file(FILE *f, int close_handle_on_close,
+STBVDEF stb_vorbis * stb_vorbis_open_file(FILE *f, int close_handle_on_close,
                                   int *error, const stb_vorbis_alloc *alloc_buffer);
 // create an ogg vorbis decoder from an open FILE *, looking for a stream at
 // the _current_ seek point (ftell). on failure, returns NULL and sets *error.
@@ -258,7 +264,7 @@ extern stb_vorbis * stb_vorbis_open_file(FILE *f, int close_handle_on_close,
 // owns the _entire_ rest of the file after the start point. Use the next
 // function, stb_vorbis_open_file_section(), to limit it.
 
-extern stb_vorbis * stb_vorbis_open_file_section(FILE *f, int close_handle_on_close,
+STBVDEF stb_vorbis * stb_vorbis_open_file_section(FILE *f, int close_handle_on_close,
                 int *error, const stb_vorbis_alloc *alloc_buffer, unsigned int len);
 // create an ogg vorbis decoder from an open FILE *, looking for a stream at
 // the _current_ seek point (ftell); the stream will be of length 'len' bytes.
@@ -267,8 +273,8 @@ extern stb_vorbis * stb_vorbis_open_file_section(FILE *f, int close_handle_on_cl
 // confused.
 #endif
 
-extern int stb_vorbis_seek_frame(stb_vorbis *f, unsigned int sample_number);
-extern int stb_vorbis_seek(stb_vorbis *f, unsigned int sample_number);
+STBVDEF int stb_vorbis_seek_frame(stb_vorbis *f, unsigned int sample_number);
+STBVDEF int stb_vorbis_seek(stb_vorbis *f, unsigned int sample_number);
 // these functions seek in the Vorbis file to (approximately) 'sample_number'.
 // after calling seek_frame(), the next call to get_frame_*() will include
 // the specified sample. after calling stb_vorbis_seek(), the next call to
@@ -276,14 +282,14 @@ extern int stb_vorbis_seek(stb_vorbis *f, unsigned int sample_number);
 // do not need to seek to EXACTLY the target sample when using get_samples_*,
 // you can also use seek_frame().
 
-extern int stb_vorbis_seek_start(stb_vorbis *f);
+STBVDEF int stb_vorbis_seek_start(stb_vorbis *f);
 // this function is equivalent to stb_vorbis_seek(f,0)
 
-extern unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f);
-extern float        stb_vorbis_stream_length_in_seconds(stb_vorbis *f);
+STBVDEF unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f);
+STBVDEF float        stb_vorbis_stream_length_in_seconds(stb_vorbis *f);
 // these functions return the total length of the vorbis stream
 
-extern int stb_vorbis_get_frame_float(stb_vorbis *f, int *channels, float ***output);
+STBVDEF int stb_vorbis_get_frame_float(stb_vorbis *f, int *channels, float ***output);
 // decode the next frame and return the number of samples. the number of
 // channels returned are stored in *channels (which can be NULL--it is always
 // the same as the number of channels reported by get_info). *output will
@@ -294,8 +300,8 @@ extern int stb_vorbis_get_frame_float(stb_vorbis *f, int *channels, float ***out
 // and stb_vorbis_get_samples_*(), since the latter calls the former.
 
 #ifndef STB_VORBIS_NO_INTEGER_CONVERSION
-extern int stb_vorbis_get_frame_short_interleaved(stb_vorbis *f, int num_c, short *buffer, int num_shorts);
-extern int stb_vorbis_get_frame_short            (stb_vorbis *f, int num_c, short **buffer, int num_samples);
+STBVDEF int stb_vorbis_get_frame_short_interleaved(stb_vorbis *f, int num_c, short *buffer, int num_shorts);
+STBVDEF int stb_vorbis_get_frame_short            (stb_vorbis *f, int num_c, short **buffer, int num_samples);
 #endif
 // decode the next frame and return the number of *samples* per channel.
 // Note that for interleaved data, you pass in the number of shorts (the
@@ -322,16 +328,16 @@ extern int stb_vorbis_get_frame_short            (stb_vorbis *f, int num_c, shor
 //    Note that this is not _good_ surround etc. mixing at all! It's just so
 //    you get something useful.
 
-extern int stb_vorbis_get_samples_float_interleaved(stb_vorbis *f, int channels, float *buffer, int num_floats);
-extern int stb_vorbis_get_samples_float(stb_vorbis *f, int channels, float **buffer, int num_samples);
+STBVDEF int stb_vorbis_get_samples_float_interleaved(stb_vorbis *f, int channels, float *buffer, int num_floats);
+STBVDEF int stb_vorbis_get_samples_float(stb_vorbis *f, int channels, float **buffer, int num_samples);
 // gets num_samples samples, not necessarily on a frame boundary--this requires
 // buffering so you have to supply the buffers. DOES NOT APPLY THE COERCION RULES.
 // Returns the number of samples stored per channel; it may be less than requested
 // at the end of the file. If there are no more samples in the file, returns 0.
 
 #ifndef STB_VORBIS_NO_INTEGER_CONVERSION
-extern int stb_vorbis_get_samples_short_interleaved(stb_vorbis *f, int channels, short *buffer, int num_shorts);
-extern int stb_vorbis_get_samples_short(stb_vorbis *f, int channels, short **buffer, int num_samples);
+STBVDEF int stb_vorbis_get_samples_short_interleaved(stb_vorbis *f, int channels, short *buffer, int num_shorts);
+STBVDEF int stb_vorbis_get_samples_short(stb_vorbis *f, int channels, short **buffer, int num_samples);
 #endif
 // gets num_samples samples, not necessarily on a frame boundary--this requires
 // buffering so you have to supply the buffers. Applies the coercion rules above
@@ -388,7 +394,7 @@ enum STBVorbisError
 //
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef STB_VORBIS_HEADER_ONLY
+#ifdef STB_VORBIS_IMPLEMENTATION
 
 // global configuration settings (e.g. set these in the project/makefile),
 // or just set them in this file at the top (although ideally the first few
@@ -417,7 +423,7 @@ enum STBVorbisError
 // STB_VORBIS_NO_FAST_SCALED_FLOAT
 //      does not use a fast float-to-int trick to accelerate float-to-int on
 //      most platforms which requires endianness be defined correctly.
-//#define STB_VORBIS_NO_FAST_SCALED_FLOAT
+// #define STB_VORBIS_NO_FAST_SCALED_FLOAT
 
 
 // STB_VORBIS_MAX_CHANNELS [number]
@@ -581,7 +587,9 @@ enum STBVorbisError
    #undef __forceinline
    #endif
    #define __forceinline
-   #define alloca __builtin_alloca
+   #ifndef alloca
+   #define alloca(s) __builtin_alloca(s)
+   #endif
 #elif !defined(_MSC_VER)
    #if __GNUC__
       #define __forceinline inline
@@ -601,28 +609,28 @@ enum STBVorbisError
 
 #if 0
 #include <crtdbg.h>
-#define CHECK(f)   _CrtIsValidHeapPointer(f->channel_buffers[1])
+#define STBV_CHECK(f)   _CrtIsValidHeapPointer(f->channel_buffers[1])
 #else
-#define CHECK(f)   ((void) 0)
+#define STBV_CHECK(f)   ((void) 0)
 #endif
 
-#define MAX_BLOCKSIZE_LOG  13   // from specification
-#define MAX_BLOCKSIZE      (1 << MAX_BLOCKSIZE_LOG)
+#define STBV_MAX_BLOCKSIZE_LOG  13   // from specification
+#define STBV_MAX_BLOCKSIZE      (1 << STBV_MAX_BLOCKSIZE_LOG)
 
 
-typedef unsigned char  uint8;
-typedef   signed char   int8;
-typedef unsigned short uint16;
-typedef   signed short  int16;
-typedef unsigned int   uint32;
-typedef   signed int    int32;
+typedef unsigned char  stbv_uint8;
+typedef   signed char  stbv_int8;
+typedef unsigned short stbv_uint16;
+typedef   signed short stbv_int16;
+typedef unsigned int   stbv_uint32;
+typedef   signed int   stbv_int32;
 
 #ifndef TRUE
 #define TRUE 1
 #define FALSE 0
 #endif
 
-typedef float codetype;
+typedef float stbv_codetype;
 
 // @NOTE
 //
@@ -637,113 +645,113 @@ typedef float codetype;
 // the sizes larger--nothing relies on silently truncating etc., nor the
 // order of variables.
 
-#define FAST_HUFFMAN_TABLE_SIZE   (1 << STB_VORBIS_FAST_HUFFMAN_LENGTH)
-#define FAST_HUFFMAN_TABLE_MASK   (FAST_HUFFMAN_TABLE_SIZE - 1)
+#define STBV_FAST_HUFFMAN_TABLE_SIZE   (1 << STB_VORBIS_FAST_HUFFMAN_LENGTH)
+#define STBV_FAST_HUFFMAN_TABLE_MASK   (STBV_FAST_HUFFMAN_TABLE_SIZE - 1)
 
 typedef struct
 {
    int dimensions, entries;
-   uint8 *codeword_lengths;
+   stbv_uint8 *codeword_lengths;
    float  minimum_value;
    float  delta_value;
-   uint8  value_bits;
-   uint8  lookup_type;
-   uint8  sequence_p;
-   uint8  sparse;
-   uint32 lookup_values;
-   codetype *multiplicands;
-   uint32 *codewords;
+   stbv_uint8  value_bits;
+   stbv_uint8  lookup_type;
+   stbv_uint8  sequence_p;
+   stbv_uint8  sparse;
+   stbv_uint32 lookup_values;
+   stbv_codetype *multiplicands;
+   stbv_uint32 *codewords;
    #ifdef STB_VORBIS_FAST_HUFFMAN_SHORT
-    int16  fast_huffman[FAST_HUFFMAN_TABLE_SIZE];
+    stbv_int16  fast_huffman[STBV_FAST_HUFFMAN_TABLE_SIZE];
    #else
-    int32  fast_huffman[FAST_HUFFMAN_TABLE_SIZE];
+    stbv_int32  fast_huffman[STBV_FAST_HUFFMAN_TABLE_SIZE];
    #endif
-   uint32 *sorted_codewords;
+   stbv_uint32 *sorted_codewords;
    int    *sorted_values;
    int     sorted_entries;
-} Codebook;
+} StbvCodebook;
 
 typedef struct
 {
-   uint8 order;
-   uint16 rate;
-   uint16 bark_map_size;
-   uint8 amplitude_bits;
-   uint8 amplitude_offset;
-   uint8 number_of_books;
-   uint8 book_list[16]; // varies
-} Floor0;
+   stbv_uint8 order;
+   stbv_uint16 rate;
+   stbv_uint16 bark_map_size;
+   stbv_uint8 amplitude_bits;
+   stbv_uint8 amplitude_offset;
+   stbv_uint8 number_of_books;
+   stbv_uint8 book_list[16]; // varies
+} StbvFloor0;
 
 typedef struct
 {
-   uint8 partitions;
-   uint8 partition_class_list[32]; // varies
-   uint8 class_dimensions[16]; // varies
-   uint8 class_subclasses[16]; // varies
-   uint8 class_masterbooks[16]; // varies
-   int16 subclass_books[16][8]; // varies
-   uint16 Xlist[31*8+2]; // varies
-   uint8 sorted_order[31*8+2];
-   uint8 neighbors[31*8+2][2];
-   uint8 floor1_multiplier;
-   uint8 rangebits;
+   stbv_uint8 partitions;
+   stbv_uint8 partition_class_list[32]; // varies
+   stbv_uint8 class_dimensions[16]; // varies
+   stbv_uint8 class_subclasses[16]; // varies
+   stbv_uint8 class_masterbooks[16]; // varies
+   stbv_int16 subclass_books[16][8]; // varies
+   stbv_uint16 Xlist[31*8+2]; // varies
+   stbv_uint8 sorted_order[31*8+2];
+   stbv_uint8 stbv_neighbors[31*8+2][2];
+   stbv_uint8 floor1_multiplier;
+   stbv_uint8 rangebits;
    int values;
-} Floor1;
+} StbvFloor1;
 
 typedef union
 {
-   Floor0 floor0;
-   Floor1 floor1;
-} Floor;
+   StbvFloor0 floor0;
+   StbvFloor1 floor1;
+} StbvFloor;
 
 typedef struct
 {
-   uint32 begin, end;
-   uint32 part_size;
-   uint8 classifications;
-   uint8 classbook;
-   uint8 **classdata;
-   int16 (*residue_books)[8];
-} Residue;
+   stbv_uint32 begin, end;
+   stbv_uint32 part_size;
+   stbv_uint8 classifications;
+   stbv_uint8 classbook;
+   stbv_uint8 **classdata;
+   stbv_int16 (*residue_books)[8];
+} StbvResidue;
 
 typedef struct
 {
-   uint8 magnitude;
-   uint8 angle;
-   uint8 mux;
-} MappingChannel;
+   stbv_uint8 magnitude;
+   stbv_uint8 angle;
+   stbv_uint8 mux;
+} StbvMappingChannel;
 
 typedef struct
 {
-   uint16 coupling_steps;
-   MappingChannel *chan;
-   uint8  submaps;
-   uint8  submap_floor[15]; // varies
-   uint8  submap_residue[15]; // varies
-} Mapping;
+   stbv_uint16 coupling_steps;
+   StbvMappingChannel *chan;
+   stbv_uint8  submaps;
+   stbv_uint8  submap_floor[15]; // varies
+   stbv_uint8  submap_residue[15]; // varies
+} StbvMapping;
 
 typedef struct
 {
-   uint8 blockflag;
-   uint8 mapping;
-   uint16 windowtype;
-   uint16 transformtype;
-} Mode;
+   stbv_uint8 blockflag;
+   stbv_uint8 mapping;
+   stbv_uint16 windowtype;
+   stbv_uint16 transformtype;
+} StbvMode;
 
 typedef struct
 {
-   uint32  goal_crc;    // expected crc if match
+   stbv_uint32  goal_crc;    // expected crc if match
    int     bytes_left;  // bytes left in packet
-   uint32  crc_so_far;  // running crc
+   stbv_uint32  crc_so_far;  // running crc
    int     bytes_done;  // bytes processed in _current_ chunk
-   uint32  sample_loc;  // granule pos encoded in page
-} CRCscan;
+   stbv_uint32  sample_loc;  // granule pos encoded in page
+} StbvCRCscan;
 
 typedef struct
 {
-   uint32 page_start, page_end;
-   uint32 last_decoded_sample;
-} ProbedPage;
+   stbv_uint32 page_start, page_end;
+   stbv_uint32 last_decoded_sample;
+} StbvProbedPage;
 
 struct stb_vorbis
 {
@@ -758,21 +766,21 @@ struct stb_vorbis
   // input config
 #ifndef STB_VORBIS_NO_STDIO
    FILE *f;
-   uint32 f_start;
+   stbv_uint32 f_start;
    int close_on_free;
 #endif
 
-   uint8 *stream;
-   uint8 *stream_start;
-   uint8 *stream_end;
+   stbv_uint8 *stream;
+   stbv_uint8 *stream_start;
+   stbv_uint8 *stream_end;
 
-   uint32 stream_len;
+   stbv_uint32 stream_len;
 
-   uint8  push_mode;
+   stbv_uint8  push_mode;
 
-   uint32 first_audio_page_offset;
+   stbv_uint32 first_audio_page_offset;
 
-   ProbedPage p_first, p_last;
+   StbvProbedPage p_first, p_last;
 
   // memory management
    stb_vorbis_alloc alloc;
@@ -789,19 +797,19 @@ struct stb_vorbis
    int blocksize[2];
    int blocksize_0, blocksize_1;
    int codebook_count;
-   Codebook *codebooks;
+   StbvCodebook *codebooks;
    int floor_count;
-   uint16 floor_types[64]; // varies
-   Floor *floor_config;
+   stbv_uint16 floor_types[64]; // varies
+   StbvFloor *floor_config;
    int residue_count;
-   uint16 residue_types[64]; // varies
-   Residue *residue_config;
+   stbv_uint16 residue_types[64]; // varies
+   StbvResidue *residue_config;
    int mapping_count;
-   Mapping *mapping;
+   StbvMapping *mapping;
    int mode_count;
-   Mode mode_config[64];  // varies
+   StbvMode mode_config[64];  // varies
 
-   uint32 total_samples;
+   stbv_uint32 total_samples;
 
   // decode buffer
    float *channel_buffers[STB_VORBIS_MAX_CHANNELS];
@@ -811,12 +819,12 @@ struct stb_vorbis
    int previous_length;
 
    #ifndef STB_VORBIS_NO_DEFER_FLOOR
-   int16 *finalY[STB_VORBIS_MAX_CHANNELS];
+   stbv_int16 *finalY[STB_VORBIS_MAX_CHANNELS];
    #else
    float *floor_buffers[STB_VORBIS_MAX_CHANNELS];
    #endif
 
-   uint32 current_loc; // sample location of next frame to decode
+   stbv_uint32 current_loc; // sample location of next frame to decode
    int    current_loc_valid;
 
   // per-blocksize precomputed data
@@ -824,31 +832,31 @@ struct stb_vorbis
    // twiddle factors
    float *A[2],*B[2],*C[2];
    float *window[2];
-   uint16 *bit_reverse[2];
+   stbv_uint16 *stbv_bit_reverse[2];
 
   // current page/packet/segment streaming info
-   uint32 serial; // stream serial number for verification
+   stbv_uint32 serial; // stream serial number for verification
    int last_page;
    int segment_count;
-   uint8 segments[255];
-   uint8 page_flag;
-   uint8 bytes_in_seg;
-   uint8 first_decode;
+   stbv_uint8 segments[255];
+   stbv_uint8 page_flag;
+   stbv_uint8 bytes_in_seg;
+   stbv_uint8 first_decode;
    int next_seg;
    int last_seg;  // flag that we're on the last segment
    int last_seg_which; // what was the segment number of the last seg?
-   uint32 acc;
+   stbv_uint32 acc;
    int valid_bits;
    int packet_bytes;
    int end_seg_with_known_loc;
-   uint32 known_loc_for_packet;
+   stbv_uint32 known_loc_for_packet;
    int discard_samples_deferred;
-   uint32 samples_output;
+   stbv_uint32 samples_output;
 
   // push mode scanning
    int page_crc_tests; // only in push_mode: number of tests active; -1 if not searching
 #ifndef STB_VORBIS_NO_PUSHDATA_API
-   CRCscan scan[STB_VORBIS_PUSHDATA_CRC_COUNT];
+   StbvCRCscan scan[STB_VORBIS_PUSHDATA_CRC_COUNT];
 #endif
 
   // sample-access
@@ -857,16 +865,16 @@ struct stb_vorbis
 };
 
 #if defined(STB_VORBIS_NO_PUSHDATA_API)
-   #define IS_PUSH_MODE(f)   FALSE
+   #define STBV_IS_PUSH_MODE(f)   FALSE
 #elif defined(STB_VORBIS_NO_PULLDATA_API)
-   #define IS_PUSH_MODE(f)   TRUE
+   #define STBV_IS_PUSH_MODE(f)   TRUE
 #else
-   #define IS_PUSH_MODE(f)   ((f)->push_mode)
+   #define STBV_IS_PUSH_MODE(f)   ((f)->push_mode)
 #endif
 
-typedef struct stb_vorbis vorb;
+typedef struct stb_vorbis stbv_vorb;
 
-static int error(vorb *f, enum STBVorbisError e)
+static int stbv_error(stbv_vorb *f, enum STBVorbisError e)
 {
    f->error = e;
    if (!f->eof && e != VORBIS_need_more_data) {
@@ -881,17 +889,17 @@ static int error(vorb *f, enum STBVorbisError e)
 // alloca(); otherwise, provide a temp buffer and it will
 // allocate out of those.
 
-#define array_size_required(count,size)  (count*(sizeof(void *)+(size)))
+#define stbv_array_size_required(count,size)  (count*(sizeof(void *)+(size)))
 
-#define temp_alloc(f,size)              (f->alloc.alloc_buffer ? setup_temp_malloc(f,size) : alloca(size))
-#define temp_free(f,p)                  0
-#define temp_alloc_save(f)              ((f)->temp_offset)
-#define temp_alloc_restore(f,p)         ((f)->temp_offset = (p))
+#define stbv_temp_alloc(f,size)              (f->alloc.alloc_buffer ? stbv_setup_temp_malloc(f,size) : alloca(size))
+#define stbv_temp_free(f,p)                  0
+#define stbv_temp_alloc_save(f)              ((f)->temp_offset)
+#define stbv_temp_alloc_restore(f,p)         ((f)->temp_offset = (p))
 
-#define temp_block_array(f,count,size)  make_block_array(temp_alloc(f,array_size_required(count,size)), count, size)
+#define stbv_temp_block_array(f,count,size)  stbv_make_block_array(stbv_temp_alloc(f,stbv_array_size_required(count,size)), count, size)
 
 // given a sufficiently large block of memory, make an array of pointers to subblocks of it
-static void *make_block_array(void *mem, int count, int size)
+static void *stbv_make_block_array(void *mem, int count, int size)
 {
    int i;
    void ** p = (void **) mem;
@@ -903,7 +911,7 @@ static void *make_block_array(void *mem, int count, int size)
    return p;
 }
 
-static void *setup_malloc(vorb *f, int sz)
+static void *stbv_setup_malloc(stbv_vorb *f, int sz)
 {
    sz = (sz+3) & ~3;
    f->setup_memory_required += sz;
@@ -916,13 +924,13 @@ static void *setup_malloc(vorb *f, int sz)
    return sz ? malloc(sz) : NULL;
 }
 
-static void setup_free(vorb *f, void *p)
+static void stbv_setup_free(stbv_vorb *f, void *p)
 {
    if (f->alloc.alloc_buffer) return; // do nothing; setup mem is a stack
    free(p);
 }
 
-static void *setup_temp_malloc(vorb *f, int sz)
+static void *stbv_setup_temp_malloc(stbv_vorb *f, int sz)
 {
    sz = (sz+3) & ~3;
    if (f->alloc.alloc_buffer) {
@@ -933,7 +941,7 @@ static void *setup_temp_malloc(vorb *f, int sz)
    return malloc(sz);
 }
 
-static void setup_temp_free(vorb *f, void *p, int sz)
+static void stbv_setup_temp_free(stbv_vorb *f, void *p, int sz)
 {
    if (f->alloc.alloc_buffer) {
       f->temp_offset += (sz+3)&~3;
@@ -942,28 +950,28 @@ static void setup_temp_free(vorb *f, void *p, int sz)
    free(p);
 }
 
-#define CRC32_POLY    0x04c11db7   // from spec
+#define STBV_CRC32_POLY    0x04c11db7   // from spec
 
-static uint32 crc_table[256];
-static void crc32_init(void)
+static stbv_uint32 stbv_crc_table[256];
+static void stbv_crc32_init(void)
 {
    int i,j;
-   uint32 s;
+   stbv_uint32 s;
    for(i=0; i < 256; i++) {
-      for (s=(uint32) i << 24, j=0; j < 8; ++j)
-         s = (s << 1) ^ (s >= (1U<<31) ? CRC32_POLY : 0);
-      crc_table[i] = s;
+      for (s=(stbv_uint32) i << 24, j=0; j < 8; ++j)
+         s = (s << 1) ^ (s >= (1U<<31) ? STBV_CRC32_POLY : 0);
+      stbv_crc_table[i] = s;
    }
 }
 
-static __forceinline uint32 crc32_update(uint32 crc, uint8 byte)
+static __forceinline stbv_uint32 stbv_crc32_update(stbv_uint32 crc, stbv_uint8 byte)
 {
-   return (crc << 8) ^ crc_table[byte ^ (crc >> 24)];
+   return (crc << 8) ^ stbv_crc_table[byte ^ (crc >> 24)];
 }
 
 
 // used in setup, and for huffman that doesn't go fast path
-static unsigned int bit_reverse(unsigned int n)
+static unsigned int stbv_bit_reverse(unsigned int n)
 {
   n = ((n & 0xAAAAAAAA) >>  1) | ((n & 0x55555555) << 1);
   n = ((n & 0xCCCCCCCC) >>  2) | ((n & 0x33333333) << 2);
@@ -972,7 +980,7 @@ static unsigned int bit_reverse(unsigned int n)
   return (n >> 16) | (n << 16);
 }
 
-static float square(float x)
+static float stbv_square(float x)
 {
    return x*x;
 }
@@ -980,7 +988,7 @@ static float square(float x)
 // this is a weird definition of log2() for which log2(1) = 1, log2(2) = 2, log2(4) = 3
 // as required by the specification. fast(?) implementation from stb.h
 // @OPTIMIZE: called multiple times per-packet with "constants"; move to setup
-static int ilog(int32 n)
+static int stbv_ilog(stbv_int32 n)
 {
    static signed char log2_4[16] = { 0,1,2,2,3,3,3,3,4,4,4,4,4,4,4,4 };
 
@@ -1010,12 +1018,12 @@ static int ilog(int32 n)
 // these functions are only called at setup, and only a few times
 // per file
 
-static float float32_unpack(uint32 x)
+static float stbv_float32_unpack(stbv_uint32 x)
 {
    // from the specification
-   uint32 mantissa = x & 0x1fffff;
-   uint32 sign = x & 0x80000000;
-   uint32 exp = (x & 0x7fe00000) >> 21;
+   stbv_uint32 mantissa = x & 0x1fffff;
+   stbv_uint32 sign = x & 0x80000000;
+   stbv_uint32 exp = (x & 0x7fe00000) >> 21;
    double res = sign ? -(double)mantissa : (double)mantissa;
    return (float) ldexp((float)res, exp-788);
 }
@@ -1028,7 +1036,7 @@ static float float32_unpack(uint32 x)
 // vorbis allows a huffman table with non-sorted lengths. This
 // requires a more sophisticated construction, since symbols in
 // order do not map to huffman codes "in order".
-static void add_entry(Codebook *c, uint32 huff_code, int symbol, int count, int len, uint32 *values)
+static void stbv_add_entry(StbvCodebook *c, stbv_uint32 huff_code, int symbol, int count, int len, stbv_uint32 *values)
 {
    if (!c->sparse) {
       c->codewords      [symbol] = huff_code;
@@ -1039,17 +1047,17 @@ static void add_entry(Codebook *c, uint32 huff_code, int symbol, int count, int 
    }
 }
 
-static int compute_codewords(Codebook *c, uint8 *len, int n, uint32 *values)
+static int stbv_compute_codewords(StbvCodebook *c, stbv_uint8 *len, int n, stbv_uint32 *values)
 {
    int i,k,m=0;
-   uint32 available[32];
+   stbv_uint32 available[32];
 
    memset(available, 0, sizeof(available));
    // find the first entry
    for (k=0; k < n; ++k) if (len[k] < NO_CODE) break;
    if (k == n) { assert(c->sorted_entries == 0); return TRUE; }
    // add to the list
-   add_entry(c, 0, k, m++, len[k], values);
+   stbv_add_entry(c, 0, k, m++, len[k], values);
    // add all available leaves
    for (i=1; i <= len[k]; ++i)
       available[i] = 1U << (32-i);
@@ -1058,7 +1066,7 @@ static int compute_codewords(Codebook *c, uint8 *len, int n, uint32 *values)
    // could probably be combined (except the initial code is 0,
    // and I use 0 in available[] to mean 'empty')
    for (i=k+1; i < n; ++i) {
-      uint32 res;
+      stbv_uint32 res;
       int z = len[i], y;
       if (z == NO_CODE) continue;
       // find lowest available leaf (should always be earliest,
@@ -1072,7 +1080,7 @@ static int compute_codewords(Codebook *c, uint8 *len, int n, uint32 *values)
       res = available[z];
       assert(z >= 0 && z < 32);
       available[z] = 0;
-      add_entry(c, bit_reverse(res), i, m++, len[i], values);
+      stbv_add_entry(c, stbv_bit_reverse(res), i, m++, len[i], values);
       // propogate availability up the tree
       if (z != len[i]) {
          assert(len[i] >= 0 && len[i] < 32);
@@ -1087,10 +1095,10 @@ static int compute_codewords(Codebook *c, uint8 *len, int n, uint32 *values)
 
 // accelerated huffman table allows fast O(1) match of all symbols
 // of length <= STB_VORBIS_FAST_HUFFMAN_LENGTH
-static void compute_accelerated_huffman(Codebook *c)
+static void stbv_compute_accelerated_huffman(StbvCodebook *c)
 {
    int i, len;
-   for (i=0; i < FAST_HUFFMAN_TABLE_SIZE; ++i)
+   for (i=0; i < STBV_FAST_HUFFMAN_TABLE_SIZE; ++i)
       c->fast_huffman[i] = -1;
 
    len = c->sparse ? c->sorted_entries : c->entries;
@@ -1099,9 +1107,9 @@ static void compute_accelerated_huffman(Codebook *c)
    #endif
    for (i=0; i < len; ++i) {
       if (c->codeword_lengths[i] <= STB_VORBIS_FAST_HUFFMAN_LENGTH) {
-         uint32 z = c->sparse ? bit_reverse(c->sorted_codewords[i]) : c->codewords[i];
+         stbv_uint32 z = c->sparse ? stbv_bit_reverse(c->sorted_codewords[i]) : c->codewords[i];
          // set table entries for all bit combinations in the higher bits
-         while (z < FAST_HUFFMAN_TABLE_SIZE) {
+         while (z < STBV_FAST_HUFFMAN_TABLE_SIZE) {
              c->fast_huffman[z] = i;
              z += 1 << c->codeword_lengths[i];
          }
@@ -1115,14 +1123,14 @@ static void compute_accelerated_huffman(Codebook *c)
 #define STBV_CDECL
 #endif
 
-static int STBV_CDECL uint32_compare(const void *p, const void *q)
+static int STBV_CDECL stbv_uint32_compare(const void *p, const void *q)
 {
-   uint32 x = * (uint32 *) p;
-   uint32 y = * (uint32 *) q;
+   stbv_uint32 x = * (stbv_uint32 *) p;
+   stbv_uint32 y = * (stbv_uint32 *) q;
    return x < y ? -1 : x > y;
 }
 
-static int include_in_sort(Codebook *c, uint8 len)
+static int stbv_include_in_sort(StbvCodebook *c, stbv_uint8 len)
 {
    if (c->sparse) { assert(len != NO_CODE); return TRUE; }
    if (len == NO_CODE) return FALSE;
@@ -1132,7 +1140,7 @@ static int include_in_sort(Codebook *c, uint8 len)
 
 // if the fast table above doesn't work, we want to binary
 // search them... need to reverse the bits
-static void compute_sorted_huffman(Codebook *c, uint8 *lengths, uint32 *values)
+static void stbv_compute_sorted_huffman(StbvCodebook *c, stbv_uint8 *lengths, stbv_uint32 *values)
 {
    int i, len;
    // build a list of all the entries
@@ -1142,15 +1150,15 @@ static void compute_sorted_huffman(Codebook *c, uint8 *lengths, uint32 *values)
    if (!c->sparse) {
       int k = 0;
       for (i=0; i < c->entries; ++i)
-         if (include_in_sort(c, lengths[i])) 
-            c->sorted_codewords[k++] = bit_reverse(c->codewords[i]);
+         if (stbv_include_in_sort(c, lengths[i])) 
+            c->sorted_codewords[k++] = stbv_bit_reverse(c->codewords[i]);
       assert(k == c->sorted_entries);
    } else {
       for (i=0; i < c->sorted_entries; ++i)
-         c->sorted_codewords[i] = bit_reverse(c->codewords[i]);
+         c->sorted_codewords[i] = stbv_bit_reverse(c->codewords[i]);
    }
 
-   qsort(c->sorted_codewords, c->sorted_entries, sizeof(c->sorted_codewords[0]), uint32_compare);
+   qsort(c->sorted_codewords, c->sorted_entries, sizeof(c->sorted_codewords[0]), stbv_uint32_compare);
    c->sorted_codewords[c->sorted_entries] = 0xffffffff;
 
    len = c->sparse ? c->sorted_entries : c->entries;
@@ -1161,8 +1169,8 @@ static void compute_sorted_huffman(Codebook *c, uint8 *lengths, uint32 *values)
    // #1 requires extra storage, #2 is slow, #3 can use binary search!
    for (i=0; i < len; ++i) {
       int huff_len = c->sparse ? lengths[values[i]] : lengths[i];
-      if (include_in_sort(c,huff_len)) {
-         uint32 code = bit_reverse(c->codewords[i]);
+      if (stbv_include_in_sort(c,huff_len)) {
+         stbv_uint32 code = stbv_bit_reverse(c->codewords[i]);
          int x=0, n=c->sorted_entries;
          while (n > 1) {
             // invariant: sc[x] <= code < sc[x+n]
@@ -1186,15 +1194,15 @@ static void compute_sorted_huffman(Codebook *c, uint8 *lengths, uint32 *values)
 }
 
 // only run while parsing the header (3 times)
-static int vorbis_validate(uint8 *data)
+static int stbv_vorbis_validate(stbv_uint8 *data)
 {
-   static uint8 vorbis[6] = { 'v', 'o', 'r', 'b', 'i', 's' };
+   static stbv_uint8 vorbis[6] = { 'v', 'o', 'r', 'b', 'i', 's' };
    return memcmp(data, vorbis, 6) == 0;
 }
 
 // called from setup only, once per code book
 // (formula implied by specification)
-static int lookup1_values(int entries, int dim)
+static int stbv_lookup1_values(int entries, int dim)
 {
    int r = (int) floor(exp((float) log((float) entries) / dim));
    if ((int) floor(pow((float) r+1, dim)) <= entries)   // (int) cast for MinGW warning;
@@ -1205,7 +1213,7 @@ static int lookup1_values(int entries, int dim)
 }
 
 // called twice per file
-static void compute_twiddle_factors(int n, float *A, float *B, float *C)
+static void stbv_compute_twiddle_factors(int n, float *A, float *B, float *C)
 {
    int n4 = n >> 2, n8 = n >> 3;
    int k,k2;
@@ -1222,39 +1230,39 @@ static void compute_twiddle_factors(int n, float *A, float *B, float *C)
    }
 }
 
-static void compute_window(int n, float *window)
+static void stbv_compute_window(int n, float *window)
 {
    int n2 = n >> 1, i;
    for (i=0; i < n2; ++i)
-      window[i] = (float) sin(0.5 * M_PI * square((float) sin((i - 0 + 0.5) / n2 * 0.5 * M_PI)));
+      window[i] = (float) sin(0.5 * M_PI * stbv_square((float) sin((i - 0 + 0.5) / n2 * 0.5 * M_PI)));
 }
 
-static void compute_bitreverse(int n, uint16 *rev)
+static void stbv_compute_bitreverse(int n, stbv_uint16 *rev)
 {
-   int ld = ilog(n) - 1; // ilog is off-by-one from normal definitions
+   int ld = stbv_ilog(n) - 1; // stbv_ilog is off-by-one from normal definitions
    int i, n8 = n >> 3;
    for (i=0; i < n8; ++i)
-      rev[i] = (bit_reverse(i) >> (32-ld+3)) << 2;
+      rev[i] = (stbv_bit_reverse(i) >> (32-ld+3)) << 2;
 }
 
-static int init_blocksize(vorb *f, int b, int n)
+static int stbv_init_blocksize(stbv_vorb *f, int b, int n)
 {
    int n2 = n >> 1, n4 = n >> 2, n8 = n >> 3;
-   f->A[b] = (float *) setup_malloc(f, sizeof(float) * n2);
-   f->B[b] = (float *) setup_malloc(f, sizeof(float) * n2);
-   f->C[b] = (float *) setup_malloc(f, sizeof(float) * n4);
-   if (!f->A[b] || !f->B[b] || !f->C[b]) return error(f, VORBIS_outofmem);
-   compute_twiddle_factors(n, f->A[b], f->B[b], f->C[b]);
-   f->window[b] = (float *) setup_malloc(f, sizeof(float) * n2);
-   if (!f->window[b]) return error(f, VORBIS_outofmem);
-   compute_window(n, f->window[b]);
-   f->bit_reverse[b] = (uint16 *) setup_malloc(f, sizeof(uint16) * n8);
-   if (!f->bit_reverse[b]) return error(f, VORBIS_outofmem);
-   compute_bitreverse(n, f->bit_reverse[b]);
+   f->A[b] = (float *) stbv_setup_malloc(f, sizeof(float) * n2);
+   f->B[b] = (float *) stbv_setup_malloc(f, sizeof(float) * n2);
+   f->C[b] = (float *) stbv_setup_malloc(f, sizeof(float) * n4);
+   if (!f->A[b] || !f->B[b] || !f->C[b]) return stbv_error(f, VORBIS_outofmem);
+   stbv_compute_twiddle_factors(n, f->A[b], f->B[b], f->C[b]);
+   f->window[b] = (float *) stbv_setup_malloc(f, sizeof(float) * n2);
+   if (!f->window[b]) return stbv_error(f, VORBIS_outofmem);
+   stbv_compute_window(n, f->window[b]);
+   f->stbv_bit_reverse[b] = (stbv_uint16 *) stbv_setup_malloc(f, sizeof(stbv_uint16) * n8);
+   if (!f->stbv_bit_reverse[b]) return stbv_error(f, VORBIS_outofmem);
+   stbv_compute_bitreverse(n, f->stbv_bit_reverse[b]);
    return TRUE;
 }
 
-static void neighbors(uint16 *x, int n, int *plow, int *phigh)
+static void stbv_neighbors(stbv_uint16 *x, int n, int *plow, int *phigh)
 {
    int low = -1;
    int high = 65536;
@@ -1268,13 +1276,13 @@ static void neighbors(uint16 *x, int n, int *plow, int *phigh)
 // this has been repurposed so y is now the original index instead of y
 typedef struct
 {
-   uint16 x,id;
-} stbv__floor_ordering;
+   stbv_uint16 x,id;
+} stbv_floor_ordering;
 
-static int STBV_CDECL point_compare(const void *p, const void *q)
+static int STBV_CDECL stbv_point_compare(const void *p, const void *q)
 {
-   stbv__floor_ordering *a = (stbv__floor_ordering *) p;
-   stbv__floor_ordering *b = (stbv__floor_ordering *) q;
+   stbv_floor_ordering *a = (stbv_floor_ordering *) p;
+   stbv_floor_ordering *b = (stbv_floor_ordering *) q;
    return a->x < b->x ? -1 : a->x > b->x;
 }
 
@@ -1283,14 +1291,14 @@ static int STBV_CDECL point_compare(const void *p, const void *q)
 
 
 #if defined(STB_VORBIS_NO_STDIO)
-   #define USE_MEMORY(z)    TRUE
+   #define STBV_USE_MEMORY(z)    TRUE
 #else
-   #define USE_MEMORY(z)    ((z)->stream)
+   #define STBV_USE_MEMORY(z)    ((z)->stream)
 #endif
 
-static uint8 get8(vorb *z)
+static stbv_uint8 stbv_get8(stbv_vorb *z)
 {
-   if (USE_MEMORY(z)) {
+   if (STBV_USE_MEMORY(z)) {
       if (z->stream >= z->stream_end) { z->eof = TRUE; return 0; }
       return *z->stream++;
    }
@@ -1304,19 +1312,19 @@ static uint8 get8(vorb *z)
    #endif
 }
 
-static uint32 get32(vorb *f)
+static stbv_uint32 stbv_get32(stbv_vorb *f)
 {
-   uint32 x;
-   x = get8(f);
-   x += get8(f) << 8;
-   x += get8(f) << 16;
-   x += (uint32) get8(f) << 24;
+   stbv_uint32 x;
+   x = stbv_get8(f);
+   x += stbv_get8(f) << 8;
+   x += stbv_get8(f) << 16;
+   x += (stbv_uint32) stbv_get8(f) << 24;
    return x;
 }
 
-static int getn(vorb *z, uint8 *data, int n)
+static int stbv_getn(stbv_vorb *z, stbv_uint8 *data, int n)
 {
-   if (USE_MEMORY(z)) {
+   if (STBV_USE_MEMORY(z)) {
       if (z->stream+n > z->stream_end) { z->eof = 1; return 0; }
       memcpy(data, z->stream, n);
       z->stream += n;
@@ -1333,9 +1341,9 @@ static int getn(vorb *z, uint8 *data, int n)
    #endif
 }
 
-static void skip(vorb *z, int n)
+static void stbv_skip(stbv_vorb *z, int n)
 {
-   if (USE_MEMORY(z)) {
+   if (STBV_USE_MEMORY(z)) {
       z->stream += n;
       if (z->stream >= z->stream_end) z->eof = 1;
       return;
@@ -1348,13 +1356,13 @@ static void skip(vorb *z, int n)
    #endif
 }
 
-static int set_file_offset(stb_vorbis *f, unsigned int loc)
+static int stbv_set_file_offset(stb_vorbis *f, unsigned int loc)
 {
    #ifndef STB_VORBIS_NO_PUSHDATA_API
    if (f->push_mode) return 0;
    #endif
    f->eof = 0;
-   if (USE_MEMORY(f)) {
+   if (STBV_USE_MEMORY(f)) {
       if (f->stream_start + loc >= f->stream_end || f->stream_start + loc < f->stream_start) {
          f->stream = f->stream_end;
          f->eof = 1;
@@ -1380,44 +1388,44 @@ static int set_file_offset(stb_vorbis *f, unsigned int loc)
 }
 
 
-static uint8 ogg_page_header[4] = { 0x4f, 0x67, 0x67, 0x53 };
+static stbv_uint8 stbv_ogg_page_header[4] = { 0x4f, 0x67, 0x67, 0x53 };
 
-static int capture_pattern(vorb *f)
+static int stbv_capture_pattern(stbv_vorb *f)
 {
-   if (0x4f != get8(f)) return FALSE;
-   if (0x67 != get8(f)) return FALSE;
-   if (0x67 != get8(f)) return FALSE;
-   if (0x53 != get8(f)) return FALSE;
+   if (0x4f != stbv_get8(f)) return FALSE;
+   if (0x67 != stbv_get8(f)) return FALSE;
+   if (0x67 != stbv_get8(f)) return FALSE;
+   if (0x53 != stbv_get8(f)) return FALSE;
    return TRUE;
 }
 
-#define PAGEFLAG_continued_packet   1
-#define PAGEFLAG_first_page         2
-#define PAGEFLAG_last_page          4
+#define STBV_PAGEFLAG_continued_packet   1
+#define STBV_PAGEFLAG_first_page         2
+#define STBV_PAGEFLAG_last_page          4
 
-static int start_page_no_capturepattern(vorb *f)
+static int stbv_start_page_no_capturepattern(stbv_vorb *f)
 {
-   uint32 loc0,loc1,n;
+   stbv_uint32 loc0,loc1,n;
    // stream structure version
-   if (0 != get8(f)) return error(f, VORBIS_invalid_stream_structure_version);
+   if (0 != stbv_get8(f)) return stbv_error(f, VORBIS_invalid_stream_structure_version);
    // header flag
-   f->page_flag = get8(f);
+   f->page_flag = stbv_get8(f);
    // absolute granule position
-   loc0 = get32(f); 
-   loc1 = get32(f);
+   loc0 = stbv_get32(f); 
+   loc1 = stbv_get32(f);
    // @TODO: validate loc0,loc1 as valid positions?
    // stream serial number -- vorbis doesn't interleave, so discard
-   get32(f);
-   //if (f->serial != get32(f)) return error(f, VORBIS_incorrect_stream_serial_number);
+   stbv_get32(f);
+   //if (f->serial != stbv_get32(f)) return stbv_error(f, VORBIS_incorrect_stream_serial_number);
    // page sequence number
-   n = get32(f);
+   n = stbv_get32(f);
    f->last_page = n;
    // CRC32
-   get32(f);
+   stbv_get32(f);
    // page_segments
-   f->segment_count = get8(f);
-   if (!getn(f, f->segments, f->segment_count))
-      return error(f, VORBIS_unexpected_eof);
+   f->segment_count = stbv_get8(f);
+   if (!stbv_getn(f, f->segments, f->segment_count))
+      return stbv_error(f, VORBIS_unexpected_eof);
    // assume we _don't_ know any the sample position of any segments
    f->end_seg_with_known_loc = -2;
    if (loc0 != ~0U || loc1 != ~0U) {
@@ -1434,7 +1442,7 @@ static int start_page_no_capturepattern(vorb *f)
    }
    if (f->first_decode) {
       int i,len;
-      ProbedPage p;
+      StbvProbedPage p;
       len = 0;
       for (i=0; i < f->segment_count; ++i)
          len += f->segments[i];
@@ -1448,18 +1456,18 @@ static int start_page_no_capturepattern(vorb *f)
    return TRUE;
 }
 
-static int start_page(vorb *f)
+static int stbv_start_page(stbv_vorb *f)
 {
-   if (!capture_pattern(f)) return error(f, VORBIS_missing_capture_pattern);
-   return start_page_no_capturepattern(f);
+   if (!stbv_capture_pattern(f)) return stbv_error(f, VORBIS_missing_capture_pattern);
+   return stbv_start_page_no_capturepattern(f);
 }
 
-static int start_packet(vorb *f)
+static int stbv_start_packet(stbv_vorb *f)
 {
    while (f->next_seg == -1) {
-      if (!start_page(f)) return FALSE;
-      if (f->page_flag & PAGEFLAG_continued_packet)
-         return error(f, VORBIS_continued_packet_flag_invalid);
+      if (!stbv_start_page(f)) return FALSE;
+      if (f->page_flag & STBV_PAGEFLAG_continued_packet)
+         return stbv_error(f, VORBIS_continued_packet_flag_invalid);
    }
    f->last_seg = FALSE;
    f->valid_bits = 0;
@@ -1469,35 +1477,35 @@ static int start_packet(vorb *f)
    return TRUE;
 }
 
-static int maybe_start_packet(vorb *f)
+static int stbv_maybe_start_packet(stbv_vorb *f)
 {
    if (f->next_seg == -1) {
-      int x = get8(f);
+      int x = stbv_get8(f);
       if (f->eof) return FALSE; // EOF at page boundary is not an error!
-      if (0x4f != x      ) return error(f, VORBIS_missing_capture_pattern);
-      if (0x67 != get8(f)) return error(f, VORBIS_missing_capture_pattern);
-      if (0x67 != get8(f)) return error(f, VORBIS_missing_capture_pattern);
-      if (0x53 != get8(f)) return error(f, VORBIS_missing_capture_pattern);
-      if (!start_page_no_capturepattern(f)) return FALSE;
-      if (f->page_flag & PAGEFLAG_continued_packet) {
+      if (0x4f != x      ) return stbv_error(f, VORBIS_missing_capture_pattern);
+      if (0x67 != stbv_get8(f)) return stbv_error(f, VORBIS_missing_capture_pattern);
+      if (0x67 != stbv_get8(f)) return stbv_error(f, VORBIS_missing_capture_pattern);
+      if (0x53 != stbv_get8(f)) return stbv_error(f, VORBIS_missing_capture_pattern);
+      if (!stbv_start_page_no_capturepattern(f)) return FALSE;
+      if (f->page_flag & STBV_PAGEFLAG_continued_packet) {
          // set up enough state that we can read this packet if we want,
          // e.g. during recovery
          f->last_seg = FALSE;
          f->bytes_in_seg = 0;
-         return error(f, VORBIS_continued_packet_flag_invalid);
+         return stbv_error(f, VORBIS_continued_packet_flag_invalid);
       }
    }
-   return start_packet(f);
+   return stbv_start_packet(f);
 }
 
-static int next_segment(vorb *f)
+static int stbv_next_segment(stbv_vorb *f)
 {
    int len;
    if (f->last_seg) return 0;
    if (f->next_seg == -1) {
-      f->last_seg_which = f->segment_count-1; // in case start_page fails
-      if (!start_page(f)) { f->last_seg = 1; return 0; }
-      if (!(f->page_flag & PAGEFLAG_continued_packet)) return error(f, VORBIS_continued_packet_flag_invalid);
+      f->last_seg_which = f->segment_count-1; // in case stbv_start_page fails
+      if (!stbv_start_page(f)) { f->last_seg = 1; return 0; }
+      if (!(f->page_flag & STBV_PAGEFLAG_continued_packet)) return stbv_error(f, VORBIS_continued_packet_flag_invalid);
    }
    len = f->segments[f->next_seg++];
    if (len < 255) {
@@ -1511,52 +1519,52 @@ static int next_segment(vorb *f)
    return len;
 }
 
-#define EOP    (-1)
-#define INVALID_BITS  (-1)
+#define STBV_EOP    (-1)
+#define STBV_INVALID_BITS  (-1)
 
-static int get8_packet_raw(vorb *f)
+static int stbv_get8_packet_raw(stbv_vorb *f)
 {
    if (!f->bytes_in_seg) {  // CLANG!
-      if (f->last_seg) return EOP;
-      else if (!next_segment(f)) return EOP;
+      if (f->last_seg) return STBV_EOP;
+      else if (!stbv_next_segment(f)) return STBV_EOP;
    }
    assert(f->bytes_in_seg > 0);
    --f->bytes_in_seg;
    ++f->packet_bytes;
-   return get8(f);
+   return stbv_get8(f);
 }
 
-static int get8_packet(vorb *f)
+static int stbv_get8_packet(stbv_vorb *f)
 {
-   int x = get8_packet_raw(f);
+   int x = stbv_get8_packet_raw(f);
    f->valid_bits = 0;
    return x;
 }
 
-static void flush_packet(vorb *f)
+static void stbv_flush_packet(stbv_vorb *f)
 {
-   while (get8_packet_raw(f) != EOP);
+   while (stbv_get8_packet_raw(f) != STBV_EOP);
 }
 
 // @OPTIMIZE: this is the secondary bit decoder, so it's probably not as important
 // as the huffman decoder?
-static uint32 get_bits(vorb *f, int n)
+static stbv_uint32 stbv_get_bits(stbv_vorb *f, int n)
 {
-   uint32 z;
+   stbv_uint32 z;
 
    if (f->valid_bits < 0) return 0;
    if (f->valid_bits < n) {
       if (n > 24) {
          // the accumulator technique below would not work correctly in this case
-         z = get_bits(f, 24);
-         z += get_bits(f, n-24) << 24;
+         z = stbv_get_bits(f, 24);
+         z += stbv_get_bits(f, n-24) << 24;
          return z;
       }
       if (f->valid_bits == 0) f->acc = 0;
       while (f->valid_bits < n) {
-         int z = get8_packet_raw(f);
-         if (z == EOP) {
-            f->valid_bits = INVALID_BITS;
+         int z = stbv_get8_packet_raw(f);
+         if (z == STBV_EOP) {
+            f->valid_bits = STBV_INVALID_BITS;
             return 0;
          }
          f->acc += z << f->valid_bits;
@@ -1574,15 +1582,15 @@ static uint32 get_bits(vorb *f, int n)
 // expand the buffer to as many bits as possible without reading off end of packet
 // it might be nice to allow f->valid_bits and f->acc to be stored in registers,
 // e.g. cache them locally and decode locally
-static __forceinline void prep_huffman(vorb *f)
+static __forceinline void stbv_prep_huffman(stbv_vorb *f)
 {
    if (f->valid_bits <= 24) {
       if (f->valid_bits == 0) f->acc = 0;
       do {
          int z;
          if (f->last_seg && !f->bytes_in_seg) return;
-         z = get8_packet_raw(f);
-         if (z == EOP) return;
+         z = stbv_get8_packet_raw(f);
+         if (z == STBV_EOP) return;
          f->acc += (unsigned) z << f->valid_bits;
          f->valid_bits += 8;
       } while (f->valid_bits <= 24);
@@ -1591,15 +1599,15 @@ static __forceinline void prep_huffman(vorb *f)
 
 enum
 {
-   VORBIS_packet_id = 1,
-   VORBIS_packet_comment = 3,
-   VORBIS_packet_setup = 5
+   STBV_VORBIS_packet_id = 1,
+   STBV_VORBIS_packet_comment = 3,
+   STBV_VORBIS_packet_setup = 5
 };
 
-static int codebook_decode_scalar_raw(vorb *f, Codebook *c)
+static int stbv_codebook_decode_scalar_raw(stbv_vorb *f, StbvCodebook *c)
 {
    int i;
-   prep_huffman(f);
+   stbv_prep_huffman(f);
 
    if (c->codewords == NULL && c->sorted_codewords == NULL)
       return -1;
@@ -1608,7 +1616,7 @@ static int codebook_decode_scalar_raw(vorb *f, Codebook *c)
    //                             sorted_codewords && c->entries > 8
    if (c->entries > 8 ? c->sorted_codewords!=NULL : !c->codewords) {
       // binary search
-      uint32 code = bit_reverse(f->acc);
+      stbv_uint32 code = stbv_bit_reverse(f->acc);
       int x=0, n=c->sorted_entries, len;
 
       while (n > 1) {
@@ -1650,17 +1658,17 @@ static int codebook_decode_scalar_raw(vorb *f, Codebook *c)
       }
    }
 
-   error(f, VORBIS_invalid_stream);
+   stbv_error(f, VORBIS_invalid_stream);
    f->valid_bits = 0;
    return -1;
 }
 
 #ifndef STB_VORBIS_NO_INLINE_DECODE
 
-#define DECODE_RAW(var, f,c)                                  \
+#define STBV_DECODE_RAW(var, f,c)                                  \
    if (f->valid_bits < STB_VORBIS_FAST_HUFFMAN_LENGTH)        \
-      prep_huffman(f);                                        \
-   var = f->acc & FAST_HUFFMAN_TABLE_MASK;                    \
+      stbv_prep_huffman(f);                                        \
+   var = f->acc & STBV_FAST_HUFFMAN_TABLE_MASK;                    \
    var = c->fast_huffman[var];                                \
    if (var >= 0) {                                            \
       int n = c->codeword_lengths[var];                       \
@@ -1668,18 +1676,18 @@ static int codebook_decode_scalar_raw(vorb *f, Codebook *c)
       f->valid_bits -= n;                                     \
       if (f->valid_bits < 0) { f->valid_bits = 0; var = -1; } \
    } else {                                                   \
-      var = codebook_decode_scalar_raw(f,c);                  \
+      var = stbv_codebook_decode_scalar_raw(f,c);                  \
    }
 
 #else
 
-static int codebook_decode_scalar(vorb *f, Codebook *c)
+static int stbv_codebook_decode_scalar(stbv_vorb *f, StbvCodebook *c)
 {
    int i;
    if (f->valid_bits < STB_VORBIS_FAST_HUFFMAN_LENGTH)
-      prep_huffman(f);
+      stbv_prep_huffman(f);
    // fast huffman table lookup
-   i = f->acc & FAST_HUFFMAN_TABLE_MASK;
+   i = f->acc & STBV_FAST_HUFFMAN_TABLE_MASK;
    i = c->fast_huffman[i];
    if (i >= 0) {
       f->acc >>= c->codeword_lengths[i];
@@ -1687,21 +1695,21 @@ static int codebook_decode_scalar(vorb *f, Codebook *c)
       if (f->valid_bits < 0) { f->valid_bits = 0; return -1; }
       return i;
    }
-   return codebook_decode_scalar_raw(f,c);
+   return stbv_codebook_decode_scalar_raw(f,c);
 }
 
-#define DECODE_RAW(var,f,c)    var = codebook_decode_scalar(f,c);
+#define STBV_DECODE_RAW(var,f,c)    var = stbv_codebook_decode_scalar(f,c);
 
 #endif
 
-#define DECODE(var,f,c)                                       \
-   DECODE_RAW(var,f,c)                                        \
+#define STBV_DECODE(var,f,c)                                       \
+   STBV_DECODE_RAW(var,f,c)                                        \
    if (c->sparse) var = c->sorted_values[var];
 
 #ifndef STB_VORBIS_DIVIDES_IN_CODEBOOK
-  #define DECODE_VQ(var,f,c)   DECODE_RAW(var,f,c)
+  #define DECODE_VQ(var,f,c)   STBV_DECODE_RAW(var,f,c)
 #else
-  #define DECODE_VQ(var,f,c)   DECODE(var,f,c)
+  #define DECODE_VQ(var,f,c)   STBV_DECODE(var,f,c)
 #endif
 
 
@@ -1709,45 +1717,45 @@ static int codebook_decode_scalar(vorb *f, Codebook *c)
 
 
 
-// CODEBOOK_ELEMENT_FAST is an optimization for the CODEBOOK_FLOATS case
+// STBV_CODEBOOK_ELEMENT_FAST is an optimization for the CODEBOOK_FLOATS case
 // where we avoid one addition
-#define CODEBOOK_ELEMENT(c,off)          (c->multiplicands[off])
-#define CODEBOOK_ELEMENT_FAST(c,off)     (c->multiplicands[off])
-#define CODEBOOK_ELEMENT_BASE(c)         (0)
+#define STBV_CODEBOOK_ELEMENT(c,off)          (c->multiplicands[off])
+#define STBV_CODEBOOK_ELEMENT_FAST(c,off)     (c->multiplicands[off])
+#define STBV_CODEBOOK_ELEMENT_BASE(c)         (0)
 
-static int codebook_decode_start(vorb *f, Codebook *c)
+static int stbv_codebook_decode_start(stbv_vorb *f, StbvCodebook *c)
 {
    int z = -1;
 
    // type 0 is only legal in a scalar context
    if (c->lookup_type == 0)
-      error(f, VORBIS_invalid_stream);
+      stbv_error(f, VORBIS_invalid_stream);
    else {
       DECODE_VQ(z,f,c);
       if (c->sparse) assert(z < c->sorted_entries);
-      if (z < 0) {  // check for EOP
+      if (z < 0) {  // check for STBV_EOP
          if (!f->bytes_in_seg)
             if (f->last_seg)
                return z;
-         error(f, VORBIS_invalid_stream);
+         stbv_error(f, VORBIS_invalid_stream);
       }
    }
    return z;
 }
 
-static int codebook_decode(vorb *f, Codebook *c, float *output, int len)
+static int stbv_codebook_decode(stbv_vorb *f, StbvCodebook *c, float *output, int len)
 {
-   int i,z = codebook_decode_start(f,c);
+   int i,z = stbv_codebook_decode_start(f,c);
    if (z < 0) return FALSE;
    if (len > c->dimensions) len = c->dimensions;
 
 #ifdef STB_VORBIS_DIVIDES_IN_CODEBOOK
    if (c->lookup_type == 1) {
-      float last = CODEBOOK_ELEMENT_BASE(c);
+      float last = STBV_CODEBOOK_ELEMENT_BASE(c);
       int div = 1;
       for (i=0; i < len; ++i) {
          int off = (z / div) % c->lookup_values;
-         float val = CODEBOOK_ELEMENT_FAST(c,off) + last;
+         float val = STBV_CODEBOOK_ELEMENT_FAST(c,off) + last;
          output[i] += val;
          if (c->sequence_p) last = val + c->minimum_value;
          div *= c->lookup_values;
@@ -1758,26 +1766,26 @@ static int codebook_decode(vorb *f, Codebook *c, float *output, int len)
 
    z *= c->dimensions;
    if (c->sequence_p) {
-      float last = CODEBOOK_ELEMENT_BASE(c);
+      float last = STBV_CODEBOOK_ELEMENT_BASE(c);
       for (i=0; i < len; ++i) {
-         float val = CODEBOOK_ELEMENT_FAST(c,z+i) + last;
+         float val = STBV_CODEBOOK_ELEMENT_FAST(c,z+i) + last;
          output[i] += val;
          last = val + c->minimum_value;
       }
    } else {
-      float last = CODEBOOK_ELEMENT_BASE(c);
+      float last = STBV_CODEBOOK_ELEMENT_BASE(c);
       for (i=0; i < len; ++i) {
-         output[i] += CODEBOOK_ELEMENT_FAST(c,z+i) + last;
+         output[i] += STBV_CODEBOOK_ELEMENT_FAST(c,z+i) + last;
       }
    }
 
    return TRUE;
 }
 
-static int codebook_decode_step(vorb *f, Codebook *c, float *output, int len, int step)
+static int stbv_codebook_decode_step(stbv_vorb *f, StbvCodebook *c, float *output, int len, int step)
 {
-   int i,z = codebook_decode_start(f,c);
-   float last = CODEBOOK_ELEMENT_BASE(c);
+   int i,z = stbv_codebook_decode_start(f,c);
+   float last = STBV_CODEBOOK_ELEMENT_BASE(c);
    if (z < 0) return FALSE;
    if (len > c->dimensions) len = c->dimensions;
 
@@ -1786,7 +1794,7 @@ static int codebook_decode_step(vorb *f, Codebook *c, float *output, int len, in
       int div = 1;
       for (i=0; i < len; ++i) {
          int off = (z / div) % c->lookup_values;
-         float val = CODEBOOK_ELEMENT_FAST(c,off) + last;
+         float val = STBV_CODEBOOK_ELEMENT_FAST(c,off) + last;
          output[i*step] += val;
          if (c->sequence_p) last = val;
          div *= c->lookup_values;
@@ -1797,7 +1805,7 @@ static int codebook_decode_step(vorb *f, Codebook *c, float *output, int len, in
 
    z *= c->dimensions;
    for (i=0; i < len; ++i) {
-      float val = CODEBOOK_ELEMENT_FAST(c,z+i) + last;
+      float val = STBV_CODEBOOK_ELEMENT_FAST(c,z+i) + last;
       output[i*step] += val;
       if (c->sequence_p) last = val;
    }
@@ -1805,17 +1813,17 @@ static int codebook_decode_step(vorb *f, Codebook *c, float *output, int len, in
    return TRUE;
 }
 
-static int codebook_decode_deinterleave_repeat(vorb *f, Codebook *c, float **outputs, int ch, int *c_inter_p, int *p_inter_p, int len, int total_decode)
+static int stbv_codebook_decode_deinterleave_repeat(stbv_vorb *f, StbvCodebook *c, float **outputs, int ch, int *c_inter_p, int *p_inter_p, int len, int total_decode)
 {
    int c_inter = *c_inter_p;
    int p_inter = *p_inter_p;
    int i,z, effective = c->dimensions;
 
    // type 0 is only legal in a scalar context
-   if (c->lookup_type == 0)   return error(f, VORBIS_invalid_stream);
+   if (c->lookup_type == 0)   return stbv_error(f, VORBIS_invalid_stream);
 
    while (total_decode > 0) {
-      float last = CODEBOOK_ELEMENT_BASE(c);
+      float last = STBV_CODEBOOK_ELEMENT_BASE(c);
       DECODE_VQ(z,f,c);
       #ifndef STB_VORBIS_DIVIDES_IN_CODEBOOK
       assert(!c->sparse || z < c->sorted_entries);
@@ -1823,7 +1831,7 @@ static int codebook_decode_deinterleave_repeat(vorb *f, Codebook *c, float **out
       if (z < 0) {
          if (!f->bytes_in_seg)
             if (f->last_seg) return FALSE;
-         return error(f, VORBIS_invalid_stream);
+         return stbv_error(f, VORBIS_invalid_stream);
       }
 
       // if this will take us off the end of the buffers, stop short!
@@ -1839,7 +1847,7 @@ static int codebook_decode_deinterleave_repeat(vorb *f, Codebook *c, float **out
          int div = 1;
          for (i=0; i < effective; ++i) {
             int off = (z / div) % c->lookup_values;
-            float val = CODEBOOK_ELEMENT_FAST(c,off) + last;
+            float val = STBV_CODEBOOK_ELEMENT_FAST(c,off) + last;
             if (outputs[c_inter])
                outputs[c_inter][p_inter] += val;
             if (++c_inter == ch) { c_inter = 0; ++p_inter; }
@@ -1852,7 +1860,7 @@ static int codebook_decode_deinterleave_repeat(vorb *f, Codebook *c, float **out
          z *= c->dimensions;
          if (c->sequence_p) {
             for (i=0; i < effective; ++i) {
-               float val = CODEBOOK_ELEMENT_FAST(c,z+i) + last;
+               float val = STBV_CODEBOOK_ELEMENT_FAST(c,z+i) + last;
                if (outputs[c_inter])
                   outputs[c_inter][p_inter] += val;
                if (++c_inter == ch) { c_inter = 0; ++p_inter; }
@@ -1860,7 +1868,7 @@ static int codebook_decode_deinterleave_repeat(vorb *f, Codebook *c, float **out
             }
          } else {
             for (i=0; i < effective; ++i) {
-               float val = CODEBOOK_ELEMENT_FAST(c,z+i) + last;
+               float val = STBV_CODEBOOK_ELEMENT_FAST(c,z+i) + last;
                if (outputs[c_inter])
                   outputs[c_inter][p_inter] += val;
                if (++c_inter == ch) { c_inter = 0; ++p_inter; }
@@ -1875,7 +1883,7 @@ static int codebook_decode_deinterleave_repeat(vorb *f, Codebook *c, float **out
    return TRUE;
 }
 
-static int predict_point(int x, int x0, int x1, int y0, int y1)
+static int stbv_predict_point(int x, int x0, int x1, int y0, int y1)
 {
    int dy = y1 - y0;
    int adx = x1 - x0;
@@ -1886,7 +1894,7 @@ static int predict_point(int x, int x0, int x1, int y0, int y1)
 }
 
 // the following table is block-copied from the specification
-static float inverse_db_table[256] =
+static float stbv_inverse_db_table[256] =
 {
   1.0649863e-07f, 1.1341951e-07f, 1.2079015e-07f, 1.2863978e-07f, 
   1.3699951e-07f, 1.4590251e-07f, 1.5538408e-07f, 1.6548181e-07f, 
@@ -1963,18 +1971,18 @@ static float inverse_db_table[256] =
 //     ... also, isn't the whole point of Bresenham's algorithm to NOT
 // have to divide in the setup? sigh.
 #ifndef STB_VORBIS_NO_DEFER_FLOOR
-#define LINE_OP(a,b)   a *= b
+#define STBV_LINE_OP(a,b)   a *= b
 #else
-#define LINE_OP(a,b)   a = b
+#define STBV_LINE_OP(a,b)   a = b
 #endif
 
 #ifdef STB_VORBIS_DIVIDE_TABLE
-#define DIVTAB_NUMER   32
-#define DIVTAB_DENOM   64
-int8 integer_divide_table[DIVTAB_NUMER][DIVTAB_DENOM]; // 2KB
+#define STBV_DIVTAB_NUMER   32
+#define STBV_DIVTAB_DENOM   64
+stbv_int8 stbv_integer_divide_table[STBV_DIVTAB_NUMER][STBV_DIVTAB_DENOM]; // 2KB
 #endif
 
-static __forceinline void draw_line(float *output, int x0, int y0, int x1, int y1, int n)
+static __forceinline void stbv_draw_line(float *output, int x0, int y0, int x1, int y1, int n)
 {
    int dy = y1 - y0;
    int adx = x1 - x0;
@@ -1985,12 +1993,12 @@ static __forceinline void draw_line(float *output, int x0, int y0, int x1, int y
    int sy;
 
 #ifdef STB_VORBIS_DIVIDE_TABLE
-   if (adx < DIVTAB_DENOM && ady < DIVTAB_NUMER) {
+   if (adx < STBV_DIVTAB_DENOM && ady < STBV_DIVTAB_NUMER) {
       if (dy < 0) {
-         base = -integer_divide_table[ady][adx];
+         base = -stbv_integer_divide_table[ady][adx];
          sy = base-1;
       } else {
-         base =  integer_divide_table[ady][adx];
+         base =  stbv_integer_divide_table[ady][adx];
          sy = base+1;
       }
    } else {
@@ -2010,7 +2018,7 @@ static __forceinline void draw_line(float *output, int x0, int y0, int x1, int y
    ady -= abs(base) * adx;
    if (x1 > n) x1 = n;
    if (x < x1) {
-      LINE_OP(output[x], inverse_db_table[y]);
+      STBV_LINE_OP(output[x], stbv_inverse_db_table[y]);
       for (++x; x < x1; ++x) {
          err += ady;
          if (err >= adx) {
@@ -2018,22 +2026,22 @@ static __forceinline void draw_line(float *output, int x0, int y0, int x1, int y
             y += sy;
          } else
             y += base;
-         LINE_OP(output[x], inverse_db_table[y]);
+         STBV_LINE_OP(output[x], stbv_inverse_db_table[y]);
       }
    }
 }
 
-static int residue_decode(vorb *f, Codebook *book, float *target, int offset, int n, int rtype)
+static int stbv_residue_decode(stbv_vorb *f, StbvCodebook *book, float *target, int offset, int n, int rtype)
 {
    int k;
    if (rtype == 0) {
       int step = n / book->dimensions;
       for (k=0; k < step; ++k)
-         if (!codebook_decode_step(f, book, target+offset+k, n-offset-k, step))
+         if (!stbv_codebook_decode_step(f, book, target+offset+k, n-offset-k, step))
             return FALSE;
    } else {
       for (k=0; k < n; ) {
-         if (!codebook_decode(f, book, target+offset, n-k))
+         if (!stbv_codebook_decode(f, book, target+offset, n-k))
             return FALSE;
          k += book->dimensions;
          offset += book->dimensions;
@@ -2044,10 +2052,10 @@ static int residue_decode(vorb *f, Codebook *book, float *target, int offset, in
 
 // n is 1/2 of the blocksize --
 // specification: "Correct per-vector decode length is [n]/2"
-static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int rn, uint8 *do_not_decode)
+static void stbv_decode_residue(stbv_vorb *f, float *residue_buffers[], int ch, int n, int rn, stbv_uint8 *do_not_decode)
 {
    int i,j,pass;
-   Residue *r = f->residue_config + rn;
+   StbvResidue *r = f->residue_config + rn;
    int rtype = f->residue_types[rn];
    int c = r->classbook;
    int classwords = f->codebooks[c].dimensions;
@@ -2056,14 +2064,14 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
    unsigned int limit_r_end   = (r->end   < actual_size ? r->end   : actual_size);
    int n_read = limit_r_end - limit_r_begin;
    int part_read = n_read / r->part_size;
-   int temp_alloc_point = temp_alloc_save(f);
+   int temp_alloc_point = stbv_temp_alloc_save(f);
    #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
-   uint8 ***part_classdata = (uint8 ***) temp_block_array(f,f->channels, part_read * sizeof(**part_classdata));
+   stbv_uint8 ***part_classdata = (stbv_uint8 ***) stbv_temp_block_array(f,f->channels, part_read * sizeof(**part_classdata));
    #else
-   int **classifications = (int **) temp_block_array(f,f->channels, part_read * sizeof(**classifications));
+   int **classifications = (int **) stbv_temp_block_array(f,f->channels, part_read * sizeof(**classifications));
    #endif
 
-   CHECK(f);
+   STBV_CHECK(f);
 
    for (i=0; i < ch; ++i)
       if (!do_not_decode[i])
@@ -2083,10 +2091,10 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
                int z = r->begin + pcount*r->part_size;
                int c_inter = (z & 1), p_inter = z>>1;
                if (pass == 0) {
-                  Codebook *c = f->codebooks+r->classbook;
+                  StbvCodebook *c = f->codebooks+r->classbook;
                   int q;
-                  DECODE(q,f,c);
-                  if (q == EOP) goto done;
+                  STBV_DECODE(q,f,c);
+                  if (q == STBV_EOP) goto done;
                   #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
                   part_classdata[0][class_set] = r->classdata[q];
                   #else
@@ -2105,13 +2113,13 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
                   #endif
                   int b = r->residue_books[c][pass];
                   if (b >= 0) {
-                     Codebook *book = f->codebooks + b;
+                     StbvCodebook *book = f->codebooks + b;
                      #ifdef STB_VORBIS_DIVIDES_IN_CODEBOOK
-                     if (!codebook_decode_deinterleave_repeat(f, book, residue_buffers, ch, &c_inter, &p_inter, n, r->part_size))
+                     if (!stbv_codebook_decode_deinterleave_repeat(f, book, residue_buffers, ch, &c_inter, &p_inter, n, r->part_size))
                         goto done;
                      #else
                      // saves 1%
-                     if (!codebook_decode_deinterleave_repeat(f, book, residue_buffers, ch, &c_inter, &p_inter, n, r->part_size))
+                     if (!stbv_codebook_decode_deinterleave_repeat(f, book, residue_buffers, ch, &c_inter, &p_inter, n, r->part_size))
                         goto done;
                      #endif
                   } else {
@@ -2129,10 +2137,10 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
                int z = r->begin + pcount*r->part_size;
                int c_inter = 0, p_inter = z;
                if (pass == 0) {
-                  Codebook *c = f->codebooks+r->classbook;
+                  StbvCodebook *c = f->codebooks+r->classbook;
                   int q;
-                  DECODE(q,f,c);
-                  if (q == EOP) goto done;
+                  STBV_DECODE(q,f,c);
+                  if (q == STBV_EOP) goto done;
                   #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
                   part_classdata[0][class_set] = r->classdata[q];
                   #else
@@ -2151,8 +2159,8 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
                   #endif
                   int b = r->residue_books[c][pass];
                   if (b >= 0) {
-                     Codebook *book = f->codebooks + b;
-                     if (!codebook_decode_deinterleave_repeat(f, book, residue_buffers, ch, &c_inter, &p_inter, n, r->part_size))
+                     StbvCodebook *book = f->codebooks + b;
+                     if (!stbv_codebook_decode_deinterleave_repeat(f, book, residue_buffers, ch, &c_inter, &p_inter, n, r->part_size))
                         goto done;
                   } else {
                      z += r->part_size;
@@ -2169,10 +2177,10 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
                int z = r->begin + pcount*r->part_size;
                int c_inter = z % ch, p_inter = z/ch;
                if (pass == 0) {
-                  Codebook *c = f->codebooks+r->classbook;
+                  StbvCodebook *c = f->codebooks+r->classbook;
                   int q;
-                  DECODE(q,f,c);
-                  if (q == EOP) goto done;
+                  STBV_DECODE(q,f,c);
+                  if (q == STBV_EOP) goto done;
                   #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
                   part_classdata[0][class_set] = r->classdata[q];
                   #else
@@ -2191,8 +2199,8 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
                   #endif
                   int b = r->residue_books[c][pass];
                   if (b >= 0) {
-                     Codebook *book = f->codebooks + b;
-                     if (!codebook_decode_deinterleave_repeat(f, book, residue_buffers, ch, &c_inter, &p_inter, n, r->part_size))
+                     StbvCodebook *book = f->codebooks + b;
+                     if (!stbv_codebook_decode_deinterleave_repeat(f, book, residue_buffers, ch, &c_inter, &p_inter, n, r->part_size))
                         goto done;
                   } else {
                      z += r->part_size;
@@ -2208,7 +2216,7 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
       }
       goto done;
    }
-   CHECK(f);
+   STBV_CHECK(f);
 
    for (pass=0; pass < 8; ++pass) {
       int pcount = 0, class_set=0;
@@ -2216,10 +2224,10 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
          if (pass == 0) {
             for (j=0; j < ch; ++j) {
                if (!do_not_decode[j]) {
-                  Codebook *c = f->codebooks+r->classbook;
+                  StbvCodebook *c = f->codebooks+r->classbook;
                   int temp;
-                  DECODE(temp,f,c);
-                  if (temp == EOP) goto done;
+                  STBV_DECODE(temp,f,c);
+                  if (temp == STBV_EOP) goto done;
                   #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
                   part_classdata[j][class_set] = r->classdata[temp];
                   #else
@@ -2244,8 +2252,8 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
                      float *target = residue_buffers[j];
                      int offset = r->begin + pcount * r->part_size;
                      int n = r->part_size;
-                     Codebook *book = f->codebooks + b;
-                     if (!residue_decode(f, book, target, offset, n, rtype))
+                     StbvCodebook *book = f->codebooks + b;
+                     if (!stbv_residue_decode(f, book, target, offset, n, rtype))
                         goto done;
                   }
                }
@@ -2257,13 +2265,13 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
       }
    }
   done:
-   CHECK(f);
+   STBV_CHECK(f);
    #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
-   temp_free(f,part_classdata);
+   stbv_temp_free(f,part_classdata);
    #else
-   temp_free(f,classifications);
+   stbv_temp_free(f,classifications);
    #endif
-   temp_alloc_restore(f,temp_alloc_point);
+   stbv_temp_alloc_restore(f,temp_alloc_point);
 }
 
 
@@ -2292,7 +2300,7 @@ void inverse_mdct_slow(float *buffer, int n)
 }
 #elif 0
 // same as above, but just barely able to run in real time on modern machines
-void inverse_mdct_slow(float *buffer, int n, vorb *f, int blocktype)
+void inverse_mdct_slow(float *buffer, int n, stbv_vorb *f, int blocktype)
 {
    float mcos[16384];
    int i,j;
@@ -2330,7 +2338,7 @@ void dct_iv_slow(float *buffer, int n)
    }
 }
 
-void inverse_mdct_slow(float *buffer, int n, vorb *f, int blocktype)
+void inverse_mdct_slow(float *buffer, int n, stbv_vorb *f, int blocktype)
 {
    int i, n4 = n >> 2, n2 = n >> 1, n3_4 = n - n4;
    float temp[4096];
@@ -2368,7 +2376,7 @@ extern void mdct_backward(mdct_lookup *init, float *in, float *out);
 
 mdct_lookup M1,M2;
 
-void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
+void stbv_inverse_mdct(float *buffer, int n, stbv_vorb *f, int blocktype)
 {
    mdct_lookup *M;
    if (M1.n == n) M = &M1;
@@ -2388,7 +2396,7 @@ void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
 // the following were split out into separate functions while optimizing;
 // they could be pushed back up but eh. __forceinline showed no change;
 // they're probably already being inlined.
-static void imdct_step3_iter0_loop(int n, float *e, int i_off, int k_off, float *A)
+static void stbv_imdct_step3_iter0_loop(int n, float *e, int i_off, int k_off, float *A)
 {
    float *ee0 = e + i_off;
    float *ee2 = ee0 + k_off;
@@ -2433,7 +2441,7 @@ static void imdct_step3_iter0_loop(int n, float *e, int i_off, int k_off, float 
    }
 }
 
-static void imdct_step3_inner_r_loop(int lim, float *e, int d0, int k_off, float *A, int k1)
+static void stbv_imdct_step3_inner_r_loop(int lim, float *e, int d0, int k_off, float *A, int k1)
 {
    int i;
    float k00_20, k01_21;
@@ -2483,7 +2491,7 @@ static void imdct_step3_inner_r_loop(int lim, float *e, int d0, int k_off, float
    }
 }
 
-static void imdct_step3_inner_s_loop(int n, float *e, int i_off, int k_off, float *A, int a_off, int k0)
+static void stbv_imdct_step3_inner_s_loop(int n, float *e, int i_off, int k_off, float *A, int a_off, int k0)
 {
    int i;
    float A0 = A[0];
@@ -2534,7 +2542,7 @@ static void imdct_step3_inner_s_loop(int n, float *e, int i_off, int k_off, floa
    }
 }
 
-static __forceinline void iter_54(float *z)
+static __forceinline void stbv_iter_54(float *z)
 {
    float k00,k11,k22,k33;
    float y0,y1,y2,y3;
@@ -2566,7 +2574,7 @@ static __forceinline void iter_54(float *z)
    z[-7] = k11 + k22;    // z1 - z5 - z2 + z6
 }
 
-static void imdct_step3_inner_s_loop_ld654(int n, float *e, int i_off, float *A, int base_n)
+static void stbv_imdct_step3_inner_s_loop_ld654(int n, float *e, int i_off, float *A, int base_n)
 {
    int a_off = base_n >> 3;
    float A2 = A[0+a_off];
@@ -2604,19 +2612,19 @@ static void imdct_step3_inner_s_loop_ld654(int n, float *e, int i_off, float *A,
       z[-14] = (k00+k11) * A2;
       z[-15] = (k00-k11) * A2;
 
-      iter_54(z);
-      iter_54(z-8);
+      stbv_iter_54(z);
+      stbv_iter_54(z-8);
       z -= 16;
    }
 }
 
-static void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
+static void stbv_inverse_mdct(float *buffer, int n, stbv_vorb *f, int blocktype)
 {
    int n2 = n >> 1, n4 = n >> 2, n8 = n >> 3, l;
    int ld;
    // @OPTIMIZE: reduce register pressure by using fewer variables?
-   int save_point = temp_alloc_save(f);
-   float *buf2 = (float *) temp_alloc(f, n2 * sizeof(*buf2));
+   int save_point = stbv_temp_alloc_save(f);
+   float *buf2 = (float *) stbv_temp_alloc(f, n2 * sizeof(*buf2));
    float *u=NULL,*v=NULL;
    // twiddle factors
    float *A = f->A[blocktype];
@@ -2711,7 +2719,7 @@ static void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
    }
 
    // step 3
-   ld = ilog(n) - 1; // ilog is off-by-one from normal definitions
+   ld = stbv_ilog(n) - 1; // stbv_ilog is off-by-one from normal definitions
 
    // optimized step 3:
 
@@ -2721,14 +2729,14 @@ static void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
    // switch between them halfway.
 
    // this is iteration 0 of step 3
-   imdct_step3_iter0_loop(n >> 4, u, n2-1-n4*0, -(n >> 3), A);
-   imdct_step3_iter0_loop(n >> 4, u, n2-1-n4*1, -(n >> 3), A);
+   stbv_imdct_step3_iter0_loop(n >> 4, u, n2-1-n4*0, -(n >> 3), A);
+   stbv_imdct_step3_iter0_loop(n >> 4, u, n2-1-n4*1, -(n >> 3), A);
 
    // this is iteration 1 of step 3
-   imdct_step3_inner_r_loop(n >> 5, u, n2-1 - n8*0, -(n >> 4), A, 16);
-   imdct_step3_inner_r_loop(n >> 5, u, n2-1 - n8*1, -(n >> 4), A, 16);
-   imdct_step3_inner_r_loop(n >> 5, u, n2-1 - n8*2, -(n >> 4), A, 16);
-   imdct_step3_inner_r_loop(n >> 5, u, n2-1 - n8*3, -(n >> 4), A, 16);
+   stbv_imdct_step3_inner_r_loop(n >> 5, u, n2-1 - n8*0, -(n >> 4), A, 16);
+   stbv_imdct_step3_inner_r_loop(n >> 5, u, n2-1 - n8*1, -(n >> 4), A, 16);
+   stbv_imdct_step3_inner_r_loop(n >> 5, u, n2-1 - n8*2, -(n >> 4), A, 16);
+   stbv_imdct_step3_inner_r_loop(n >> 5, u, n2-1 - n8*3, -(n >> 4), A, 16);
 
    l=2;
    for (; l < (ld-3)>>1; ++l) {
@@ -2736,7 +2744,7 @@ static void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
       int lim = 1 << (l+1);
       int i;
       for (i=0; i < lim; ++i)
-         imdct_step3_inner_r_loop(n >> (l+4), u, n2-1 - k0*i, -k0_2, A, 1 << (l+3));
+         stbv_imdct_step3_inner_r_loop(n >> (l+4), u, n2-1 - k0*i, -k0_2, A, 1 << (l+3));
    }
 
    for (; l < ld-6; ++l) {
@@ -2747,7 +2755,7 @@ static void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
       float *A0 = A;
       i_off = n2-1;
       for (r=rlim; r > 0; --r) {
-         imdct_step3_inner_s_loop(lim, u, i_off, -k0_2, A0, k1, k0);
+         stbv_imdct_step3_inner_s_loop(lim, u, i_off, -k0_2, A0, k1, k0);
          A0 += k1*4;
          i_off -= 8;
       }
@@ -2758,14 +2766,14 @@ static void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
    //       the big win comes from getting rid of needless flops
    //         due to the constants on pass 5 & 4 being all 1 and 0;
    //       combining them to be simultaneous to improve cache made little difference
-   imdct_step3_inner_s_loop_ld654(n >> 5, u, n2-1, A, n);
+   stbv_imdct_step3_inner_s_loop_ld654(n >> 5, u, n2-1, A, n);
 
    // output is u
 
    // step 4, 5, and 6
    // cannot be in-place because of step 5
    {
-      uint16 *bitrev = f->bit_reverse[blocktype];
+      stbv_uint16 *bitrev = f->stbv_bit_reverse[blocktype];
       // weirdly, I'd have thought reading sequentially and writing
       // erratically would have been better than vice-versa, but in
       // fact that's not what my testing showed. (That is, with
@@ -2908,8 +2916,8 @@ static void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
       }
    }
 
-   temp_free(f,buf2);
-   temp_alloc_restore(f,save_point);
+   stbv_temp_free(f,buf2);
+   stbv_temp_alloc_restore(f,save_point);
 }
 
 #if 0
@@ -2960,7 +2968,7 @@ void inverse_mdct_naive(float *buffer, int n)
       w[k4+1]    = (v[n2+1+k4] - v[k4+1])*A[n2-4-k4] + (v[n2+3+k4]-v[k4+3])*A[n2-3-k4];
    }
    // step 3
-   ld = ilog(n) - 1; // ilog is off-by-one from normal definitions
+   ld = stbv_ilog(n) - 1; // stbv_ilog is off-by-one from normal definitions
    for (l=0; l < ld-3; ++l) {
       int k0 = n >> (l+2), k1 = 1 << (l+3);
       int rlim = n >> (l+4), r4, r;
@@ -2983,7 +2991,7 @@ void inverse_mdct_naive(float *buffer, int n)
 
    // step 4
    for (i=0; i < n8; ++i) {
-      int j = bit_reverse(i) >> (32-ld+3);
+      int j = stbv_bit_reverse(i) >> (32-ld+3);
       assert(j < n8);
       if (i == j) {
          // paper bug: original code probably swapped in place; if copying,
@@ -3040,7 +3048,7 @@ void inverse_mdct_naive(float *buffer, int n)
 }
 #endif
 
-static float *get_window(vorb *f, int len)
+static float *stbv_get_window(stbv_vorb *f, int len)
 {
    len <<= 1;
    if (len == f->blocksize_0) return f->window[0];
@@ -3050,19 +3058,19 @@ static float *get_window(vorb *f, int len)
 }
 
 #ifndef STB_VORBIS_NO_DEFER_FLOOR
-typedef int16 YTYPE;
+typedef stbv_int16 STBV_YTYPE;
 #else
-typedef int YTYPE;
+typedef int STBV_YTYPE;
 #endif
-static int do_floor(vorb *f, Mapping *map, int i, int n, float *target, YTYPE *finalY, uint8 *step2_flag)
+static int stbv_do_floor(stbv_vorb *f, StbvMapping *map, int i, int n, float *target, STBV_YTYPE *finalY, stbv_uint8 *step2_flag)
 {
    int n2 = n >> 1;
    int s = map->chan[i].mux, floor;
    floor = map->submap_floor[s];
    if (f->floor_types[floor] == 0) {
-      return error(f, VORBIS_invalid_stream);
+      return stbv_error(f, VORBIS_invalid_stream);
    } else {
-      Floor1 *g = &f->floor_config[floor].floor1;
+      StbvFloor1 *g = &f->floor_config[floor].floor1;
       int j,q;
       int lx = 0, ly = finalY[0] * g->floor1_multiplier;
       for (q=1; q < g->values; ++q) {
@@ -3076,16 +3084,16 @@ static int do_floor(vorb *f, Mapping *map, int i, int n, float *target, YTYPE *f
             int hy = finalY[j] * g->floor1_multiplier;
             int hx = g->Xlist[j];
             if (lx != hx)
-               draw_line(target, lx,ly, hx,hy, n2);
-            CHECK(f);
+               stbv_draw_line(target, lx,ly, hx,hy, n2);
+            STBV_CHECK(f);
             lx = hx, ly = hy;
          }
       }
       if (lx < n2) {
-         // optimization of: draw_line(target, lx,ly, n,ly, n2);
+         // optimization of: stbv_draw_line(target, lx,ly, n,ly, n2);
          for (j=lx; j < n2; ++j)
-            LINE_OP(target[j], inverse_db_table[ly]);
-         CHECK(f);
+            STBV_LINE_OP(target[j], stbv_inverse_db_table[ly]);
+         STBV_CHECK(f);
       }
    }
    return TRUE;
@@ -3105,36 +3113,36 @@ static int do_floor(vorb *f, Mapping *map, int i, int n, float *target, YTYPE *f
 //        has to be the same as frame N+1's left_end-left_start (which they are by
 //        construction)
 
-static int vorbis_decode_initial(vorb *f, int *p_left_start, int *p_left_end, int *p_right_start, int *p_right_end, int *mode)
+static int stbv_vorbis_decode_initial(stbv_vorb *f, int *p_left_start, int *p_left_end, int *p_right_start, int *p_right_end, int *mode)
 {
-   Mode *m;
+   StbvMode *m;
    int i, n, prev, next, window_center;
    f->channel_buffer_start = f->channel_buffer_end = 0;
 
   retry:
    if (f->eof) return FALSE;
-   if (!maybe_start_packet(f))
+   if (!stbv_maybe_start_packet(f))
       return FALSE;
    // check packet type
-   if (get_bits(f,1) != 0) {
-      if (IS_PUSH_MODE(f))
-         return error(f,VORBIS_bad_packet_type);
-      while (EOP != get8_packet(f));
+   if (stbv_get_bits(f,1) != 0) {
+      if (STBV_IS_PUSH_MODE(f))
+         return stbv_error(f,VORBIS_bad_packet_type);
+      while (STBV_EOP != stbv_get8_packet(f));
       goto retry;
    }
 
    if (f->alloc.alloc_buffer)
       assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
 
-   i = get_bits(f, ilog(f->mode_count-1));
-   if (i == EOP) return FALSE;
+   i = stbv_get_bits(f, stbv_ilog(f->mode_count-1));
+   if (i == STBV_EOP) return FALSE;
    if (i >= f->mode_count) return FALSE;
    *mode = i;
    m = f->mode_config + i;
    if (m->blockflag) {
       n = f->blocksize_1;
-      prev = get_bits(f,1);
-      next = get_bits(f,1);
+      prev = stbv_get_bits(f,1);
+      next = stbv_get_bits(f,1);
    } else {
       prev = next = 0;
       n = f->blocksize_0;
@@ -3161,9 +3169,9 @@ static int vorbis_decode_initial(vorb *f, int *p_left_start, int *p_left_end, in
    return TRUE;
 }
 
-static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start, int left_end, int right_start, int right_end, int *p_left)
+static int stbv_vorbis_decode_packet_rest(stbv_vorb *f, int *len, StbvMode *m, int left_start, int left_end, int right_start, int right_end, int *p_left)
 {
-   Mapping *map;
+   StbvMapping *map;
    int i,j,k,n,n2;
    int zero_channel[256];
    int really_zero_channel[256];
@@ -3176,25 +3184,25 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
 // FLOORS
    n2 = n >> 1;
 
-   CHECK(f);
+   STBV_CHECK(f);
 
    for (i=0; i < f->channels; ++i) {
       int s = map->chan[i].mux, floor;
       zero_channel[i] = FALSE;
       floor = map->submap_floor[s];
       if (f->floor_types[floor] == 0) {
-         return error(f, VORBIS_invalid_stream);
+         return stbv_error(f, VORBIS_invalid_stream);
       } else {
-         Floor1 *g = &f->floor_config[floor].floor1;
-         if (get_bits(f, 1)) {
+         StbvFloor1 *g = &f->floor_config[floor].floor1;
+         if (stbv_get_bits(f, 1)) {
             short *finalY;
-            uint8 step2_flag[256];
+            stbv_uint8 step2_flag[256];
             static int range_list[4] = { 256, 128, 86, 64 };
             int range = range_list[g->floor1_multiplier-1];
             int offset = 2;
             finalY = f->finalY[i];
-            finalY[0] = get_bits(f, ilog(range)-1);
-            finalY[1] = get_bits(f, ilog(range)-1);
+            finalY[0] = stbv_get_bits(f, stbv_ilog(range)-1);
+            finalY[1] = stbv_get_bits(f, stbv_ilog(range)-1);
             for (j=0; j < g->partitions; ++j) {
                int pclass = g->partition_class_list[j];
                int cdim = g->class_dimensions[pclass];
@@ -3202,29 +3210,29 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
                int csub = (1 << cbits)-1;
                int cval = 0;
                if (cbits) {
-                  Codebook *c = f->codebooks + g->class_masterbooks[pclass];
-                  DECODE(cval,f,c);
+                  StbvCodebook *c = f->codebooks + g->class_masterbooks[pclass];
+                  STBV_DECODE(cval,f,c);
                }
                for (k=0; k < cdim; ++k) {
                   int book = g->subclass_books[pclass][cval & csub];
                   cval = cval >> cbits;
                   if (book >= 0) {
                      int temp;
-                     Codebook *c = f->codebooks + book;
-                     DECODE(temp,f,c);
+                     StbvCodebook *c = f->codebooks + book;
+                     STBV_DECODE(temp,f,c);
                      finalY[offset++] = temp;
                   } else
                      finalY[offset++] = 0;
                }
             }
-            if (f->valid_bits == INVALID_BITS) goto error; // behavior according to spec
+            if (f->valid_bits == STBV_INVALID_BITS) goto error; // behavior according to spec
             step2_flag[0] = step2_flag[1] = 1;
             for (j=2; j < g->values; ++j) {
                int low, high, pred, highroom, lowroom, room, val;
-               low = g->neighbors[j][0];
-               high = g->neighbors[j][1];
-               //neighbors(g->Xlist, j, &low, &high);
-               pred = predict_point(g->Xlist[j], g->Xlist[low], g->Xlist[high], finalY[low], finalY[high]);
+               low = g->stbv_neighbors[j][0];
+               high = g->stbv_neighbors[j][1];
+               //stbv_neighbors(g->Xlist, j, &low, &high);
+               pred = stbv_predict_point(g->Xlist[j], g->Xlist[low], g->Xlist[high], finalY[low], finalY[high]);
                val = finalY[j];
                highroom = range - pred;
                lowroom = pred;
@@ -3252,7 +3260,7 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
             }
 
 #ifdef STB_VORBIS_NO_DEFER_FLOOR
-            do_floor(f, map, i, n, f->floor_buffers[i], finalY, step2_flag);
+            stbv_do_floor(f, map, i, n, f->floor_buffers[i], finalY, step2_flag);
 #else
             // defer final floor computation until _after_ residue
             for (j=0; j < g->values; ++j) {
@@ -3269,7 +3277,7 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
          // at this point we've decoded the floor into buffer
       }
    }
-   CHECK(f);
+   STBV_CHECK(f);
    // at this point we've decoded all floors
 
    if (f->alloc.alloc_buffer)
@@ -3282,12 +3290,12 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
          zero_channel[map->chan[i].magnitude] = zero_channel[map->chan[i].angle] = FALSE;
       }
 
-   CHECK(f);
-// RESIDUE DECODE
+   STBV_CHECK(f);
+// RESIDUE STBV_DECODE
    for (i=0; i < map->submaps; ++i) {
       float *residue_buffers[STB_VORBIS_MAX_CHANNELS];
       int r;
-      uint8 do_not_decode[256];
+      stbv_uint8 do_not_decode[256];
       int ch = 0;
       for (j=0; j < f->channels; ++j) {
          if (map->chan[j].mux == i) {
@@ -3302,12 +3310,12 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
          }
       }
       r = map->submap_residue[i];
-      decode_residue(f, residue_buffers, ch, n2, r, do_not_decode);
+      stbv_decode_residue(f, residue_buffers, ch, n2, r, do_not_decode);
    }
 
    if (f->alloc.alloc_buffer)
       assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
-   CHECK(f);
+   STBV_CHECK(f);
 
 // INVERSE COUPLING
    for (i = map->coupling_steps-1; i >= 0; --i) {
@@ -3330,7 +3338,7 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
          a[j] = a2;
       }
    }
-   CHECK(f);
+   STBV_CHECK(f);
 
    // finish decoding the floors
 #ifndef STB_VORBIS_NO_DEFER_FLOOR
@@ -3338,7 +3346,7 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
       if (really_zero_channel[i]) {
          memset(f->channel_buffers[i], 0, sizeof(*f->channel_buffers[i]) * n2);
       } else {
-         do_floor(f, map, i, n, f->channel_buffers[i], f->finalY[i], NULL);
+         stbv_do_floor(f, map, i, n, f->channel_buffers[i], f->finalY[i], NULL);
       }
    }
 #else
@@ -3353,14 +3361,14 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
 #endif
 
 // INVERSE MDCT
-   CHECK(f);
+   STBV_CHECK(f);
    for (i=0; i < f->channels; ++i)
-      inverse_mdct(f->channel_buffers[i], n, f, m->blockflag);
-   CHECK(f);
+      stbv_inverse_mdct(f->channel_buffers[i], n, f, m->blockflag);
+   STBV_CHECK(f);
 
    // this shouldn't be necessary, unless we exited on an error
    // and want to flush to get to the next packet
-   flush_packet(f);
+   stbv_flush_packet(f);
 
    if (f->first_decode) {
       // assume we start so first non-discarded sample is sample 0
@@ -3395,8 +3403,8 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
    // check if we have ogg information about the sample # for this packet
    if (f->last_seg_which == f->end_seg_with_known_loc) {
       // if we have a valid current loc, and this is final:
-      if (f->current_loc_valid && (f->page_flag & PAGEFLAG_last_page)) {
-         uint32 current_end = f->known_loc_for_packet;
+      if (f->current_loc_valid && (f->page_flag & STBV_PAGEFLAG_last_page)) {
+         stbv_uint32 current_end = f->known_loc_for_packet;
          // then let's infer the size of the (probably) short final frame
          if (current_end < f->current_loc + (right_end-left_start)) {
             if (current_end < f->current_loc) {
@@ -3424,19 +3432,19 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
    if (f->alloc.alloc_buffer)
       assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
    *len = right_end;  // ignore samples after the window goes to 0
-   CHECK(f);
+   STBV_CHECK(f);
 
    return TRUE;
 }
 
-static int vorbis_decode_packet(vorb *f, int *len, int *p_left, int *p_right)
+static int stbv_vorbis_decode_packet(stbv_vorb *f, int *len, int *p_left, int *p_right)
 {
    int mode, left_end, right_end;
-   if (!vorbis_decode_initial(f, p_left, &left_end, p_right, &right_end, &mode)) return 0;
-   return vorbis_decode_packet_rest(f, len, f->mode_config + mode, *p_left, left_end, *p_right, right_end, p_left);
+   if (!stbv_vorbis_decode_initial(f, p_left, &left_end, p_right, &right_end, &mode)) return 0;
+   return stbv_vorbis_decode_packet_rest(f, len, f->mode_config + mode, *p_left, left_end, *p_right, right_end, p_left);
 }
 
-static int vorbis_finish_frame(stb_vorbis *f, int len, int left, int right)
+static int stbv_vorbis_finish_frame(stb_vorbis *f, int len, int left, int right)
 {
    int prev,i,j;
    // we use right&left (the start of the right- and left-window sin()-regions)
@@ -3450,7 +3458,7 @@ static int vorbis_finish_frame(stb_vorbis *f, int len, int left, int right)
    // mixin from previous window
    if (f->previous_length) {
       int i,j, n = f->previous_length;
-      float *w = get_window(f, n);
+      float *w = stbv_get_window(f, n);
       for (i=0; i < f->channels; ++i) {
          for (j=0; j < n; ++j)
             f->channel_buffers[i][left+j] =
@@ -3488,28 +3496,28 @@ static int vorbis_finish_frame(stb_vorbis *f, int len, int left, int right)
    return right - left;
 }
 
-static int vorbis_pump_first_frame(stb_vorbis *f)
+static int stbv_vorbis_pump_first_frame(stb_vorbis *f)
 {
    int len, right, left, res;
-   res = vorbis_decode_packet(f, &len, &left, &right);
+   res = stbv_vorbis_decode_packet(f, &len, &left, &right);
    if (res)
-      vorbis_finish_frame(f, len, left, right);
+      stbv_vorbis_finish_frame(f, len, left, right);
    return res;
 }
 
 #ifndef STB_VORBIS_NO_PUSHDATA_API
-static int is_whole_packet_present(stb_vorbis *f, int end_page)
+static int stbv_is_whole_packet_present(stb_vorbis *f, int end_page)
 {
    // make sure that we have the packet available before continuing...
    // this requires a full ogg parse, but we know we can fetch from f->stream
 
    // instead of coding this out explicitly, we could save the current read state,
-   // read the next packet with get8() until end-of-packet, check f->eof, then
+   // read the next packet with stbv_get8() until end-of-packet, check f->eof, then
    // reset the state? but that would be slower, esp. since we'd have over 256 bytes
    // of state to restore (primarily the page segment table)
 
    int s = f->next_seg, first = TRUE;
-   uint8 *p = f->stream;
+   stbv_uint8 *p = f->stream;
 
    if (s != -1) { // if we're not starting the packet with a 'continue on next page' flag
       for (; s < f->segment_count; ++s) {
@@ -3519,111 +3527,111 @@ static int is_whole_packet_present(stb_vorbis *f, int end_page)
       }
       // either this continues, or it ends it...
       if (end_page)
-         if (s < f->segment_count-1)             return error(f, VORBIS_invalid_stream);
+         if (s < f->segment_count-1)             return stbv_error(f, VORBIS_invalid_stream);
       if (s == f->segment_count)
          s = -1; // set 'crosses page' flag
-      if (p > f->stream_end)                     return error(f, VORBIS_need_more_data);
+      if (p > f->stream_end)                     return stbv_error(f, VORBIS_need_more_data);
       first = FALSE;
    }
    for (; s == -1;) {
-      uint8 *q; 
+      stbv_uint8 *q; 
       int n;
 
       // check that we have the page header ready
-      if (p + 26 >= f->stream_end)               return error(f, VORBIS_need_more_data);
+      if (p + 26 >= f->stream_end)               return stbv_error(f, VORBIS_need_more_data);
       // validate the page
-      if (memcmp(p, ogg_page_header, 4))         return error(f, VORBIS_invalid_stream);
-      if (p[4] != 0)                             return error(f, VORBIS_invalid_stream);
+      if (memcmp(p, stbv_ogg_page_header, 4))         return stbv_error(f, VORBIS_invalid_stream);
+      if (p[4] != 0)                             return stbv_error(f, VORBIS_invalid_stream);
       if (first) { // the first segment must NOT have 'continued_packet', later ones MUST
          if (f->previous_length)
-            if ((p[5] & PAGEFLAG_continued_packet))  return error(f, VORBIS_invalid_stream);
+            if ((p[5] & STBV_PAGEFLAG_continued_packet))  return stbv_error(f, VORBIS_invalid_stream);
          // if no previous length, we're resynching, so we can come in on a continued-packet,
          // which we'll just drop
       } else {
-         if (!(p[5] & PAGEFLAG_continued_packet)) return error(f, VORBIS_invalid_stream);
+         if (!(p[5] & STBV_PAGEFLAG_continued_packet)) return stbv_error(f, VORBIS_invalid_stream);
       }
       n = p[26]; // segment counts
       q = p+27;  // q points to segment table
       p = q + n; // advance past header
       // make sure we've read the segment table
-      if (p > f->stream_end)                     return error(f, VORBIS_need_more_data);
+      if (p > f->stream_end)                     return stbv_error(f, VORBIS_need_more_data);
       for (s=0; s < n; ++s) {
          p += q[s];
          if (q[s] < 255)
             break;
       }
       if (end_page)
-         if (s < n-1)                            return error(f, VORBIS_invalid_stream);
+         if (s < n-1)                            return stbv_error(f, VORBIS_invalid_stream);
       if (s == n)
          s = -1; // set 'crosses page' flag
-      if (p > f->stream_end)                     return error(f, VORBIS_need_more_data);
+      if (p > f->stream_end)                     return stbv_error(f, VORBIS_need_more_data);
       first = FALSE;
    }
    return TRUE;
 }
 #endif // !STB_VORBIS_NO_PUSHDATA_API
 
-static int start_decoder(vorb *f)
+static int stbv_start_decoder(stbv_vorb *f)
 {
-   uint8 header[6], x,y;
+   stbv_uint8 header[6], x,y;
    int len,i,j,k, max_submaps = 0;
    int longest_floorlist=0;
 
    // first page, first packet
 
-   if (!start_page(f))                              return FALSE;
+   if (!stbv_start_page(f))                              return FALSE;
    // validate page flag
-   if (!(f->page_flag & PAGEFLAG_first_page))       return error(f, VORBIS_invalid_first_page);
-   if (f->page_flag & PAGEFLAG_last_page)           return error(f, VORBIS_invalid_first_page);
-   if (f->page_flag & PAGEFLAG_continued_packet)    return error(f, VORBIS_invalid_first_page);
+   if (!(f->page_flag & STBV_PAGEFLAG_first_page))       return stbv_error(f, VORBIS_invalid_first_page);
+   if (f->page_flag & STBV_PAGEFLAG_last_page)           return stbv_error(f, VORBIS_invalid_first_page);
+   if (f->page_flag & STBV_PAGEFLAG_continued_packet)    return stbv_error(f, VORBIS_invalid_first_page);
    // check for expected packet length
-   if (f->segment_count != 1)                       return error(f, VORBIS_invalid_first_page);
-   if (f->segments[0] != 30)                        return error(f, VORBIS_invalid_first_page);
+   if (f->segment_count != 1)                       return stbv_error(f, VORBIS_invalid_first_page);
+   if (f->segments[0] != 30)                        return stbv_error(f, VORBIS_invalid_first_page);
    // read packet
    // check packet header
-   if (get8(f) != VORBIS_packet_id)                 return error(f, VORBIS_invalid_first_page);
-   if (!getn(f, header, 6))                         return error(f, VORBIS_unexpected_eof);
-   if (!vorbis_validate(header))                    return error(f, VORBIS_invalid_first_page);
+   if (stbv_get8(f) != STBV_VORBIS_packet_id)                 return stbv_error(f, VORBIS_invalid_first_page);
+   if (!stbv_getn(f, header, 6))                         return stbv_error(f, VORBIS_unexpected_eof);
+   if (!stbv_vorbis_validate(header))                    return stbv_error(f, VORBIS_invalid_first_page);
    // vorbis_version
-   if (get32(f) != 0)                               return error(f, VORBIS_invalid_first_page);
-   f->channels = get8(f); if (!f->channels)         return error(f, VORBIS_invalid_first_page);
-   if (f->channels > STB_VORBIS_MAX_CHANNELS)       return error(f, VORBIS_too_many_channels);
-   f->sample_rate = get32(f); if (!f->sample_rate)  return error(f, VORBIS_invalid_first_page);
-   get32(f); // bitrate_maximum
-   get32(f); // bitrate_nominal
-   get32(f); // bitrate_minimum
-   x = get8(f);
+   if (stbv_get32(f) != 0)                               return stbv_error(f, VORBIS_invalid_first_page);
+   f->channels = stbv_get8(f); if (!f->channels)         return stbv_error(f, VORBIS_invalid_first_page);
+   if (f->channels > STB_VORBIS_MAX_CHANNELS)       return stbv_error(f, VORBIS_too_many_channels);
+   f->sample_rate = stbv_get32(f); if (!f->sample_rate)  return stbv_error(f, VORBIS_invalid_first_page);
+   stbv_get32(f); // bitrate_maximum
+   stbv_get32(f); // bitrate_nominal
+   stbv_get32(f); // bitrate_minimum
+   x = stbv_get8(f);
    {
       int log0,log1;
       log0 = x & 15;
       log1 = x >> 4;
       f->blocksize_0 = 1 << log0;
       f->blocksize_1 = 1 << log1;
-      if (log0 < 6 || log0 > 13)                       return error(f, VORBIS_invalid_setup);
-      if (log1 < 6 || log1 > 13)                       return error(f, VORBIS_invalid_setup);
-      if (log0 > log1)                                 return error(f, VORBIS_invalid_setup);
+      if (log0 < 6 || log0 > 13)                       return stbv_error(f, VORBIS_invalid_setup);
+      if (log1 < 6 || log1 > 13)                       return stbv_error(f, VORBIS_invalid_setup);
+      if (log0 > log1)                                 return stbv_error(f, VORBIS_invalid_setup);
    }
 
    // framing_flag
-   x = get8(f);
-   if (!(x & 1))                                    return error(f, VORBIS_invalid_first_page);
+   x = stbv_get8(f);
+   if (!(x & 1))                                    return stbv_error(f, VORBIS_invalid_first_page);
 
    // second packet!
-   if (!start_page(f))                              return FALSE;
+   if (!stbv_start_page(f))                              return FALSE;
 
-   if (!start_packet(f))                            return FALSE;
+   if (!stbv_start_packet(f))                            return FALSE;
    do {
-      len = next_segment(f);
-      skip(f, len);
+      len = stbv_next_segment(f);
+      stbv_skip(f, len);
       f->bytes_in_seg = 0;
    } while (len);
 
    // third packet!
-   if (!start_packet(f))                            return FALSE;
+   if (!stbv_start_packet(f))                            return FALSE;
 
    #ifndef STB_VORBIS_NO_PUSHDATA_API
-   if (IS_PUSH_MODE(f)) {
-      if (!is_whole_packet_present(f, TRUE)) {
+   if (STBV_IS_PUSH_MODE(f)) {
+      if (!stbv_is_whole_packet_present(f, TRUE)) {
          // convert error in ogg header to write type
          if (f->error == VORBIS_invalid_stream)
             f->error = VORBIS_invalid_setup;
@@ -3632,64 +3640,64 @@ static int start_decoder(vorb *f)
    }
    #endif
 
-   crc32_init(); // always init it, to avoid multithread race conditions
+   stbv_crc32_init(); // always init it, to avoid multithread race conditions
 
-   if (get8_packet(f) != VORBIS_packet_setup)       return error(f, VORBIS_invalid_setup);
-   for (i=0; i < 6; ++i) header[i] = get8_packet(f);
-   if (!vorbis_validate(header))                    return error(f, VORBIS_invalid_setup);
+   if (stbv_get8_packet(f) != STBV_VORBIS_packet_setup)       return stbv_error(f, VORBIS_invalid_setup);
+   for (i=0; i < 6; ++i) header[i] = stbv_get8_packet(f);
+   if (!stbv_vorbis_validate(header))                    return stbv_error(f, VORBIS_invalid_setup);
 
    // codebooks
 
-   f->codebook_count = get_bits(f,8) + 1;
-   f->codebooks = (Codebook *) setup_malloc(f, sizeof(*f->codebooks) * f->codebook_count);
-   if (f->codebooks == NULL)                        return error(f, VORBIS_outofmem);
+   f->codebook_count = stbv_get_bits(f,8) + 1;
+   f->codebooks = (StbvCodebook *) stbv_setup_malloc(f, sizeof(*f->codebooks) * f->codebook_count);
+   if (f->codebooks == NULL)                        return stbv_error(f, VORBIS_outofmem);
    memset(f->codebooks, 0, sizeof(*f->codebooks) * f->codebook_count);
    for (i=0; i < f->codebook_count; ++i) {
-      uint32 *values;
+      stbv_uint32 *values;
       int ordered, sorted_count;
       int total=0;
-      uint8 *lengths;
-      Codebook *c = f->codebooks+i;
-      CHECK(f);
-      x = get_bits(f, 8); if (x != 0x42)            return error(f, VORBIS_invalid_setup);
-      x = get_bits(f, 8); if (x != 0x43)            return error(f, VORBIS_invalid_setup);
-      x = get_bits(f, 8); if (x != 0x56)            return error(f, VORBIS_invalid_setup);
-      x = get_bits(f, 8);
-      c->dimensions = (get_bits(f, 8)<<8) + x;
-      x = get_bits(f, 8);
-      y = get_bits(f, 8);
-      c->entries = (get_bits(f, 8)<<16) + (y<<8) + x;
-      ordered = get_bits(f,1);
-      c->sparse = ordered ? 0 : get_bits(f,1);
+      stbv_uint8 *lengths;
+      StbvCodebook *c = f->codebooks+i;
+      STBV_CHECK(f);
+      x = stbv_get_bits(f, 8); if (x != 0x42)            return stbv_error(f, VORBIS_invalid_setup);
+      x = stbv_get_bits(f, 8); if (x != 0x43)            return stbv_error(f, VORBIS_invalid_setup);
+      x = stbv_get_bits(f, 8); if (x != 0x56)            return stbv_error(f, VORBIS_invalid_setup);
+      x = stbv_get_bits(f, 8);
+      c->dimensions = (stbv_get_bits(f, 8)<<8) + x;
+      x = stbv_get_bits(f, 8);
+      y = stbv_get_bits(f, 8);
+      c->entries = (stbv_get_bits(f, 8)<<16) + (y<<8) + x;
+      ordered = stbv_get_bits(f,1);
+      c->sparse = ordered ? 0 : stbv_get_bits(f,1);
 
-      if (c->dimensions == 0 && c->entries != 0)    return error(f, VORBIS_invalid_setup);
+      if (c->dimensions == 0 && c->entries != 0)    return stbv_error(f, VORBIS_invalid_setup);
 
       if (c->sparse)
-         lengths = (uint8 *) setup_temp_malloc(f, c->entries);
+         lengths = (stbv_uint8 *) stbv_setup_temp_malloc(f, c->entries);
       else
-         lengths = c->codeword_lengths = (uint8 *) setup_malloc(f, c->entries);
+         lengths = c->codeword_lengths = (stbv_uint8 *) stbv_setup_malloc(f, c->entries);
 
-      if (!lengths) return error(f, VORBIS_outofmem);
+      if (!lengths) return stbv_error(f, VORBIS_outofmem);
 
       if (ordered) {
          int current_entry = 0;
-         int current_length = get_bits(f,5) + 1;
+         int current_length = stbv_get_bits(f,5) + 1;
          while (current_entry < c->entries) {
             int limit = c->entries - current_entry;
-            int n = get_bits(f, ilog(limit));
-            if (current_entry + n > (int) c->entries) { return error(f, VORBIS_invalid_setup); }
+            int n = stbv_get_bits(f, stbv_ilog(limit));
+            if (current_entry + n > (int) c->entries) { return stbv_error(f, VORBIS_invalid_setup); }
             memset(lengths + current_entry, current_length, n);
             current_entry += n;
             ++current_length;
          }
       } else {
          for (j=0; j < c->entries; ++j) {
-            int present = c->sparse ? get_bits(f,1) : 1;
+            int present = c->sparse ? stbv_get_bits(f,1) : 1;
             if (present) {
-               lengths[j] = get_bits(f, 5) + 1;
+               lengths[j] = stbv_get_bits(f, 5) + 1;
                ++total;
                if (lengths[j] == 32)
-                  return error(f, VORBIS_invalid_setup);
+                  return stbv_error(f, VORBIS_invalid_setup);
             } else {
                lengths[j] = NO_CODE;
             }
@@ -3701,10 +3709,10 @@ static int start_decoder(vorb *f)
          if (c->entries > (int) f->setup_temp_memory_required)
             f->setup_temp_memory_required = c->entries;
 
-         c->codeword_lengths = (uint8 *) setup_malloc(f, c->entries);
-         if (c->codeword_lengths == NULL) return error(f, VORBIS_outofmem);
+         c->codeword_lengths = (stbv_uint8 *) stbv_setup_malloc(f, c->entries);
+         if (c->codeword_lengths == NULL) return stbv_error(f, VORBIS_outofmem);
          memcpy(c->codeword_lengths, lengths, c->entries);
-         setup_temp_free(f, lengths, c->entries); // note this is only safe if there have been no intervening temp mallocs!
+         stbv_setup_temp_free(f, lengths, c->entries); // note this is only safe if there have been no intervening temp mallocs!
          lengths = c->codeword_lengths;
          c->sparse = 0;
       }
@@ -3724,72 +3732,72 @@ static int start_decoder(vorb *f)
       c->sorted_entries = sorted_count;
       values = NULL;
 
-      CHECK(f);
+      STBV_CHECK(f);
       if (!c->sparse) {
-         c->codewords = (uint32 *) setup_malloc(f, sizeof(c->codewords[0]) * c->entries);
-         if (!c->codewords)                  return error(f, VORBIS_outofmem);
+         c->codewords = (stbv_uint32 *) stbv_setup_malloc(f, sizeof(c->codewords[0]) * c->entries);
+         if (!c->codewords)                  return stbv_error(f, VORBIS_outofmem);
       } else {
          unsigned int size;
          if (c->sorted_entries) {
-            c->codeword_lengths = (uint8 *) setup_malloc(f, c->sorted_entries);
-            if (!c->codeword_lengths)           return error(f, VORBIS_outofmem);
-            c->codewords = (uint32 *) setup_temp_malloc(f, sizeof(*c->codewords) * c->sorted_entries);
-            if (!c->codewords)                  return error(f, VORBIS_outofmem);
-            values = (uint32 *) setup_temp_malloc(f, sizeof(*values) * c->sorted_entries);
-            if (!values)                        return error(f, VORBIS_outofmem);
+            c->codeword_lengths = (stbv_uint8 *) stbv_setup_malloc(f, c->sorted_entries);
+            if (!c->codeword_lengths)           return stbv_error(f, VORBIS_outofmem);
+            c->codewords = (stbv_uint32 *) stbv_setup_temp_malloc(f, sizeof(*c->codewords) * c->sorted_entries);
+            if (!c->codewords)                  return stbv_error(f, VORBIS_outofmem);
+            values = (stbv_uint32 *) stbv_setup_temp_malloc(f, sizeof(*values) * c->sorted_entries);
+            if (!values)                        return stbv_error(f, VORBIS_outofmem);
          }
          size = c->entries + (sizeof(*c->codewords) + sizeof(*values)) * c->sorted_entries;
          if (size > f->setup_temp_memory_required)
             f->setup_temp_memory_required = size;
       }
 
-      if (!compute_codewords(c, lengths, c->entries, values)) {
-         if (c->sparse) setup_temp_free(f, values, 0);
-         return error(f, VORBIS_invalid_setup);
+      if (!stbv_compute_codewords(c, lengths, c->entries, values)) {
+         if (c->sparse) stbv_setup_temp_free(f, values, 0);
+         return stbv_error(f, VORBIS_invalid_setup);
       }
 
       if (c->sorted_entries) {
          // allocate an extra slot for sentinels
-         c->sorted_codewords = (uint32 *) setup_malloc(f, sizeof(*c->sorted_codewords) * (c->sorted_entries+1));
-         if (c->sorted_codewords == NULL) return error(f, VORBIS_outofmem);
+         c->sorted_codewords = (stbv_uint32 *) stbv_setup_malloc(f, sizeof(*c->sorted_codewords) * (c->sorted_entries+1));
+         if (c->sorted_codewords == NULL) return stbv_error(f, VORBIS_outofmem);
          // allocate an extra slot at the front so that c->sorted_values[-1] is defined
          // so that we can catch that case without an extra if
-         c->sorted_values    = ( int   *) setup_malloc(f, sizeof(*c->sorted_values   ) * (c->sorted_entries+1));
-         if (c->sorted_values == NULL) return error(f, VORBIS_outofmem);
+         c->sorted_values    = ( int   *) stbv_setup_malloc(f, sizeof(*c->sorted_values   ) * (c->sorted_entries+1));
+         if (c->sorted_values == NULL) return stbv_error(f, VORBIS_outofmem);
          ++c->sorted_values;
          c->sorted_values[-1] = -1;
-         compute_sorted_huffman(c, lengths, values);
+         stbv_compute_sorted_huffman(c, lengths, values);
       }
 
       if (c->sparse) {
-         setup_temp_free(f, values, sizeof(*values)*c->sorted_entries);
-         setup_temp_free(f, c->codewords, sizeof(*c->codewords)*c->sorted_entries);
-         setup_temp_free(f, lengths, c->entries);
+         stbv_setup_temp_free(f, values, sizeof(*values)*c->sorted_entries);
+         stbv_setup_temp_free(f, c->codewords, sizeof(*c->codewords)*c->sorted_entries);
+         stbv_setup_temp_free(f, lengths, c->entries);
          c->codewords = NULL;
       }
 
-      compute_accelerated_huffman(c);
+      stbv_compute_accelerated_huffman(c);
 
-      CHECK(f);
-      c->lookup_type = get_bits(f, 4);
-      if (c->lookup_type > 2) return error(f, VORBIS_invalid_setup);
+      STBV_CHECK(f);
+      c->lookup_type = stbv_get_bits(f, 4);
+      if (c->lookup_type > 2) return stbv_error(f, VORBIS_invalid_setup);
       if (c->lookup_type > 0) {
-         uint16 *mults;
-         c->minimum_value = float32_unpack(get_bits(f, 32));
-         c->delta_value = float32_unpack(get_bits(f, 32));
-         c->value_bits = get_bits(f, 4)+1;
-         c->sequence_p = get_bits(f,1);
+         stbv_uint16 *mults;
+         c->minimum_value = stbv_float32_unpack(stbv_get_bits(f, 32));
+         c->delta_value = stbv_float32_unpack(stbv_get_bits(f, 32));
+         c->value_bits = stbv_get_bits(f, 4)+1;
+         c->sequence_p = stbv_get_bits(f,1);
          if (c->lookup_type == 1) {
-            c->lookup_values = lookup1_values(c->entries, c->dimensions);
+            c->lookup_values = stbv_lookup1_values(c->entries, c->dimensions);
          } else {
             c->lookup_values = c->entries * c->dimensions;
          }
-         if (c->lookup_values == 0) return error(f, VORBIS_invalid_setup);
-         mults = (uint16 *) setup_temp_malloc(f, sizeof(mults[0]) * c->lookup_values);
-         if (mults == NULL) return error(f, VORBIS_outofmem);
+         if (c->lookup_values == 0) return stbv_error(f, VORBIS_invalid_setup);
+         mults = (stbv_uint16 *) stbv_setup_temp_malloc(f, sizeof(mults[0]) * c->lookup_values);
+         if (mults == NULL) return stbv_error(f, VORBIS_outofmem);
          for (j=0; j < (int) c->lookup_values; ++j) {
-            int q = get_bits(f, c->value_bits);
-            if (q == EOP) { setup_temp_free(f,mults,sizeof(mults[0])*c->lookup_values); return error(f, VORBIS_invalid_setup); }
+            int q = stbv_get_bits(f, c->value_bits);
+            if (q == STBV_EOP) { stbv_setup_temp_free(f,mults,sizeof(mults[0])*c->lookup_values); return stbv_error(f, VORBIS_invalid_setup); }
             mults[j] = q;
          }
 
@@ -3799,11 +3807,11 @@ static int start_decoder(vorb *f)
             float last=0;
             // pre-expand the lookup1-style multiplicands, to avoid a divide in the inner loop
             if (sparse) {
-               if (c->sorted_entries == 0) goto skip;
-               c->multiplicands = (codetype *) setup_malloc(f, sizeof(c->multiplicands[0]) * c->sorted_entries * c->dimensions);
+               if (c->sorted_entries == 0) goto stbv_skip;
+               c->multiplicands = (stbv_codetype *) stbv_setup_malloc(f, sizeof(c->multiplicands[0]) * c->sorted_entries * c->dimensions);
             } else
-               c->multiplicands = (codetype *) setup_malloc(f, sizeof(c->multiplicands[0]) * c->entries        * c->dimensions);
-            if (c->multiplicands == NULL) { setup_temp_free(f,mults,sizeof(mults[0])*c->lookup_values); return error(f, VORBIS_outofmem); }
+               c->multiplicands = (stbv_codetype *) stbv_setup_malloc(f, sizeof(c->multiplicands[0]) * c->entries        * c->dimensions);
+            if (c->multiplicands == NULL) { stbv_setup_temp_free(f,mults,sizeof(mults[0])*c->lookup_values); return stbv_error(f, VORBIS_outofmem); }
             len = sparse ? c->sorted_entries : c->entries;
             for (j=0; j < len; ++j) {
                unsigned int z = sparse ? c->sorted_values[j] : j;
@@ -3817,8 +3825,8 @@ static int start_decoder(vorb *f)
                      last = val;
                   if (k+1 < c->dimensions) {
                      if (div > UINT_MAX / (unsigned int) c->lookup_values) {
-                        setup_temp_free(f, mults,sizeof(mults[0])*c->lookup_values);
-                        return error(f, VORBIS_invalid_setup);
+                        stbv_setup_temp_free(f, mults,sizeof(mults[0])*c->lookup_values);
+                        return stbv_error(f, VORBIS_invalid_setup);
                      }
                      div *= c->lookup_values;
                   }
@@ -3830,9 +3838,9 @@ static int start_decoder(vorb *f)
 #endif
          {
             float last=0;
-            CHECK(f);
-            c->multiplicands = (codetype *) setup_malloc(f, sizeof(c->multiplicands[0]) * c->lookup_values);
-            if (c->multiplicands == NULL) { setup_temp_free(f, mults,sizeof(mults[0])*c->lookup_values); return error(f, VORBIS_outofmem); }
+            STBV_CHECK(f);
+            c->multiplicands = (stbv_codetype *) stbv_setup_malloc(f, sizeof(c->multiplicands[0]) * c->lookup_values);
+            if (c->multiplicands == NULL) { stbv_setup_temp_free(f, mults,sizeof(mults[0])*c->lookup_values); return stbv_error(f, VORBIS_outofmem); }
             for (j=0; j < (int) c->lookup_values; ++j) {
                float val = mults[j] * c->delta_value + c->minimum_value + last;
                c->multiplicands[j] = val;
@@ -3841,72 +3849,72 @@ static int start_decoder(vorb *f)
             }
          }
 #ifndef STB_VORBIS_DIVIDES_IN_CODEBOOK
-        skip:;
+        stbv_skip:;
 #endif
-         setup_temp_free(f, mults, sizeof(mults[0])*c->lookup_values);
+         stbv_setup_temp_free(f, mults, sizeof(mults[0])*c->lookup_values);
 
-         CHECK(f);
+         STBV_CHECK(f);
       }
-      CHECK(f);
+      STBV_CHECK(f);
    }
 
    // time domain transfers (notused)
 
-   x = get_bits(f, 6) + 1;
+   x = stbv_get_bits(f, 6) + 1;
    for (i=0; i < x; ++i) {
-      uint32 z = get_bits(f, 16);
-      if (z != 0) return error(f, VORBIS_invalid_setup);
+      stbv_uint32 z = stbv_get_bits(f, 16);
+      if (z != 0) return stbv_error(f, VORBIS_invalid_setup);
    }
 
    // Floors
-   f->floor_count = get_bits(f, 6)+1;
-   f->floor_config = (Floor *)  setup_malloc(f, f->floor_count * sizeof(*f->floor_config));
-   if (f->floor_config == NULL) return error(f, VORBIS_outofmem);
+   f->floor_count = stbv_get_bits(f, 6)+1;
+   f->floor_config = (StbvFloor *)  stbv_setup_malloc(f, f->floor_count * sizeof(*f->floor_config));
+   if (f->floor_config == NULL) return stbv_error(f, VORBIS_outofmem);
    for (i=0; i < f->floor_count; ++i) {
-      f->floor_types[i] = get_bits(f, 16);
-      if (f->floor_types[i] > 1) return error(f, VORBIS_invalid_setup);
+      f->floor_types[i] = stbv_get_bits(f, 16);
+      if (f->floor_types[i] > 1) return stbv_error(f, VORBIS_invalid_setup);
       if (f->floor_types[i] == 0) {
-         Floor0 *g = &f->floor_config[i].floor0;
-         g->order = get_bits(f,8);
-         g->rate = get_bits(f,16);
-         g->bark_map_size = get_bits(f,16);
-         g->amplitude_bits = get_bits(f,6);
-         g->amplitude_offset = get_bits(f,8);
-         g->number_of_books = get_bits(f,4) + 1;
+         StbvFloor0 *g = &f->floor_config[i].floor0;
+         g->order = stbv_get_bits(f,8);
+         g->rate = stbv_get_bits(f,16);
+         g->bark_map_size = stbv_get_bits(f,16);
+         g->amplitude_bits = stbv_get_bits(f,6);
+         g->amplitude_offset = stbv_get_bits(f,8);
+         g->number_of_books = stbv_get_bits(f,4) + 1;
          for (j=0; j < g->number_of_books; ++j)
-            g->book_list[j] = get_bits(f,8);
-         return error(f, VORBIS_feature_not_supported);
+            g->book_list[j] = stbv_get_bits(f,8);
+         return stbv_error(f, VORBIS_feature_not_supported);
       } else {
-         stbv__floor_ordering p[31*8+2];
-         Floor1 *g = &f->floor_config[i].floor1;
+         stbv_floor_ordering p[31*8+2];
+         StbvFloor1 *g = &f->floor_config[i].floor1;
          int max_class = -1; 
-         g->partitions = get_bits(f, 5);
+         g->partitions = stbv_get_bits(f, 5);
          for (j=0; j < g->partitions; ++j) {
-            g->partition_class_list[j] = get_bits(f, 4);
+            g->partition_class_list[j] = stbv_get_bits(f, 4);
             if (g->partition_class_list[j] > max_class)
                max_class = g->partition_class_list[j];
          }
          for (j=0; j <= max_class; ++j) {
-            g->class_dimensions[j] = get_bits(f, 3)+1;
-            g->class_subclasses[j] = get_bits(f, 2);
+            g->class_dimensions[j] = stbv_get_bits(f, 3)+1;
+            g->class_subclasses[j] = stbv_get_bits(f, 2);
             if (g->class_subclasses[j]) {
-               g->class_masterbooks[j] = get_bits(f, 8);
-               if (g->class_masterbooks[j] >= f->codebook_count) return error(f, VORBIS_invalid_setup);
+               g->class_masterbooks[j] = stbv_get_bits(f, 8);
+               if (g->class_masterbooks[j] >= f->codebook_count) return stbv_error(f, VORBIS_invalid_setup);
             }
             for (k=0; k < 1 << g->class_subclasses[j]; ++k) {
-               g->subclass_books[j][k] = get_bits(f,8)-1;
-               if (g->subclass_books[j][k] >= f->codebook_count) return error(f, VORBIS_invalid_setup);
+               g->subclass_books[j][k] = stbv_get_bits(f,8)-1;
+               if (g->subclass_books[j][k] >= f->codebook_count) return stbv_error(f, VORBIS_invalid_setup);
             }
          }
-         g->floor1_multiplier = get_bits(f,2)+1;
-         g->rangebits = get_bits(f,4);
+         g->floor1_multiplier = stbv_get_bits(f,2)+1;
+         g->rangebits = stbv_get_bits(f,4);
          g->Xlist[0] = 0;
          g->Xlist[1] = 1 << g->rangebits;
          g->values = 2;
          for (j=0; j < g->partitions; ++j) {
             int c = g->partition_class_list[j];
             for (k=0; k < g->class_dimensions[c]; ++k) {
-               g->Xlist[g->values] = get_bits(f, g->rangebits);
+               g->Xlist[g->values] = stbv_get_bits(f, g->rangebits);
                ++g->values;
             }
          }
@@ -3915,15 +3923,15 @@ static int start_decoder(vorb *f)
             p[j].x = g->Xlist[j];
             p[j].id = j;
          }
-         qsort(p, g->values, sizeof(p[0]), point_compare);
+         qsort(p, g->values, sizeof(p[0]), stbv_point_compare);
          for (j=0; j < g->values; ++j)
-            g->sorted_order[j] = (uint8) p[j].id;
-         // precompute the neighbors
+            g->sorted_order[j] = (stbv_uint8) p[j].id;
+         // precompute the stbv_neighbors
          for (j=2; j < g->values; ++j) {
             int low,hi;
-            neighbors(g->Xlist, j, &low,&hi);
-            g->neighbors[j][0] = low;
-            g->neighbors[j][1] = hi;
+            stbv_neighbors(g->Xlist, j, &low,&hi);
+            g->stbv_neighbors[j][0] = low;
+            g->stbv_neighbors[j][1] = hi;
          }
 
          if (g->values > longest_floorlist)
@@ -3931,37 +3939,37 @@ static int start_decoder(vorb *f)
       }
    }
 
-   // Residue
-   f->residue_count = get_bits(f, 6)+1;
-   f->residue_config = (Residue *) setup_malloc(f, f->residue_count * sizeof(f->residue_config[0]));
-   if (f->residue_config == NULL) return error(f, VORBIS_outofmem);
+   // StbvResidue
+   f->residue_count = stbv_get_bits(f, 6)+1;
+   f->residue_config = (StbvResidue *) stbv_setup_malloc(f, f->residue_count * sizeof(f->residue_config[0]));
+   if (f->residue_config == NULL) return stbv_error(f, VORBIS_outofmem);
    memset(f->residue_config, 0, f->residue_count * sizeof(f->residue_config[0]));
    for (i=0; i < f->residue_count; ++i) {
-      uint8 residue_cascade[64];
-      Residue *r = f->residue_config+i;
-      f->residue_types[i] = get_bits(f, 16);
-      if (f->residue_types[i] > 2) return error(f, VORBIS_invalid_setup);
-      r->begin = get_bits(f, 24);
-      r->end = get_bits(f, 24);
-      if (r->end < r->begin) return error(f, VORBIS_invalid_setup);
-      r->part_size = get_bits(f,24)+1;
-      r->classifications = get_bits(f,6)+1;
-      r->classbook = get_bits(f,8);
-      if (r->classbook >= f->codebook_count) return error(f, VORBIS_invalid_setup);
+      stbv_uint8 residue_cascade[64];
+      StbvResidue *r = f->residue_config+i;
+      f->residue_types[i] = stbv_get_bits(f, 16);
+      if (f->residue_types[i] > 2) return stbv_error(f, VORBIS_invalid_setup);
+      r->begin = stbv_get_bits(f, 24);
+      r->end = stbv_get_bits(f, 24);
+      if (r->end < r->begin) return stbv_error(f, VORBIS_invalid_setup);
+      r->part_size = stbv_get_bits(f,24)+1;
+      r->classifications = stbv_get_bits(f,6)+1;
+      r->classbook = stbv_get_bits(f,8);
+      if (r->classbook >= f->codebook_count) return stbv_error(f, VORBIS_invalid_setup);
       for (j=0; j < r->classifications; ++j) {
-         uint8 high_bits=0;
-         uint8 low_bits=get_bits(f,3);
-         if (get_bits(f,1))
-            high_bits = get_bits(f,5);
+         stbv_uint8 high_bits=0;
+         stbv_uint8 low_bits=stbv_get_bits(f,3);
+         if (stbv_get_bits(f,1))
+            high_bits = stbv_get_bits(f,5);
          residue_cascade[j] = high_bits*8 + low_bits;
       }
-      r->residue_books = (short (*)[8]) setup_malloc(f, sizeof(r->residue_books[0]) * r->classifications);
-      if (r->residue_books == NULL) return error(f, VORBIS_outofmem);
+      r->residue_books = (short (*)[8]) stbv_setup_malloc(f, sizeof(r->residue_books[0]) * r->classifications);
+      if (r->residue_books == NULL) return stbv_error(f, VORBIS_outofmem);
       for (j=0; j < r->classifications; ++j) {
          for (k=0; k < 8; ++k) {
             if (residue_cascade[j] & (1 << k)) {
-               r->residue_books[j][k] = get_bits(f, 8);
-               if (r->residue_books[j][k] >= f->codebook_count) return error(f, VORBIS_invalid_setup);
+               r->residue_books[j][k] = stbv_get_bits(f, 8);
+               if (r->residue_books[j][k] >= f->codebook_count) return stbv_error(f, VORBIS_invalid_setup);
             } else {
                r->residue_books[j][k] = -1;
             }
@@ -3969,14 +3977,14 @@ static int start_decoder(vorb *f)
       }
       // precompute the classifications[] array to avoid inner-loop mod/divide
       // call it 'classdata' since we already have r->classifications
-      r->classdata = (uint8 **) setup_malloc(f, sizeof(*r->classdata) * f->codebooks[r->classbook].entries);
-      if (!r->classdata) return error(f, VORBIS_outofmem);
+      r->classdata = (stbv_uint8 **) stbv_setup_malloc(f, sizeof(*r->classdata) * f->codebooks[r->classbook].entries);
+      if (!r->classdata) return stbv_error(f, VORBIS_outofmem);
       memset(r->classdata, 0, sizeof(*r->classdata) * f->codebooks[r->classbook].entries);
       for (j=0; j < f->codebooks[r->classbook].entries; ++j) {
          int classwords = f->codebooks[r->classbook].dimensions;
          int temp = j;
-         r->classdata[j] = (uint8 *) setup_malloc(f, sizeof(r->classdata[j][0]) * classwords);
-         if (r->classdata[j] == NULL) return error(f, VORBIS_outofmem);
+         r->classdata[j] = (stbv_uint8 *) stbv_setup_malloc(f, sizeof(r->classdata[j][0]) * classwords);
+         if (r->classdata[j] == NULL) return stbv_error(f, VORBIS_outofmem);
          for (k=classwords-1; k >= 0; --k) {
             r->classdata[j][k] = temp % r->classifications;
             temp /= r->classifications;
@@ -3984,40 +3992,40 @@ static int start_decoder(vorb *f)
       }
    }
 
-   f->mapping_count = get_bits(f,6)+1;
-   f->mapping = (Mapping *) setup_malloc(f, f->mapping_count * sizeof(*f->mapping));
-   if (f->mapping == NULL) return error(f, VORBIS_outofmem);
+   f->mapping_count = stbv_get_bits(f,6)+1;
+   f->mapping = (StbvMapping *) stbv_setup_malloc(f, f->mapping_count * sizeof(*f->mapping));
+   if (f->mapping == NULL) return stbv_error(f, VORBIS_outofmem);
    memset(f->mapping, 0, f->mapping_count * sizeof(*f->mapping));
    for (i=0; i < f->mapping_count; ++i) {
-      Mapping *m = f->mapping + i;      
-      int mapping_type = get_bits(f,16);
-      if (mapping_type != 0) return error(f, VORBIS_invalid_setup);
-      m->chan = (MappingChannel *) setup_malloc(f, f->channels * sizeof(*m->chan));
-      if (m->chan == NULL) return error(f, VORBIS_outofmem);
-      if (get_bits(f,1))
-         m->submaps = get_bits(f,4)+1;
+      StbvMapping *m = f->mapping + i;      
+      int mapping_type = stbv_get_bits(f,16);
+      if (mapping_type != 0) return stbv_error(f, VORBIS_invalid_setup);
+      m->chan = (StbvMappingChannel *) stbv_setup_malloc(f, f->channels * sizeof(*m->chan));
+      if (m->chan == NULL) return stbv_error(f, VORBIS_outofmem);
+      if (stbv_get_bits(f,1))
+         m->submaps = stbv_get_bits(f,4)+1;
       else
          m->submaps = 1;
       if (m->submaps > max_submaps)
          max_submaps = m->submaps;
-      if (get_bits(f,1)) {
-         m->coupling_steps = get_bits(f,8)+1;
+      if (stbv_get_bits(f,1)) {
+         m->coupling_steps = stbv_get_bits(f,8)+1;
          for (k=0; k < m->coupling_steps; ++k) {
-            m->chan[k].magnitude = get_bits(f, ilog(f->channels-1));
-            m->chan[k].angle = get_bits(f, ilog(f->channels-1));
-            if (m->chan[k].magnitude >= f->channels)        return error(f, VORBIS_invalid_setup);
-            if (m->chan[k].angle     >= f->channels)        return error(f, VORBIS_invalid_setup);
-            if (m->chan[k].magnitude == m->chan[k].angle)   return error(f, VORBIS_invalid_setup);
+            m->chan[k].magnitude = stbv_get_bits(f, stbv_ilog(f->channels-1));
+            m->chan[k].angle = stbv_get_bits(f, stbv_ilog(f->channels-1));
+            if (m->chan[k].magnitude >= f->channels)        return stbv_error(f, VORBIS_invalid_setup);
+            if (m->chan[k].angle     >= f->channels)        return stbv_error(f, VORBIS_invalid_setup);
+            if (m->chan[k].magnitude == m->chan[k].angle)   return stbv_error(f, VORBIS_invalid_setup);
          }
       } else
          m->coupling_steps = 0;
 
       // reserved field
-      if (get_bits(f,2)) return error(f, VORBIS_invalid_setup);
+      if (stbv_get_bits(f,2)) return stbv_error(f, VORBIS_invalid_setup);
       if (m->submaps > 1) {
          for (j=0; j < f->channels; ++j) {
-            m->chan[j].mux = get_bits(f, 4);
-            if (m->chan[j].mux >= m->submaps)                return error(f, VORBIS_invalid_setup);
+            m->chan[j].mux = stbv_get_bits(f, 4);
+            if (m->chan[j].mux >= m->submaps)                return stbv_error(f, VORBIS_invalid_setup);
          }
       } else
          // @SPECIFICATION: this case is missing from the spec
@@ -4025,64 +4033,64 @@ static int start_decoder(vorb *f)
             m->chan[j].mux = 0;
 
       for (j=0; j < m->submaps; ++j) {
-         get_bits(f,8); // discard
-         m->submap_floor[j] = get_bits(f,8);
-         m->submap_residue[j] = get_bits(f,8);
-         if (m->submap_floor[j] >= f->floor_count)      return error(f, VORBIS_invalid_setup);
-         if (m->submap_residue[j] >= f->residue_count)  return error(f, VORBIS_invalid_setup);
+         stbv_get_bits(f,8); // discard
+         m->submap_floor[j] = stbv_get_bits(f,8);
+         m->submap_residue[j] = stbv_get_bits(f,8);
+         if (m->submap_floor[j] >= f->floor_count)      return stbv_error(f, VORBIS_invalid_setup);
+         if (m->submap_residue[j] >= f->residue_count)  return stbv_error(f, VORBIS_invalid_setup);
       }
    }
 
    // Modes
-   f->mode_count = get_bits(f, 6)+1;
+   f->mode_count = stbv_get_bits(f, 6)+1;
    for (i=0; i < f->mode_count; ++i) {
-      Mode *m = f->mode_config+i;
-      m->blockflag = get_bits(f,1);
-      m->windowtype = get_bits(f,16);
-      m->transformtype = get_bits(f,16);
-      m->mapping = get_bits(f,8);
-      if (m->windowtype != 0)                 return error(f, VORBIS_invalid_setup);
-      if (m->transformtype != 0)              return error(f, VORBIS_invalid_setup);
-      if (m->mapping >= f->mapping_count)     return error(f, VORBIS_invalid_setup);
+      StbvMode *m = f->mode_config+i;
+      m->blockflag = stbv_get_bits(f,1);
+      m->windowtype = stbv_get_bits(f,16);
+      m->transformtype = stbv_get_bits(f,16);
+      m->mapping = stbv_get_bits(f,8);
+      if (m->windowtype != 0)                 return stbv_error(f, VORBIS_invalid_setup);
+      if (m->transformtype != 0)              return stbv_error(f, VORBIS_invalid_setup);
+      if (m->mapping >= f->mapping_count)     return stbv_error(f, VORBIS_invalid_setup);
    }
 
-   flush_packet(f);
+   stbv_flush_packet(f);
 
    f->previous_length = 0;
 
    for (i=0; i < f->channels; ++i) {
-      f->channel_buffers[i] = (float *) setup_malloc(f, sizeof(float) * f->blocksize_1);
-      f->previous_window[i] = (float *) setup_malloc(f, sizeof(float) * f->blocksize_1/2);
-      f->finalY[i]          = (int16 *) setup_malloc(f, sizeof(int16) * longest_floorlist);
-      if (f->channel_buffers[i] == NULL || f->previous_window[i] == NULL || f->finalY[i] == NULL) return error(f, VORBIS_outofmem);
+      f->channel_buffers[i] = (float *) stbv_setup_malloc(f, sizeof(float) * f->blocksize_1);
+      f->previous_window[i] = (float *) stbv_setup_malloc(f, sizeof(float) * f->blocksize_1/2);
+      f->finalY[i]          = (stbv_int16 *) stbv_setup_malloc(f, sizeof(stbv_int16) * longest_floorlist);
+      if (f->channel_buffers[i] == NULL || f->previous_window[i] == NULL || f->finalY[i] == NULL) return stbv_error(f, VORBIS_outofmem);
       memset(f->channel_buffers[i], 0, sizeof(float) * f->blocksize_1);
       #ifdef STB_VORBIS_NO_DEFER_FLOOR
-      f->floor_buffers[i]   = (float *) setup_malloc(f, sizeof(float) * f->blocksize_1/2);
-      if (f->floor_buffers[i] == NULL) return error(f, VORBIS_outofmem);
+      f->floor_buffers[i]   = (float *) stbv_setup_malloc(f, sizeof(float) * f->blocksize_1/2);
+      if (f->floor_buffers[i] == NULL) return stbv_error(f, VORBIS_outofmem);
       #endif
    }
 
-   if (!init_blocksize(f, 0, f->blocksize_0)) return FALSE;
-   if (!init_blocksize(f, 1, f->blocksize_1)) return FALSE;
+   if (!stbv_init_blocksize(f, 0, f->blocksize_0)) return FALSE;
+   if (!stbv_init_blocksize(f, 1, f->blocksize_1)) return FALSE;
    f->blocksize[0] = f->blocksize_0;
    f->blocksize[1] = f->blocksize_1;
 
 #ifdef STB_VORBIS_DIVIDE_TABLE
-   if (integer_divide_table[1][1]==0)
-      for (i=0; i < DIVTAB_NUMER; ++i)
-         for (j=1; j < DIVTAB_DENOM; ++j)
-            integer_divide_table[i][j] = i / j;
+   if (stbv_integer_divide_table[1][1]==0)
+      for (i=0; i < STBV_DIVTAB_NUMER; ++i)
+         for (j=1; j < STBV_DIVTAB_DENOM; ++j)
+            stbv_integer_divide_table[i][j] = i / j;
 #endif
 
    // compute how much temporary memory is needed
 
    // 1.
    {
-      uint32 imdct_mem = (f->blocksize_1 * sizeof(float) >> 1);
-      uint32 classify_mem;
+      stbv_uint32 imdct_mem = (f->blocksize_1 * sizeof(float) >> 1);
+      stbv_uint32 classify_mem;
       int i,max_part_read=0;
       for (i=0; i < f->residue_count; ++i) {
-         Residue *r = f->residue_config + i;
+         StbvResidue *r = f->residue_config + i;
          unsigned int actual_size = f->blocksize_1 / 2;
          unsigned int limit_r_begin = r->begin < actual_size ? r->begin : actual_size;
          unsigned int limit_r_end   = r->end   < actual_size ? r->end   : actual_size;
@@ -4092,7 +4100,7 @@ static int start_decoder(vorb *f)
             max_part_read = part_read;
       }
       #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
-      classify_mem = f->channels * (sizeof(void*) + max_part_read * sizeof(uint8 *));
+      classify_mem = f->channels * (sizeof(void*) + max_part_read * sizeof(stbv_uint8 *));
       #else
       classify_mem = f->channels * (sizeof(void*) + max_part_read * sizeof(int *));
       #endif
@@ -4110,7 +4118,7 @@ static int start_decoder(vorb *f)
       assert(f->temp_offset == f->alloc.alloc_buffer_length_in_bytes);
       // check if there's enough temp memory so we don't error later
       if (f->setup_offset + sizeof(*f) + f->temp_memory_required > (unsigned) f->temp_offset)
-         return error(f, VORBIS_outofmem);
+         return stbv_error(f, VORBIS_outofmem);
    }
 
    f->first_audio_page_offset = stb_vorbis_get_file_offset(f);
@@ -4118,70 +4126,70 @@ static int start_decoder(vorb *f)
    return TRUE;
 }
 
-static void vorbis_deinit(stb_vorbis *p)
+static void stbv_vorbis_deinit(stb_vorbis *p)
 {
    int i,j;
    if (p->residue_config) {
       for (i=0; i < p->residue_count; ++i) {
-         Residue *r = p->residue_config+i;
+         StbvResidue *r = p->residue_config+i;
          if (r->classdata) {
             for (j=0; j < p->codebooks[r->classbook].entries; ++j)
-               setup_free(p, r->classdata[j]);
-            setup_free(p, r->classdata);
+               stbv_setup_free(p, r->classdata[j]);
+            stbv_setup_free(p, r->classdata);
          }
-         setup_free(p, r->residue_books);
+         stbv_setup_free(p, r->residue_books);
       }
    }
 
    if (p->codebooks) {
-      CHECK(p);
+      STBV_CHECK(p);
       for (i=0; i < p->codebook_count; ++i) {
-         Codebook *c = p->codebooks + i;
-         setup_free(p, c->codeword_lengths);
-         setup_free(p, c->multiplicands);
-         setup_free(p, c->codewords);
-         setup_free(p, c->sorted_codewords);
+         StbvCodebook *c = p->codebooks + i;
+         stbv_setup_free(p, c->codeword_lengths);
+         stbv_setup_free(p, c->multiplicands);
+         stbv_setup_free(p, c->codewords);
+         stbv_setup_free(p, c->sorted_codewords);
          // c->sorted_values[-1] is the first entry in the array
-         setup_free(p, c->sorted_values ? c->sorted_values-1 : NULL);
+         stbv_setup_free(p, c->sorted_values ? c->sorted_values-1 : NULL);
       }
-      setup_free(p, p->codebooks);
+      stbv_setup_free(p, p->codebooks);
    }
-   setup_free(p, p->floor_config);
-   setup_free(p, p->residue_config);
+   stbv_setup_free(p, p->floor_config);
+   stbv_setup_free(p, p->residue_config);
    if (p->mapping) {
       for (i=0; i < p->mapping_count; ++i)
-         setup_free(p, p->mapping[i].chan);
-      setup_free(p, p->mapping);
+         stbv_setup_free(p, p->mapping[i].chan);
+      stbv_setup_free(p, p->mapping);
    }
-   CHECK(p);
+   STBV_CHECK(p);
    for (i=0; i < p->channels && i < STB_VORBIS_MAX_CHANNELS; ++i) {
-      setup_free(p, p->channel_buffers[i]);
-      setup_free(p, p->previous_window[i]);
+      stbv_setup_free(p, p->channel_buffers[i]);
+      stbv_setup_free(p, p->previous_window[i]);
       #ifdef STB_VORBIS_NO_DEFER_FLOOR
-      setup_free(p, p->floor_buffers[i]);
+      stbv_setup_free(p, p->floor_buffers[i]);
       #endif
-      setup_free(p, p->finalY[i]);
+      stbv_setup_free(p, p->finalY[i]);
    }
    for (i=0; i < 2; ++i) {
-      setup_free(p, p->A[i]);
-      setup_free(p, p->B[i]);
-      setup_free(p, p->C[i]);
-      setup_free(p, p->window[i]);
-      setup_free(p, p->bit_reverse[i]);
+      stbv_setup_free(p, p->A[i]);
+      stbv_setup_free(p, p->B[i]);
+      stbv_setup_free(p, p->C[i]);
+      stbv_setup_free(p, p->window[i]);
+      stbv_setup_free(p, p->stbv_bit_reverse[i]);
    }
    #ifndef STB_VORBIS_NO_STDIO
    if (p->close_on_free) fclose(p->f);
    #endif
 }
 
-void stb_vorbis_close(stb_vorbis *p)
+STBVDEF void stb_vorbis_close(stb_vorbis *p)
 {
    if (p == NULL) return;
-   vorbis_deinit(p);
-   setup_free(p,p);
+   stbv_vorbis_deinit(p);
+   stbv_setup_free(p,p);
 }
 
-static void vorbis_init(stb_vorbis *p, const stb_vorbis_alloc *z)
+static void stbv_vorbis_init(stb_vorbis *p, const stb_vorbis_alloc *z)
 {
    memset(p, 0, sizeof(*p)); // NULL out all malloc'd pointers to start
    if (z) {
@@ -4200,7 +4208,7 @@ static void vorbis_init(stb_vorbis *p, const stb_vorbis_alloc *z)
    #endif
 }
 
-int stb_vorbis_get_sample_offset(stb_vorbis *f)
+STBVDEF int stb_vorbis_get_sample_offset(stb_vorbis *f)
 {
    if (f->current_loc_valid)
       return f->current_loc;
@@ -4208,7 +4216,7 @@ int stb_vorbis_get_sample_offset(stb_vorbis *f)
       return -1;
 }
 
-stb_vorbis_info stb_vorbis_get_info(stb_vorbis *f)
+STBVDEF stb_vorbis_info stb_vorbis_get_info(stb_vorbis *f)
 {
    stb_vorbis_info d;
    d.channels = f->channels;
@@ -4220,22 +4228,22 @@ stb_vorbis_info stb_vorbis_get_info(stb_vorbis *f)
    return d;
 }
 
-int stb_vorbis_get_error(stb_vorbis *f)
+STBVDEF int stb_vorbis_get_error(stb_vorbis *f)
 {
    int e = f->error;
    f->error = VORBIS__no_error;
    return e;
 }
 
-static stb_vorbis * vorbis_alloc(stb_vorbis *f)
+static stb_vorbis * stbv_vorbis_alloc(stb_vorbis *f)
 {
-   stb_vorbis *p = (stb_vorbis *) setup_malloc(f, sizeof(*p));
+   stb_vorbis *p = (stb_vorbis *) stbv_setup_malloc(f, sizeof(*p));
    return p;
 }
 
 #ifndef STB_VORBIS_NO_PUSHDATA_API
 
-void stb_vorbis_flush_pushdata(stb_vorbis *f)
+STBVDEF void stb_vorbis_flush_pushdata(stb_vorbis *f)
 {
    f->previous_length = 0;
    f->page_crc_tests  = 0;
@@ -4247,7 +4255,7 @@ void stb_vorbis_flush_pushdata(stb_vorbis *f)
    f->channel_buffer_end = 0;
 }
 
-static int vorbis_search_for_page_pushdata(vorb *f, uint8 *data, int data_len)
+static int stbv_vorbis_search_for_page_pushdata(stbv_vorb *f, stbv_uint8 *data, int data_len)
 {
    int i,n;
    for (i=0; i < f->page_crc_tests; ++i)
@@ -4261,9 +4269,9 @@ static int vorbis_search_for_page_pushdata(vorb *f, uint8 *data, int data_len)
                      // one that straddles a boundary
       for (i=0; i < data_len; ++i) {
          if (data[i] == 0x4f) {
-            if (0==memcmp(data+i, ogg_page_header, 4)) {
+            if (0==memcmp(data+i, stbv_ogg_page_header, 4)) {
                int j,len;
-               uint32 crc;
+               stbv_uint32 crc;
                // make sure we have the whole page header
                if (i+26 >= data_len || i+27+data[i+26] >= data_len) {
                   // only read up to this page start, so hopefully we'll
@@ -4278,10 +4286,10 @@ static int vorbis_search_for_page_pushdata(vorb *f, uint8 *data, int data_len)
                // scan everything up to the embedded crc (which we must 0)
                crc = 0;
                for (j=0; j < 22; ++j)
-                  crc = crc32_update(crc, data[i+j]);
+                  crc = stbv_crc32_update(crc, data[i+j]);
                // now process 4 0-bytes
                for (   ; j < 26; ++j)
-                  crc = crc32_update(crc, 0);
+                  crc = stbv_crc32_update(crc, 0);
                // len is the total number of bytes we need to scan
                n = f->page_crc_tests++;
                f->scan[n].bytes_left = len-j;
@@ -4303,7 +4311,7 @@ static int vorbis_search_for_page_pushdata(vorb *f, uint8 *data, int data_len)
    }
 
    for (i=0; i < f->page_crc_tests;) {
-      uint32 crc;
+      stbv_uint32 crc;
       int j;
       int n = f->scan[i].bytes_done;
       int m = f->scan[i].bytes_left;
@@ -4311,7 +4319,7 @@ static int vorbis_search_for_page_pushdata(vorb *f, uint8 *data, int data_len)
       // m is the bytes to scan in the current chunk
       crc = f->scan[i].crc_so_far;
       for (j=0; j < m; ++j)
-         crc = crc32_update(crc, data[n+j]);
+         crc = stbv_crc32_update(crc, data[n+j]);
       f->scan[i].bytes_left -= m;
       f->scan[i].crc_so_far = crc;
       if (f->scan[i].bytes_left == 0) {
@@ -4338,9 +4346,9 @@ static int vorbis_search_for_page_pushdata(vorb *f, uint8 *data, int data_len)
 }
 
 // return value: number of bytes we used
-int stb_vorbis_decode_frame_pushdata(
+STBVDEF int stb_vorbis_decode_frame_pushdata(
          stb_vorbis *f,                   // the file we're decoding
-         const uint8 *data, int data_len, // the memory available for decoding
+         const stbv_uint8 *data, int data_len, // the memory available for decoding
          int *channels,                   // place to write number of float * buffers
          float ***output,                 // place to write float ** array of float * buffers
          int *samples                     // place to write number of output samples
@@ -4349,30 +4357,30 @@ int stb_vorbis_decode_frame_pushdata(
    int i;
    int len,right,left;
 
-   if (!IS_PUSH_MODE(f)) return error(f, VORBIS_invalid_api_mixing);
+   if (!STBV_IS_PUSH_MODE(f)) return stbv_error(f, VORBIS_invalid_api_mixing);
 
    if (f->page_crc_tests >= 0) {
       *samples = 0;
-      return vorbis_search_for_page_pushdata(f, (uint8 *) data, data_len);
+      return stbv_vorbis_search_for_page_pushdata(f, (stbv_uint8 *) data, data_len);
    }
 
-   f->stream     = (uint8 *) data;
-   f->stream_end = (uint8 *) data + data_len;
+   f->stream     = (stbv_uint8 *) data;
+   f->stream_end = (stbv_uint8 *) data + data_len;
    f->error      = VORBIS__no_error;
 
    // check that we have the entire packet in memory
-   if (!is_whole_packet_present(f, FALSE)) {
+   if (!stbv_is_whole_packet_present(f, FALSE)) {
       *samples = 0;
       return 0;
    }
 
-   if (!vorbis_decode_packet(f, &len, &left, &right)) {
+   if (!stbv_vorbis_decode_packet(f, &len, &left, &right)) {
       // save the actual error we encountered
       enum STBVorbisError error = f->error;
       if (error == VORBIS_bad_packet_type) {
          // flush and resynch
          f->error = VORBIS__no_error;
-         while (get8_packet(f) != EOP)
+         while (stbv_get8_packet(f) != STBV_EOP)
             if (f->eof) break;
          *samples = 0;
          return (int) (f->stream - data);
@@ -4382,7 +4390,7 @@ int stb_vorbis_decode_frame_pushdata(
             // we may be resynching, in which case it's ok to hit one
             // of these; just discard the packet
             f->error = VORBIS__no_error;
-            while (get8_packet(f) != EOP)
+            while (stbv_get8_packet(f) != STBV_EOP)
                if (f->eof) break;
             *samples = 0;
             return (int) (f->stream - data);
@@ -4398,7 +4406,7 @@ int stb_vorbis_decode_frame_pushdata(
    }
 
    // success!
-   len = vorbis_finish_frame(f, len, left, right);
+   len = stbv_vorbis_finish_frame(f, len, left, right);
    for (i=0; i < f->channels; ++i)
       f->outputs[i] = f->channel_buffers[i] + left;
 
@@ -4408,42 +4416,42 @@ int stb_vorbis_decode_frame_pushdata(
    return (int) (f->stream - data);
 }
 
-stb_vorbis *stb_vorbis_open_pushdata(
+STBVDEF stb_vorbis *stb_vorbis_open_pushdata(
          const unsigned char *data, int data_len, // the memory available for decoding
          int *data_used,              // only defined if result is not NULL
          int *error, const stb_vorbis_alloc *alloc)
 {
    stb_vorbis *f, p;
-   vorbis_init(&p, alloc);
-   p.stream     = (uint8 *) data;
-   p.stream_end = (uint8 *) data + data_len;
+   stbv_vorbis_init(&p, alloc);
+   p.stream     = (stbv_uint8 *) data;
+   p.stream_end = (stbv_uint8 *) data + data_len;
    p.push_mode  = TRUE;
-   if (!start_decoder(&p)) {
+   if (!stbv_start_decoder(&p)) {
       if (p.eof)
          *error = VORBIS_need_more_data;
       else
          *error = p.error;
       return NULL;
    }
-   f = vorbis_alloc(&p);
+   f = stbv_vorbis_alloc(&p);
    if (f) {
       *f = p;
       *data_used = (int) (f->stream - data);
       *error = 0;
       return f;
    } else {
-      vorbis_deinit(&p);
+      stbv_vorbis_deinit(&p);
       return NULL;
    }
 }
 #endif // STB_VORBIS_NO_PUSHDATA_API
 
-unsigned int stb_vorbis_get_file_offset(stb_vorbis *f)
+STBVDEF unsigned int stb_vorbis_get_file_offset(stb_vorbis *f)
 {
    #ifndef STB_VORBIS_NO_PUSHDATA_API
    if (f->push_mode) return 0;
    #endif
-   if (USE_MEMORY(f)) return (unsigned int) (f->stream - f->stream_start);
+   if (STBV_USE_MEMORY(f)) return (unsigned int) (f->stream - f->stream_start);
    #ifndef STB_VORBIS_NO_STDIO
    return (unsigned int) (ftell(f->f) - f->f_start);
    #endif
@@ -4454,12 +4462,12 @@ unsigned int stb_vorbis_get_file_offset(stb_vorbis *f)
 // DATA-PULLING API
 //
 
-static uint32 vorbis_find_page(stb_vorbis *f, uint32 *end, uint32 *last)
+static stbv_uint32 stbv_vorbis_find_page(stb_vorbis *f, stbv_uint32 *end, stbv_uint32 *last)
 {
    for(;;) {
       int n;
       if (f->eof) return 0;
-      n = get8(f);
+      n = stbv_get8(f);
       if (n == 0x4f) { // page header candidate
          unsigned int retry_loc = stb_vorbis_get_file_offset(f);
          int i;
@@ -4468,16 +4476,16 @@ static uint32 vorbis_find_page(stb_vorbis *f, uint32 *end, uint32 *last)
             return 0;
          // check the rest of the header
          for (i=1; i < 4; ++i)
-            if (get8(f) != ogg_page_header[i])
+            if (stbv_get8(f) != stbv_ogg_page_header[i])
                break;
          if (f->eof) return 0;
          if (i == 4) {
-            uint8 header[27];
-            uint32 i, crc, goal, len;
+            stbv_uint8 header[27];
+            stbv_uint32 i, crc, goal, len;
             for (i=0; i < 4; ++i)
-               header[i] = ogg_page_header[i];
+               header[i] = stbv_ogg_page_header[i];
             for (; i < 27; ++i)
-               header[i] = get8(f);
+               header[i] = stbv_get8(f);
             if (f->eof) return 0;
             if (header[4] != 0) goto invalid;
             goal = header[22] + (header[23] << 8) + (header[24]<<16) + (header[25]<<24);
@@ -4485,16 +4493,16 @@ static uint32 vorbis_find_page(stb_vorbis *f, uint32 *end, uint32 *last)
                header[i] = 0;
             crc = 0;
             for (i=0; i < 27; ++i)
-               crc = crc32_update(crc, header[i]);
+               crc = stbv_crc32_update(crc, header[i]);
             len = 0;
             for (i=0; i < header[26]; ++i) {
-               int s = get8(f);
-               crc = crc32_update(crc, s);
+               int s = stbv_get8(f);
+               crc = stbv_crc32_update(crc, s);
                len += s;
             }
             if (len && f->eof) return 0;
             for (i=0; i < len; ++i)
-               crc = crc32_update(crc, get8(f));
+               crc = stbv_crc32_update(crc, stbv_get8(f));
             // finished parsing probable page
             if (crc == goal) {
                // we could now check that it's either got the last
@@ -4513,19 +4521,19 @@ static uint32 vorbis_find_page(stb_vorbis *f, uint32 *end, uint32 *last)
                   else
                      *last = 0;
                }
-               set_file_offset(f, retry_loc-1);
+               stbv_set_file_offset(f, retry_loc-1);
                return 1;
             }
          }
         invalid:
          // not a valid page, so rewind and look for next one
-         set_file_offset(f, retry_loc);
+         stbv_set_file_offset(f, retry_loc);
       }
    }
 }
 
 
-#define SAMPLE_unknown  0xffffffff
+#define STBV_SAMPLE_unknown  0xffffffff
 
 // seeking is implemented with a binary search, which narrows down the range to
 // 64K, before using a linear search (because finding the synchronization
@@ -4536,19 +4544,19 @@ static uint32 vorbis_find_page(stb_vorbis *f, uint32 *end, uint32 *last)
 // to try to bound either side of the binary search sensibly, while still
 // working in O(log n) time if they fail.
 
-static int get_seek_page_info(stb_vorbis *f, ProbedPage *z)
+static int stbv_get_seek_page_info(stb_vorbis *f, StbvProbedPage *z)
 {
-   uint8 header[27], lacing[255];
+   stbv_uint8 header[27], lacing[255];
    int i,len;
 
    // record where the page starts
    z->page_start = stb_vorbis_get_file_offset(f);
 
    // parse the header
-   getn(f, header, 27);
+   stbv_getn(f, header, 27);
    if (header[0] != 'O' || header[1] != 'g' || header[2] != 'g' || header[3] != 'S')
       return 0;
-   getn(f, lacing, header[26]);
+   stbv_getn(f, lacing, header[26]);
 
    // determine the length of the payload
    len = 0;
@@ -4562,13 +4570,13 @@ static int get_seek_page_info(stb_vorbis *f, ProbedPage *z)
    z->last_decoded_sample = header[6] + (header[7] << 8) + (header[8] << 16) + (header[9] << 24);
 
    // restore file state to where we were
-   set_file_offset(f, z->page_start);
+   stbv_set_file_offset(f, z->page_start);
    return 1;
 }
 
 // rarely used function to seek back to the preceeding page while finding the
 // start of a packet
-static int go_to_page_before(stb_vorbis *f, unsigned int limit_offset)
+static int stbv_go_to_page_before(stb_vorbis *f, unsigned int limit_offset)
 {
    unsigned int previous_safe, end;
 
@@ -4578,12 +4586,12 @@ static int go_to_page_before(stb_vorbis *f, unsigned int limit_offset)
    else
       previous_safe = f->first_audio_page_offset;
 
-   set_file_offset(f, previous_safe);
+   stbv_set_file_offset(f, previous_safe);
 
-   while (vorbis_find_page(f, &end, NULL)) {
+   while (stbv_vorbis_find_page(f, &end, NULL)) {
       if (end >= limit_offset && stb_vorbis_get_file_offset(f) < limit_offset)
          return 1;
-      set_file_offset(f, end);
+      stbv_set_file_offset(f, end);
    }
 
    return 0;
@@ -4593,18 +4601,18 @@ static int go_to_page_before(stb_vorbis *f, unsigned int limit_offset)
 // the function succeeds, current_loc_valid will be true and current_loc will
 // be less than or equal to the provided sample number (the closer the
 // better).
-static int seek_to_sample_coarse(stb_vorbis *f, uint32 sample_number)
+static int stbv_seek_to_sample_coarse(stb_vorbis *f, stbv_uint32 sample_number)
 {
-   ProbedPage left, right, mid;
+   StbvProbedPage left, right, mid;
    int i, start_seg_with_known_loc, end_pos, page_start;
-   uint32 delta, stream_length, padding;
+   stbv_uint32 delta, stream_length, padding;
    double offset, bytes_per_sample;
    int probe = 0;
 
    // find the last page and validate the target sample
    stream_length = stb_vorbis_stream_length_in_samples(f);
-   if (stream_length == 0)            return error(f, VORBIS_seek_without_length);
-   if (sample_number > stream_length) return error(f, VORBIS_seek_invalid);
+   if (stream_length == 0)            return stbv_error(f, VORBIS_seek_without_length);
+   if (sample_number > stream_length) return stbv_error(f, VORBIS_seek_invalid);
 
    // this is the maximum difference between the window-center (which is the
    // actual granule position value), and the right-start (which the spec
@@ -4618,8 +4626,8 @@ static int seek_to_sample_coarse(stb_vorbis *f, uint32 sample_number)
    left = f->p_first;
    while (left.last_decoded_sample == ~0U) {
       // (untested) the first page does not have a 'last_decoded_sample'
-      set_file_offset(f, left.page_end);
-      if (!get_seek_page_info(f, &left)) goto error;
+      stbv_set_file_offset(f, left.page_end);
+      if (!stbv_get_seek_page_info(f, &left)) goto error;
    }
 
    right = f->p_last;
@@ -4638,7 +4646,7 @@ static int seek_to_sample_coarse(stb_vorbis *f, uint32 sample_number)
       delta = right.page_start - left.page_end;
       if (delta <= 65536) {
          // there's only 64K left to search - handle it linearly
-         set_file_offset(f, left.page_end);
+         stbv_set_file_offset(f, left.page_end);
       } else {
          if (probe < 2) {
             if (probe == 0) {
@@ -4660,21 +4668,21 @@ static int seek_to_sample_coarse(stb_vorbis *f, uint32 sample_number)
             if (offset > right.page_start - 65536)
                offset = right.page_start - 65536;
 
-            set_file_offset(f, (unsigned int) offset);
+            stbv_set_file_offset(f, (unsigned int) offset);
          } else {
             // binary search for large ranges (offset by 32K to ensure
             // we don't hit the right page)
-            set_file_offset(f, left.page_end + (delta / 2) - 32768);
+            stbv_set_file_offset(f, left.page_end + (delta / 2) - 32768);
          }
 
-         if (!vorbis_find_page(f, NULL, NULL)) goto error;
+         if (!stbv_vorbis_find_page(f, NULL, NULL)) goto error;
       }
 
       for (;;) {
-         if (!get_seek_page_info(f, &mid)) goto error;
+         if (!stbv_get_seek_page_info(f, &mid)) goto error;
          if (mid.last_decoded_sample != ~0U) break;
          // (untested) no frames end on this page
-         set_file_offset(f, mid.page_end);
+         stbv_set_file_offset(f, mid.page_end);
          assert(mid.page_start < right.page_start);
       }
 
@@ -4693,8 +4701,8 @@ static int seek_to_sample_coarse(stb_vorbis *f, uint32 sample_number)
 
    // seek back to start of the last packet
    page_start = left.page_start;
-   set_file_offset(f, page_start);
-   if (!start_page(f)) return error(f, VORBIS_seek_failed);
+   stbv_set_file_offset(f, page_start);
+   if (!stbv_start_page(f)) return stbv_error(f, VORBIS_seek_failed);
    end_pos = f->end_seg_with_known_loc;
    assert(end_pos >= 0);
 
@@ -4705,15 +4713,15 @@ static int seek_to_sample_coarse(stb_vorbis *f, uint32 sample_number)
 
       start_seg_with_known_loc = i;
 
-      if (start_seg_with_known_loc > 0 || !(f->page_flag & PAGEFLAG_continued_packet))
+      if (start_seg_with_known_loc > 0 || !(f->page_flag & STBV_PAGEFLAG_continued_packet))
          break;
 
       // (untested) the final packet begins on an earlier page
-      if (!go_to_page_before(f, page_start))
+      if (!stbv_go_to_page_before(f, page_start))
          goto error;
 
       page_start = stb_vorbis_get_file_offset(f);
-      if (!start_page(f)) goto error;
+      if (!stbv_start_page(f)) goto error;
       end_pos = f->segment_count - 1;
    }
 
@@ -4727,38 +4735,38 @@ static int seek_to_sample_coarse(stb_vorbis *f, uint32 sample_number)
    f->next_seg = start_seg_with_known_loc;
 
    for (i = 0; i < start_seg_with_known_loc; i++)
-      skip(f, f->segments[i]);
+      stbv_skip(f, f->segments[i]);
 
    // start decoding (optimizable - this frame is generally discarded)
-   if (!vorbis_pump_first_frame(f))
+   if (!stbv_vorbis_pump_first_frame(f))
       return 0;
    if (f->current_loc > sample_number)
-      return error(f, VORBIS_seek_failed);
+      return stbv_error(f, VORBIS_seek_failed);
    return 1;
 
 error:
    // try to restore the file to a valid state
    stb_vorbis_seek_start(f);
-   return error(f, VORBIS_seek_failed);
+   return stbv_error(f, VORBIS_seek_failed);
 }
 
-// the same as vorbis_decode_initial, but without advancing
-static int peek_decode_initial(vorb *f, int *p_left_start, int *p_left_end, int *p_right_start, int *p_right_end, int *mode)
+// the same as stbv_vorbis_decode_initial, but without advancing
+static int stbv_peek_decode_initial(stbv_vorb *f, int *p_left_start, int *p_left_end, int *p_right_start, int *p_right_end, int *mode)
 {
    int bits_read, bytes_read;
 
-   if (!vorbis_decode_initial(f, p_left_start, p_left_end, p_right_start, p_right_end, mode))
+   if (!stbv_vorbis_decode_initial(f, p_left_start, p_left_end, p_right_start, p_right_end, mode))
       return 0;
 
    // either 1 or 2 bytes were read, figure out which so we can rewind
-   bits_read = 1 + ilog(f->mode_count-1);
+   bits_read = 1 + stbv_ilog(f->mode_count-1);
    if (f->mode_config[*mode].blockflag)
       bits_read += 2;
    bytes_read = (bits_read + 7) / 8;
 
    f->bytes_in_seg += bytes_read;
    f->packet_bytes -= bytes_read;
-   skip(f, -bytes_read);
+   stbv_skip(f, -bytes_read);
    if (f->next_seg == -1)
       f->next_seg = f->segment_count - 1;
    else
@@ -4768,14 +4776,14 @@ static int peek_decode_initial(vorb *f, int *p_left_start, int *p_left_end, int 
    return 1;
 }
 
-int stb_vorbis_seek_frame(stb_vorbis *f, unsigned int sample_number)
+STBVDEF int stb_vorbis_seek_frame(stb_vorbis *f, unsigned int sample_number)
 {
-   uint32 max_frame_samples;
+   stbv_uint32 max_frame_samples;
 
-   if (IS_PUSH_MODE(f)) return error(f, VORBIS_invalid_api_mixing);
+   if (STBV_IS_PUSH_MODE(f)) return stbv_error(f, VORBIS_invalid_api_mixing);
 
    // fast page-level search
-   if (!seek_to_sample_coarse(f, sample_number))
+   if (!stbv_seek_to_sample_coarse(f, sample_number))
       return 0;
 
    assert(f->current_loc_valid);
@@ -4785,21 +4793,21 @@ int stb_vorbis_seek_frame(stb_vorbis *f, unsigned int sample_number)
    max_frame_samples = (f->blocksize_1*3 - f->blocksize_0) >> 2;
    while (f->current_loc < sample_number) {
       int left_start, left_end, right_start, right_end, mode, frame_samples;
-      if (!peek_decode_initial(f, &left_start, &left_end, &right_start, &right_end, &mode))
-         return error(f, VORBIS_seek_failed);
+      if (!stbv_peek_decode_initial(f, &left_start, &left_end, &right_start, &right_end, &mode))
+         return stbv_error(f, VORBIS_seek_failed);
       // calculate the number of samples returned by the next frame
       frame_samples = right_start - left_start;
       if (f->current_loc + frame_samples > sample_number) {
          return 1; // the next frame will contain the sample
       } else if (f->current_loc + frame_samples + max_frame_samples > sample_number) {
          // there's a chance the frame after this could contain the sample
-         vorbis_pump_first_frame(f);
+         stbv_vorbis_pump_first_frame(f);
       } else {
          // this frame is too early to be relevant
          f->current_loc += frame_samples;
          f->previous_length = 0;
-         maybe_start_packet(f);
-         flush_packet(f);
+         stbv_maybe_start_packet(f);
+         stbv_flush_packet(f);
       }
    }
    // the next frame will start with the sample
@@ -4807,14 +4815,14 @@ int stb_vorbis_seek_frame(stb_vorbis *f, unsigned int sample_number)
    return 1;
 }
 
-int stb_vorbis_seek(stb_vorbis *f, unsigned int sample_number)
+STBVDEF int stb_vorbis_seek(stb_vorbis *f, unsigned int sample_number)
 {
    if (!stb_vorbis_seek_frame(f, sample_number))
       return 0;
 
    if (sample_number != f->current_loc) {
       int n;
-      uint32 frame_start = f->current_loc;
+      stbv_uint32 frame_start = f->current_loc;
       stb_vorbis_get_frame_float(f, &n, NULL);
       assert(sample_number > frame_start);
       assert(f->channel_buffer_start + (int) (sample_number-frame_start) <= f->channel_buffer_end);
@@ -4824,25 +4832,25 @@ int stb_vorbis_seek(stb_vorbis *f, unsigned int sample_number)
    return 1;
 }
 
-int stb_vorbis_seek_start(stb_vorbis *f)
+STBVDEF int stb_vorbis_seek_start(stb_vorbis *f)
 {
-   if (IS_PUSH_MODE(f)) { return error(f, VORBIS_invalid_api_mixing); }
-   set_file_offset(f, f->first_audio_page_offset);
+   if (STBV_IS_PUSH_MODE(f)) { return stbv_error(f, VORBIS_invalid_api_mixing); }
+   stbv_set_file_offset(f, f->first_audio_page_offset);
    f->previous_length = 0;
    f->first_decode = TRUE;
    f->next_seg = -1;
-   return vorbis_pump_first_frame(f);
+   return stbv_vorbis_pump_first_frame(f);
 }
 
-unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f)
+STBVDEF unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f)
 {
    unsigned int restore_offset, previous_safe;
    unsigned int end, last_page_loc;
 
-   if (IS_PUSH_MODE(f)) return error(f, VORBIS_invalid_api_mixing);
+   if (STBV_IS_PUSH_MODE(f)) return stbv_error(f, VORBIS_invalid_api_mixing);
    if (!f->total_samples) {
       unsigned int last;
-      uint32 lo,hi;
+      stbv_uint32 lo,hi;
       char header[6];
 
       // first, store the current decode position so we can restore it
@@ -4855,11 +4863,11 @@ unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f)
       else
          previous_safe = f->first_audio_page_offset;
 
-      set_file_offset(f, previous_safe);
+      stbv_set_file_offset(f, previous_safe);
       // previous_safe is now our candidate 'earliest known place that seeking
       // to will lead to the final page'
 
-      if (!vorbis_find_page(f, &end, &last)) {
+      if (!stbv_vorbis_find_page(f, &end, &last)) {
          // if we can't find a page, we're hosed!
          f->error = VORBIS_cant_find_last_page;
          f->total_samples = 0xffffffff;
@@ -4873,8 +4881,8 @@ unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f)
       // this allows us to stop short of a 'file_section' end without
       // explicitly checking the length of the section
       while (!last) {
-         set_file_offset(f, end);
-         if (!vorbis_find_page(f, &end, &last)) {
+         stbv_set_file_offset(f, end);
+         if (!stbv_vorbis_find_page(f, &end, &last)) {
             // the last page we found didn't have the 'last page' flag
             // set. whoops!
             break;
@@ -4883,16 +4891,16 @@ unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f)
          last_page_loc = stb_vorbis_get_file_offset(f);
       }
 
-      set_file_offset(f, last_page_loc);
+      stbv_set_file_offset(f, last_page_loc);
 
       // parse the header
-      getn(f, (unsigned char *)header, 6);
+      stbv_getn(f, (unsigned char *)header, 6);
       // extract the absolute granule position
-      lo = get32(f);
-      hi = get32(f);
+      lo = stbv_get32(f);
+      hi = stbv_get32(f);
       if (lo == 0xffffffff && hi == 0xffffffff) {
          f->error = VORBIS_cant_find_last_page;
-         f->total_samples = SAMPLE_unknown;
+         f->total_samples = STBV_SAMPLE_unknown;
          goto done;
       }
       if (hi)
@@ -4904,29 +4912,29 @@ unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f)
       f->p_last.last_decoded_sample = lo;
 
      done:
-      set_file_offset(f, restore_offset);
+      stbv_set_file_offset(f, restore_offset);
    }
-   return f->total_samples == SAMPLE_unknown ? 0 : f->total_samples;
+   return f->total_samples == STBV_SAMPLE_unknown ? 0 : f->total_samples;
 }
 
-float stb_vorbis_stream_length_in_seconds(stb_vorbis *f)
+STBVDEF float stb_vorbis_stream_length_in_seconds(stb_vorbis *f)
 {
    return stb_vorbis_stream_length_in_samples(f) / (float) f->sample_rate;
 }
 
 
 
-int stb_vorbis_get_frame_float(stb_vorbis *f, int *channels, float ***output)
+STBVDEF int stb_vorbis_get_frame_float(stb_vorbis *f, int *channels, float ***output)
 {
    int len, right,left,i;
-   if (IS_PUSH_MODE(f)) return error(f, VORBIS_invalid_api_mixing);
+   if (STBV_IS_PUSH_MODE(f)) return stbv_error(f, VORBIS_invalid_api_mixing);
 
-   if (!vorbis_decode_packet(f, &len, &left, &right)) {
+   if (!stbv_vorbis_decode_packet(f, &len, &left, &right)) {
       f->channel_buffer_start = f->channel_buffer_end = 0;
       return 0;
    }
 
-   len = vorbis_finish_frame(f, len, left, right);
+   len = stbv_vorbis_finish_frame(f, len, left, right);
    for (i=0; i < f->channels; ++i)
       f->outputs[i] = f->channel_buffers[i] + left;
 
@@ -4940,28 +4948,28 @@ int stb_vorbis_get_frame_float(stb_vorbis *f, int *channels, float ***output)
 
 #ifndef STB_VORBIS_NO_STDIO
 
-stb_vorbis * stb_vorbis_open_file_section(FILE *file, int close_on_free, int *error, const stb_vorbis_alloc *alloc, unsigned int length)
+STBVDEF stb_vorbis * stb_vorbis_open_file_section(FILE *file, int close_on_free, int *error, const stb_vorbis_alloc *alloc, unsigned int length)
 {
    stb_vorbis *f, p;
-   vorbis_init(&p, alloc);
+   stbv_vorbis_init(&p, alloc);
    p.f = file;
-   p.f_start = (uint32) ftell(file);
+   p.f_start = (stbv_uint32) ftell(file);
    p.stream_len   = length;
    p.close_on_free = close_on_free;
-   if (start_decoder(&p)) {
-      f = vorbis_alloc(&p);
+   if (stbv_start_decoder(&p)) {
+      f = stbv_vorbis_alloc(&p);
       if (f) {
          *f = p;
-         vorbis_pump_first_frame(f);
+         stbv_vorbis_pump_first_frame(f);
          return f;
       }
    }
    if (error) *error = p.error;
-   vorbis_deinit(&p);
+   stbv_vorbis_deinit(&p);
    return NULL;
 }
 
-stb_vorbis * stb_vorbis_open_file(FILE *file, int close_on_free, int *error, const stb_vorbis_alloc *alloc)
+STBVDEF stb_vorbis * stb_vorbis_open_file(FILE *file, int close_on_free, int *error, const stb_vorbis_alloc *alloc)
 {
    unsigned int len, start;
    start = (unsigned int) ftell(file);
@@ -4971,7 +4979,7 @@ stb_vorbis * stb_vorbis_open_file(FILE *file, int close_on_free, int *error, con
    return stb_vorbis_open_file_section(file, close_on_free, error, alloc, len);
 }
 
-stb_vorbis * stb_vorbis_open_filename(const char *filename, int *error, const stb_vorbis_alloc *alloc)
+STBVDEF stb_vorbis * stb_vorbis_open_filename(const char *filename, int *error, const stb_vorbis_alloc *alloc)
 {
    FILE *f = fopen(filename, "rb");
    if (f) 
@@ -4981,48 +4989,48 @@ stb_vorbis * stb_vorbis_open_filename(const char *filename, int *error, const st
 }
 #endif // STB_VORBIS_NO_STDIO
 
-stb_vorbis * stb_vorbis_open_memory(const unsigned char *data, int len, int *error, const stb_vorbis_alloc *alloc)
+STBVDEF stb_vorbis * stb_vorbis_open_memory(const unsigned char *data, int len, int *error, const stb_vorbis_alloc *alloc)
 {
    stb_vorbis *f, p;
    if (data == NULL) return NULL;
-   vorbis_init(&p, alloc);
-   p.stream = (uint8 *) data;
-   p.stream_end = (uint8 *) data + len;
-   p.stream_start = (uint8 *) p.stream;
+   stbv_vorbis_init(&p, alloc);
+   p.stream = (stbv_uint8 *) data;
+   p.stream_end = (stbv_uint8 *) data + len;
+   p.stream_start = (stbv_uint8 *) p.stream;
    p.stream_len = len;
    p.push_mode = FALSE;
-   if (start_decoder(&p)) {
-      f = vorbis_alloc(&p);
+   if (stbv_start_decoder(&p)) {
+      f = stbv_vorbis_alloc(&p);
       if (f) {
          *f = p;
-         vorbis_pump_first_frame(f);
+         stbv_vorbis_pump_first_frame(f);
          if (error) *error = VORBIS__no_error;
          return f;
       }
    }
    if (error) *error = p.error;
-   vorbis_deinit(&p);
+   stbv_vorbis_deinit(&p);
    return NULL;
 }
 
 #ifndef STB_VORBIS_NO_INTEGER_CONVERSION
-#define PLAYBACK_MONO     1
-#define PLAYBACK_LEFT     2
-#define PLAYBACK_RIGHT    4
+#define STBV_PLAYBACK_MONO 1
+#define STBV_PLAYBACK_LEFT 2
+#define STBV_PLAYBACK_RIGHT 4
 
-#define L  (PLAYBACK_LEFT  | PLAYBACK_MONO)
-#define C  (PLAYBACK_LEFT  | PLAYBACK_RIGHT | PLAYBACK_MONO)
-#define R  (PLAYBACK_RIGHT | PLAYBACK_MONO)
+#define STBV_L  (STBV_PLAYBACK_LEFT  | STBV_PLAYBACK_MONO)
+#define STBV_C  (STBV_PLAYBACK_LEFT  | STBV_PLAYBACK_RIGHT | STBV_PLAYBACK_MONO)
+#define STBV_R  (STBV_PLAYBACK_RIGHT | STBV_PLAYBACK_MONO)
 
-static int8 channel_position[7][6] =
+static stbv_int8 stbv_channel_position[7][6] =
 {
    { 0 },
-   { C },
-   { L, R },
-   { L, C, R },
-   { L, R, L, R },
-   { L, C, R, L, R },
-   { L, C, R, L, R, C },
+   { STBV_C },
+   { STBV_L, STBV_R },
+   { STBV_L, STBV_C, STBV_R },
+   { STBV_L, STBV_R, STBV_L, STBV_R },
+   { STBV_L, STBV_C, STBV_R, STBV_L, STBV_R },
+   { STBV_L, STBV_C, STBV_R, STBV_L, STBV_R, STBV_C },
 };
 
 
@@ -5030,51 +5038,51 @@ static int8 channel_position[7][6] =
    typedef union {
       float f;
       int i;
-   } float_conv;
+   } stbv_float_conv;
    typedef char stb_vorbis_float_size_test[sizeof(float)==4 && sizeof(int) == 4];
-   #define FASTDEF(x) float_conv x
+   #define STBV_FASTDEF(x) stbv_float_conv x
    // add (1<<23) to convert to int, then divide by 2^SHIFT, then add 0.5/2^SHIFT to round
-   #define MAGIC(SHIFT) (1.5f * (1 << (23-SHIFT)) + 0.5f/(1 << SHIFT))
-   #define ADDEND(SHIFT) (((150-SHIFT) << 23) + (1 << 22))
-   #define FAST_SCALED_FLOAT_TO_INT(temp,x,s) (temp.f = (x) + MAGIC(s), temp.i - ADDEND(s))
-   #define check_endianness()  
+   #define STBV_MAGIC(SHIFT) (1.5f * (1 << (23-SHIFT)) + 0.5f/(1 << SHIFT))
+   #define STBV_ADDEND(SHIFT) (((150-SHIFT) << 23) + (1 << 22))
+   #define STBV_FAST_SCALED_FLOAT_TO_INT(temp,x,s) (temp.f = (x) + STBV_MAGIC(s), temp.i - STBV_ADDEND(s))
+   #define stbv_check_endianness()  
 #else
-   #define FAST_SCALED_FLOAT_TO_INT(temp,x,s) ((int) ((x) * (1 << (s))))
-   #define check_endianness()
-   #define FASTDEF(x)
+   #define STBV_FAST_SCALED_FLOAT_TO_INT(temp,x,s) ((int) ((x) * (1 << (s))))
+   #define stbv_check_endianness()
+   #define STBV_FASTDEF(x)
 #endif
 
-static void copy_samples(short *dest, float *src, int len)
+static void stbv_copy_samples(short *dest, float *src, int len)
 {
    int i;
-   check_endianness();
+   stbv_check_endianness();
    for (i=0; i < len; ++i) {
-      FASTDEF(temp);
-      int v = FAST_SCALED_FLOAT_TO_INT(temp, src[i],15);
+      STBV_FASTDEF(temp);
+      int v = STBV_FAST_SCALED_FLOAT_TO_INT(temp, src[i],15);
       if ((unsigned int) (v + 32768) > 65535)
          v = v < 0 ? -32768 : 32767;
       dest[i] = v;
    }
 }
 
-static void compute_samples(int mask, short *output, int num_c, float **data, int d_offset, int len)
+static void stbv_compute_samples(int mask, short *output, int num_c, float **data, int d_offset, int len)
 {
    #define BUFFER_SIZE  32
    float buffer[BUFFER_SIZE];
    int i,j,o,n = BUFFER_SIZE;
-   check_endianness();
+   stbv_check_endianness();
    for (o = 0; o < len; o += BUFFER_SIZE) {
       memset(buffer, 0, sizeof(buffer));
       if (o + n > len) n = len - o;
       for (j=0; j < num_c; ++j) {
-         if (channel_position[num_c][j] & mask) {
+         if (stbv_channel_position[num_c][j] & mask) {
             for (i=0; i < n; ++i)
                buffer[i] += data[j][d_offset+o+i];
          }
       }
       for (i=0; i < n; ++i) {
-         FASTDEF(temp);
-         int v = FAST_SCALED_FLOAT_TO_INT(temp,buffer[i],15);
+         STBV_FASTDEF(temp);
+         int v = STBV_FAST_SCALED_FLOAT_TO_INT(temp,buffer[i],15);
          if ((unsigned int) (v + 32768) > 65535)
             v = v < 0 ? -32768 : 32767;
          output[o+i] = v;
@@ -5082,38 +5090,38 @@ static void compute_samples(int mask, short *output, int num_c, float **data, in
    }
 }
 
-static void compute_stereo_samples(short *output, int num_c, float **data, int d_offset, int len)
+static void stbv_compute_stereo_samples(short *output, int num_c, float **data, int d_offset, int len)
 {
    #define BUFFER_SIZE  32
    float buffer[BUFFER_SIZE];
    int i,j,o,n = BUFFER_SIZE >> 1;
    // o is the offset in the source data
-   check_endianness();
+   stbv_check_endianness();
    for (o = 0; o < len; o += BUFFER_SIZE >> 1) {
       // o2 is the offset in the output data
       int o2 = o << 1;
       memset(buffer, 0, sizeof(buffer));
       if (o + n > len) n = len - o;
       for (j=0; j < num_c; ++j) {
-         int m = channel_position[num_c][j] & (PLAYBACK_LEFT | PLAYBACK_RIGHT);
-         if (m == (PLAYBACK_LEFT | PLAYBACK_RIGHT)) {
+         int m = stbv_channel_position[num_c][j] & (STBV_PLAYBACK_LEFT | STBV_PLAYBACK_RIGHT);
+         if (m == (STBV_PLAYBACK_LEFT | STBV_PLAYBACK_RIGHT)) {
             for (i=0; i < n; ++i) {
                buffer[i*2+0] += data[j][d_offset+o+i];
                buffer[i*2+1] += data[j][d_offset+o+i];
             }
-         } else if (m == PLAYBACK_LEFT) {
+         } else if (m == STBV_PLAYBACK_LEFT) {
             for (i=0; i < n; ++i) {
                buffer[i*2+0] += data[j][d_offset+o+i];
             }
-         } else if (m == PLAYBACK_RIGHT) {
+         } else if (m == STBV_PLAYBACK_RIGHT) {
             for (i=0; i < n; ++i) {
                buffer[i*2+1] += data[j][d_offset+o+i];
             }
          }
       }
       for (i=0; i < (n<<1); ++i) {
-         FASTDEF(temp);
-         int v = FAST_SCALED_FLOAT_TO_INT(temp,buffer[i],15);
+         STBV_FASTDEF(temp);
+         int v = STBV_FAST_SCALED_FLOAT_TO_INT(temp,buffer[i],15);
          if ((unsigned int) (v + 32768) > 65535)
             v = v < 0 ? -32768 : 32767;
          output[o2+i] = v;
@@ -5121,48 +5129,48 @@ static void compute_stereo_samples(short *output, int num_c, float **data, int d
    }
 }
 
-static void convert_samples_short(int buf_c, short **buffer, int b_offset, int data_c, float **data, int d_offset, int samples)
+static void stbv_convert_samples_short(int buf_c, short **buffer, int b_offset, int data_c, float **data, int d_offset, int samples)
 {
    int i;
    if (buf_c != data_c && buf_c <= 2 && data_c <= 6) {
-      static int channel_selector[3][2] = { {0}, {PLAYBACK_MONO}, {PLAYBACK_LEFT, PLAYBACK_RIGHT} };
+      static int channel_selector[3][2] = { {0}, {STBV_PLAYBACK_MONO}, {STBV_PLAYBACK_LEFT, STBV_PLAYBACK_RIGHT} };
       for (i=0; i < buf_c; ++i)
-         compute_samples(channel_selector[buf_c][i], buffer[i]+b_offset, data_c, data, d_offset, samples);
+         stbv_compute_samples(channel_selector[buf_c][i], buffer[i]+b_offset, data_c, data, d_offset, samples);
    } else {
       int limit = buf_c < data_c ? buf_c : data_c;
       for (i=0; i < limit; ++i)
-         copy_samples(buffer[i]+b_offset, data[i]+d_offset, samples);
+         stbv_copy_samples(buffer[i]+b_offset, data[i]+d_offset, samples);
       for (   ; i < buf_c; ++i)
          memset(buffer[i]+b_offset, 0, sizeof(short) * samples);
    }
 }
 
-int stb_vorbis_get_frame_short(stb_vorbis *f, int num_c, short **buffer, int num_samples)
+STBVDEF int stb_vorbis_get_frame_short(stb_vorbis *f, int num_c, short **buffer, int num_samples)
 {
    float **output;
    int len = stb_vorbis_get_frame_float(f, NULL, &output);
    if (len > num_samples) len = num_samples;
    if (len)
-      convert_samples_short(num_c, buffer, 0, f->channels, output, 0, len);
+      stbv_convert_samples_short(num_c, buffer, 0, f->channels, output, 0, len);
    return len;
 }
 
-static void convert_channels_short_interleaved(int buf_c, short *buffer, int data_c, float **data, int d_offset, int len)
+static void stbv_convert_channels_short_interleaved(int buf_c, short *buffer, int data_c, float **data, int d_offset, int len)
 {
    int i;
-   check_endianness();
+   stbv_check_endianness();
    if (buf_c != data_c && buf_c <= 2 && data_c <= 6) {
       assert(buf_c == 2);
       for (i=0; i < buf_c; ++i)
-         compute_stereo_samples(buffer, data_c, data, d_offset, len);
+         stbv_compute_stereo_samples(buffer, data_c, data, d_offset, len);
    } else {
       int limit = buf_c < data_c ? buf_c : data_c;
       int j;
       for (j=0; j < len; ++j) {
          for (i=0; i < limit; ++i) {
-            FASTDEF(temp);
+            STBV_FASTDEF(temp);
             float f = data[i][d_offset+j];
-            int v = FAST_SCALED_FLOAT_TO_INT(temp, f,15);//data[i][d_offset+j],15);
+            int v = STBV_FAST_SCALED_FLOAT_TO_INT(temp, f,15);//data[i][d_offset+j],15);
             if ((unsigned int) (v + 32768) > 65535)
                v = v < 0 ? -32768 : 32767;
             *buffer++ = v;
@@ -5173,7 +5181,7 @@ static void convert_channels_short_interleaved(int buf_c, short *buffer, int dat
    }
 }
 
-int stb_vorbis_get_frame_short_interleaved(stb_vorbis *f, int num_c, short *buffer, int num_shorts)
+STBVDEF int stb_vorbis_get_frame_short_interleaved(stb_vorbis *f, int num_c, short *buffer, int num_shorts)
 {
    float **output;
    int len;
@@ -5181,12 +5189,12 @@ int stb_vorbis_get_frame_short_interleaved(stb_vorbis *f, int num_c, short *buff
    len = stb_vorbis_get_frame_float(f, NULL, &output);
    if (len) {
       if (len*num_c > num_shorts) len = num_shorts / num_c;
-      convert_channels_short_interleaved(num_c, buffer, f->channels, output, 0, len);
+      stbv_convert_channels_short_interleaved(num_c, buffer, f->channels, output, 0, len);
    }
    return len;
 }
 
-int stb_vorbis_get_samples_short_interleaved(stb_vorbis *f, int channels, short *buffer, int num_shorts)
+STBVDEF int stb_vorbis_get_samples_short_interleaved(stb_vorbis *f, int channels, short *buffer, int num_shorts)
 {
    float **outputs;
    int len = num_shorts / channels;
@@ -5197,7 +5205,7 @@ int stb_vorbis_get_samples_short_interleaved(stb_vorbis *f, int channels, short 
       int k = f->channel_buffer_end - f->channel_buffer_start;
       if (n+k >= len) k = len - n;
       if (k)
-         convert_channels_short_interleaved(channels, buffer, f->channels, f->channel_buffers, f->channel_buffer_start, k);
+         stbv_convert_channels_short_interleaved(channels, buffer, f->channels, f->channel_buffers, f->channel_buffer_start, k);
       buffer += k*channels;
       n += k;
       f->channel_buffer_start += k;
@@ -5207,7 +5215,7 @@ int stb_vorbis_get_samples_short_interleaved(stb_vorbis *f, int channels, short 
    return n;
 }
 
-int stb_vorbis_get_samples_short(stb_vorbis *f, int channels, short **buffer, int len)
+STBVDEF int stb_vorbis_get_samples_short(stb_vorbis *f, int channels, short **buffer, int len)
 {
    float **outputs;
    int n=0;
@@ -5217,7 +5225,7 @@ int stb_vorbis_get_samples_short(stb_vorbis *f, int channels, short **buffer, in
       int k = f->channel_buffer_end - f->channel_buffer_start;
       if (n+k >= len) k = len - n;
       if (k)
-         convert_samples_short(channels, buffer, n, f->channels, f->channel_buffers, f->channel_buffer_start, k);
+         stbv_convert_samples_short(channels, buffer, n, f->channels, f->channel_buffers, f->channel_buffer_start, k);
       n += k;
       f->channel_buffer_start += k;
       if (n == len) break;
@@ -5227,7 +5235,7 @@ int stb_vorbis_get_samples_short(stb_vorbis *f, int channels, short **buffer, in
 }
 
 #ifndef STB_VORBIS_NO_STDIO
-int stb_vorbis_decode_filename(const char *filename, int *channels, int *sample_rate, short **output)
+STBVDEF int stb_vorbis_decode_filename(const char *filename, int *channels, int *sample_rate, short **output)
 {
    int data_len, offset, total, limit, error;
    short *data;
@@ -5267,7 +5275,7 @@ int stb_vorbis_decode_filename(const char *filename, int *channels, int *sample_
 }
 #endif // NO_STDIO
 
-int stb_vorbis_decode_memory(const uint8 *mem, int len, int *channels, int *sample_rate, short **output)
+STBVDEF int stb_vorbis_decode_memory(const stbv_uint8 *mem, int len, int *channels, int *sample_rate, short **output)
 {
    int data_len, offset, total, limit, error;
    short *data;
@@ -5307,7 +5315,7 @@ int stb_vorbis_decode_memory(const uint8 *mem, int len, int *channels, int *samp
 }
 #endif // STB_VORBIS_NO_INTEGER_CONVERSION
 
-int stb_vorbis_get_samples_float_interleaved(stb_vorbis *f, int channels, float *buffer, int num_floats)
+STBVDEF int stb_vorbis_get_samples_float_interleaved(stb_vorbis *f, int channels, float *buffer, int num_floats)
 {
    float **outputs;
    int len = num_floats / channels;
@@ -5334,7 +5342,7 @@ int stb_vorbis_get_samples_float_interleaved(stb_vorbis *f, int channels, float 
    return n;
 }
 
-int stb_vorbis_get_samples_float(stb_vorbis *f, int channels, float **buffer, int num_samples)
+STBVDEF int stb_vorbis_get_samples_float(stb_vorbis *f, int channels, float **buffer, int num_samples)
 {
    float **outputs;
    int n=0;
@@ -5364,7 +5372,7 @@ int stb_vorbis_get_samples_float(stb_vorbis *f, int channels, float **buffer, in
 /* Version history
     1.12    - 2017-11-21 - limit residue begin/end to blocksize/2 to avoid large temp allocs in bad/corrupt files
     1.11    - 2017-07-23 - fix MinGW compilation 
-    1.10    - 2017-03-03 - more robust seeking; fix negative ilog(); clear error in open_memory
+    1.10    - 2017-03-03 - more robust seeking; fix negative stbv_ilog(); clear error in open_memory
     1.09    - 2016-04-04 - back out 'avoid discarding last frame' fix from previous version
     1.08    - 2016-04-02 - fixed multiple warnings; fix setup memory leaks;
                            avoid discarding last frame of audio data
@@ -5416,7 +5424,7 @@ int stb_vorbis_get_samples_float(stb_vorbis *f, int channels, float **buffer, in
     0.90 - first public release
 */
 
-#endif // STB_VORBIS_HEADER_ONLY
+#endif // STB_VORBIS_IMPLEMENTATION
 
 
 /*


### PR DESCRIPTION
I wanted to use stb_vorbis as it's the only public domain vorbis decoder I'm aware of, but it was in this weird sort-of-a-source-file-but-also-not state that made it unusable for me, meaning it would need to be converted to a proper header-only library. Since there was already demand for this in #25 I decided to bite the bullet and do the conversion myself based on the suggestions in that issue.

All I did was prefix everything with `stbv_` or `STBV_` respectively and add a `STB_VORBIS_STATIC` option similar to the one in stb_image. Still took me like two hours because of the sheer amount of code to go through. I also made a small fix regarding `alloca` getting redefined and breaking compilation on my MinGW.

On some other stb libraries the prefixes used for internals have two underscores, if this is preferred all you'll need to do is case-sensitively search-replace `stbv_` to `stbv__` and `STBV_` to `STBV__`. Personally I think a single underscore is sufficient here, but the decision is ultimately up to the maintainer(s).

Here's some additional things I noticed while going through the code for my prefixing:

1. The `check_endianness()` macro (now `stbv_check_endianness()`) does nothing. I suspect this is a leftover from an earlier implementation needing to do endian-specific stuff. If it really isn't needed anymore, it should be removed.

2. Using `__forceinline` seems more of a hassle than it's worth (see the issue with MinGW) and modern compilers are smart enough to inline stuff themselves anyway. Could be replaced either with `inline` if a hint to the compiler is desired, or removed entirely, thus letting the compiler make its own inlining decisions.

3. The `VORBIS_packet_comment` enum (now `STBV_VORBIS_packet_comment`) appears to be unused, possibly another leftover from something long-removed.

4. In the new header-only form the various `#ifndef` checks in the header section are likely not going to do anything. I've left them in because maybe there's a use to them that I'm not seeing, but if there isn't they probably should be removed and replaced with notices describing which functions are disabled by which defines.

I've added myself to the contributors list as "BareRose", hope that's okay.