### PR TITLE
fix warnings for unreferenced formal parameter in stb_image

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -101,6 +101,7 @@ RECENT REVISION HISTORY:
     Julian Raschke          Gregory Mullen     Baldur Karlsson    github:poppolopoppo
     Christian Floisand      Kevin Schmidt                         github:darealshinji
     Blazej Dariusz Roszkowski                                     github:Michaelangel007
+    Vasu Mahesh
 */
 
 #ifndef STBI_INCLUDE_STB_IMAGE_H
@@ -6338,6 +6339,8 @@ static stbi_uc *stbi__process_gif_raster(stbi__context *s, stbi__gif *g)
 // two back is the image from two frames ago, used for a very specific disposal format
 static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, int req_comp, stbi_uc *two_back)
 {
+   STBI_NOTUSED(req_comp);
+
    int dispose; 
    int first_frame; 
    int pi; 
@@ -6562,6 +6565,8 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
 
 static void *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
 {
+   STBI_NOTUSED(ri);
+
    stbi_uc *u = 0;
    stbi__gif g;
    memset(&g, 0, sizeof(g));


### PR DESCRIPTION
Hi,

This is a tiny change to silence the unused parameter warning. Apparently [PR #539](https://github.com/nothings/stb/pull/563) already tried this but the PR was dead. I followed up with the message left there and fixed it.

Warnings generated that were fixed:
```
stb_image.h(6339): error C2220: warning treated as error - no 'object' file generated
stb_image.h(6339): warning C4100: 'req_comp': unreferenced formal parameter
stb_image.h(6563): warning C4100: 'ri': unreferenced formal parameter
```

Let me know if I need to change some things.

Thanks!
