### PR TITLE
Some GIF fixes stb_image

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -6375,8 +6375,10 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
             }
          }
       } else if (dispose == 2) { 
-	 // clear canvas to solid black transparency
-	 memset( g->out, 0x00, 4 * g->w * g->h );
+	 // clear canvas region to solid black transparency
+	 for (pi = 0; pi < pcount; ++pi)
+	    if (g->history[pi])
+	       memset( g->out + pi * 4,  0x00, 4 );
       } else {
          // This is a non-disposal case eithe way, so just 
          // leave the pixels as is, and they will become the new background


### PR DESCRIPTION
### Fix 1: Disposal method 2 clears canvas
The old code was restoring pixels from an earlier frame with disposal method 2 in this test GIF. This disposal method should instead clear the canvas.
Left: Original GIF
Right: `stb_image.h` behavior, pre-fix
![test4b](https://user-images.githubusercontent.com/33639078/50113153-1ca74500-020f-11e9-8b24-20f134cd3bc6.gif) ![test4bstb](https://user-images.githubusercontent.com/33639078/50113154-1dd87200-020f-11e9-9c64-f13e107b71d3.gif)

### Fix 2: First frame preserves transparency for unspecified pixels.
The old code was clearing the pixels surrounding the first frame to a background color. They should instead remain transparent.
Left: Boundaries of first frame
Center: Original GIF
Right: `stb_image.h` behavior, pre-fix
![mariofallboundaries](https://user-images.githubusercontent.com/33639078/50112955-9a1e8580-020e-11e9-8a5e-54262f9268a0.png) ![mariofall](https://user-images.githubusercontent.com/33639078/50112767-1bc1e380-020e-11e9-94f4-f4153dab282f.gif) ![mariofallstb](https://user-images.githubusercontent.com/33639078/50112774-1d8ba700-020e-11e9-9218-ee63eadd4fc0.gif)
