### PR TITLE
stb_sprintf: fix integer size for %ld

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -437,6 +437,7 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
          break;
       // are we 64-bit (unix style)
       case 'l':
+         fl |= ((sizeof(long int) == 8) ? STBSP__INTMAX : 0);
          ++f;
          if (f[0] == 'l') {
             fl |= STBSP__INTMAX;


### PR DESCRIPTION
`long int` may be 64 bit on some systems.