### PR TITLE
Fixes for stb_leakcheck.h

### DIFF
--- a/stb_leakcheck.h
+++ b/stb_leakcheck.h
@@ -91,19 +91,23 @@ void *stb_leakcheck_realloc(void *ptr, size_t sz, const char *file, int line)
 
 static void stblkck_internal_print(const char *reason, const char *file,  int line, size_t size, void *ptr)
 {
-#if (defined(_MSC_VER) && _MSC_VER < 1900) /* 1900=VS 2015 */ || defined(__MINGW32__)
+#if defined(_MSC_VER) && _MSC_VER < 1900 // 1900=VS 2015
    // Compilers that use the old MS C runtime library don't have %zd
    // and the older ones don't even have %lld either... however, the old compilers
    // without "long long" don't support 64-bit targets either, so here's the
    // compromise:
-   #if (defined(_MSC_VER) && _MSC_VER < 1400) /* before VS 2005 */ || defined(__MINGW32__)
+   #if defined(_MSC_VER) && _MSC_VER < 1400 // before VS 2005
       printf("%-6s: %s (%4d): %8d bytes at %p\n", reason, file, line, (int)size, ptr);
    #else
       printf("%-6s: %s (%4d): %8lld bytes at %p\n", reason, file, line, (long long)size, ptr);
    #endif
 #else
    // Assume we have %zd on other targets.
-   printf("%-6s: %s (%4d): %zd bytes at %p\n", reason, file, line, size, ptr);
+   #ifdef __MINGW32__
+      __mingw_printf("%-6s: %s (%4d): %zd bytes at %p\n", reason, file, line, size, ptr);
+   #else
+      printf("%-6s: %s (%4d): %zd bytes at %p\n", reason, file, line, size, ptr);
+   #endif
 #endif
 }
 

--- a/stb_leakcheck.h
+++ b/stb_leakcheck.h
@@ -96,7 +96,7 @@ static void stblkck_internal_print(const char *reason, stb_leakcheck_malloc_info
    // and the older ones don't even have %lld either... however, the old compilers
    // without "long long" don't support 64-bit targets either, so here's the
    // compromise:
-   #if defined(_MSC_VER) && _MSC_VER < 1400 // before VS 2005
+   #if _MSC_VER < 1400 // before VS 2005
       printf("%s: %s (%4d): %8d bytes at %p\n", reason, mi->file, mi->line, (int)mi->size, (void*)(mi+1));
    #else
       printf("%s: %s (%4d): %16lld bytes at %p\n", reason, mi->file, mi->line, (long long)mi->size, (void*)(mi+1));

--- a/stb_leakcheck.h
+++ b/stb_leakcheck.h
@@ -58,8 +58,8 @@ void stb_leakcheck_free(void *ptr)
          mi->prev->next = mi->next;
       if (mi->next)
          mi->next->prev = mi->prev;
-      #endif
       free(mi);
+      #endif
    }
 }
 

--- a/stb_leakcheck.h
+++ b/stb_leakcheck.h
@@ -114,7 +114,7 @@ void stb_leakcheck_dumpmem(void)
       if ((ptrdiff_t) mi->size >= 0)
       {
          stblkck_internal_print("LEAKED", mi->file, mi->line, mi->size, mi+1);
-         printf("LEAKED: %s (%4d): %8d bytes at %p\n", mi->file, mi->line, (int) mi->size, mi+1);
+         printf("LEAKED: %s (%4d): %8d bytes at %p\n", mi->file, mi->line, (int) mi->size, (void*)(mi+1));
       }
       mi = mi->next;
    }
@@ -124,7 +124,7 @@ void stb_leakcheck_dumpmem(void)
       if ((ptrdiff_t) mi->size < 0)
       {
          stblkck_internal_print("FREED", mi->file, mi->line, ~mi->size, mi+1);
-         printf("FREED : %s (%4d): %8d bytes at %p\n", mi->file, mi->line, (int) ~mi->size, mi+1);
+         printf("FREED : %s (%4d): %8d bytes at %p\n", mi->file, mi->line, (int) ~mi->size, (void*)(mi+1));
       }
       mi = mi->next;
    }

