### PR TITLE
Strict aliasing rules and implementation defined shifting changes.

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -9,6 +9,7 @@
 //    Fabian "ryg" Giesen (reformatting)
 //
 // Contributors (bugfixes):
+//    Adam Allison
 //    github:d26435
 //    github:trex78
 //    Jari Komppa (SI suffixes)

--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -224,9 +224,15 @@ static stbsp__int32 stbsp__real_to_parts(stbsp__int64 *bits, stbsp__int32 *expo,
 
 static char stbsp__period = '.';
 static char stbsp__comma = ',';
-static char stbsp__digitpair[201] =
+static union {
+   char digitpair_8bit[201];
+   stbsp__uint16 digitpair_16bit[201 / 2];
+} stbsp__digitpair = {
+   {
    "0001020304050607080910111213141516171819202122232425262728293031323334353637383940414243444546474849505152535455565758596061626364656667686970717273747576"
-   "7778798081828384858687888990919293949596979899";
+   "7778798081828384858687888990919293949596979899"
+   }
+};
 
 STBSP__PUBLICDEF void STB_SPRINTF_DECORATE(set_separators)(char pcomma, char pperiod)
 {
@@ -670,7 +676,7 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
          if (dp > 0) {
             pr = (dp < (stbsp__int32)l) ? l - dp : 0;
          } else {
-            pr = -dp + ((pr > (stbsp__int32)l) ? l : pr);
+            pr = -dp + ((pr > (stbsp__int32)l) ? (stbsp__int32)l : pr);
          }
          goto dofloatfromg;
 
@@ -1030,7 +1036,7 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
             if ((fl & STBSP__TRIPLET_COMMA) == 0) {
                do {
                   s -= 2;
-                  *(stbsp__uint16 *)s = *(stbsp__uint16 *)&stbsp__digitpair[(n % 100) * 2];
+                  *(stbsp__uint16 *)s = stbsp__digitpair.digitpair_16bit[(n % 100)];
                   n /= 100;
                } while (n);
             }
@@ -1428,7 +1434,7 @@ static stbsp__int32 stbsp__real_to_parts(stbsp__int64 *bits, stbsp__int32 *expo,
    *bits = b & ((((stbsp__uint64)1) << 52) - 1);
    *expo = (stbsp__int32)(((b >> 52) & 2047) - 1023);
 
-   return (stbsp__int32)(b >> 63);
+   return (stbsp__int32)((stbsp__uint64)b >> 63);
 }
 
 static double const stbsp__bot[23] = {
@@ -1638,7 +1644,7 @@ static stbsp__int32 stbsp__real_to_str(char const **start, stbsp__uint32 *len, c
    d = value;
    STBSP__COPYFP(bits, d);
    expo = (stbsp__int32)((bits >> 52) & 2047);
-   ng = (stbsp__int32)(bits >> 63);
+   ng = (stbsp__int32)((stbsp__uint64)bits >> 63);
    if (ng)
       d = -d;
 
@@ -1748,7 +1754,7 @@ static stbsp__int32 stbsp__real_to_str(char const **start, stbsp__uint32 *len, c
       }
       while (n) {
          out -= 2;
-         *(stbsp__uint16 *)out = *(stbsp__uint16 *)&stbsp__digitpair[(n % 100) * 2];
+         *(stbsp__uint16 *)out = stbsp__digitpair.digitpair_16bit[(n % 100)];
          n /= 100;
          e += 2;
       }


### PR DESCRIPTION
3 minor fixes,
1 strict alignment, I don't think the C standard requires alignment on global variables other that what is required for that type. I could be wrong, but my compiler spit out warnings, so that prompted the change

1 right shifting of something to get the sign bit is 'implementation defined', so I cast it to a u64.

1 minor casting of variable 'l' (length) to match 'pr' (precision).

Thank you,
Adam Allison

Here is want I used to test it:

#include <stdio.h>
#define STB_SPRINTF_IMPLEMENTATION 1
#define STB_SPRINTF_NOUNALIGNED 1
#define STB_SPRINTF_STATIC 1
#include "stb_sprintf.h"
/* expected is 1.01 12345 0x1.028F5CP+0 -0x1.028F5CP+0 -1.01 */
int main(void)
{
    char buffer[512];

    stbsp_snprintf(buffer, 512, "%G", 1.01F);
    puts(buffer);

    stbsp_snprintf(buffer, 512, "%d", 12345);
    puts(buffer);

    stbsp_snprintf(buffer, 512, "%A", 1.01F);
    puts(buffer);
    stbsp_snprintf(buffer, 512, "%A", -1.01F);
    puts(buffer);

    stbsp_snprintf(buffer, 512, "%G", -1.01F);
    puts(buffer);

    return 0;
}