--- a/stb_leakcheck.h
+++ b/stb_leakcheck.h
@@ -96,7 +96,7 @@ static void stblkck_internal_print(const char *reason, const char *file,  int li
    // and the older ones don't even have %lld either... however, the old compilers
    // without "long long" don't support 64-bit targets either, so here's the
    // compromise:
-   #if defined(_MSC_VER) && _MSC_VER < 1400 // before VS 2005
+   #if (defined(_MSC_VER) && _MSC_VER < 1400) /* before VS 2005 */ || defined(__MINGW32__)
       printf("%-6s: %s (%4d): %8d bytes at %p\n", reason, file, line, (int)size, ptr);
    #else
       printf("%-6s: %s (%4d): %8lld bytes at %p\n", reason, file, line, (long long)size, ptr);
@@ -112,16 +112,20 @@ void stb_leakcheck_dumpmem(void)
    stb_leakcheck_malloc_info *mi = mi_head;
    while (mi) {
       if ((ptrdiff_t) mi->size >= 0)
+      {
          stblkck_internal_print("LEAKED", mi->file, mi->line, mi->size, mi+1);
          printf("LEAKED: %s (%4d): %8d bytes at %p\n", mi->file, mi->line, (int) mi->size, mi+1);
+      }
       mi = mi->next;
    }
    #ifdef STB_LEAKCHECK_SHOWALL
    mi = mi_head;
    while (mi) {
       if ((ptrdiff_t) mi->size < 0)
+      {
          stblkck_internal_print("FREED", mi->file, mi->line, ~mi->size, mi+1);
          printf("FREED : %s (%4d): %8d bytes at %p\n", mi->file, mi->line, (int) ~mi->size, mi+1);
+      }
       mi = mi->next;
    }
    #endif
@@ -130,6 +134,8 @@ void stb_leakcheck_dumpmem(void)
 
 #ifndef INCLUDE_STB_LEAKCHECK_H
 #define INCLUDE_STB_LEAKCHECK_H
+
+#include <stdlib.h> // we want to define the macros *after* stdlib to avoid a slew of errors
 
 #define malloc(sz)    stb_leakcheck_malloc(sz, __FILE__, __LINE__)
 #define free(p)       stb_leakcheck_free(p)

--- a/stb_leakcheck.h
+++ b/stb_leakcheck.h
@@ -116,20 +116,14 @@ void stb_leakcheck_dumpmem(void)
    stb_leakcheck_malloc_info *mi = mi_head;
    while (mi) {
       if ((ptrdiff_t) mi->size >= 0)
-      {
          stblkck_internal_print("LEAKED", mi->file, mi->line, mi->size, mi+1);
-         printf("LEAKED: %s (%4d): %8d bytes at %p\n", mi->file, mi->line, (int) mi->size, (void*)(mi+1));
-      }
       mi = mi->next;
    }
    #ifdef STB_LEAKCHECK_SHOWALL
    mi = mi_head;
    while (mi) {
       if ((ptrdiff_t) mi->size < 0)
-      {
          stblkck_internal_print("FREED", mi->file, mi->line, ~mi->size, mi+1);
-         printf("FREED : %s (%4d): %8d bytes at %p\n", mi->file, mi->line, (int) ~mi->size, (void*)(mi+1));
-      }
       mi = mi->next;
    }
    #endif


### PR DESCRIPTION
I ran into a couple of problems while trying to use this with my program:

My compiler (64-bit MinGW-w64 GCC 8.2.0) complained about not recognising `%lld` format specifiers.

The compiler also warned about non-guarding `if`s. I ignored it at first, but then I noticed my program crashed when it ran stb_leakcheck_dumpmem. Making the `if`s guard fixed that.

After that, the lib worked until I changed how it was included: instead of tacking a debug-only `#include` at the start of every file, I switched to using GCC's `-include` option to force-include it in every file. But doing that gave me errors about size_t not being defined. And after fixing that, I instead got errors about the #defines messing with stdlib.h. So to fix those I made the declaration-only part of the header include stdlib.h.

EDIT: One last "fix" was needed to make this work with my program, but I'm not sure if it's worth adding. stb_leakcheck.h was included in C++ code, but the implementation was in a C source file. To get them to play along, I had to wrap the header's contents in an `extern "C"`.