### PR TITLE
hdr export segfault fix

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -694,7 +694,7 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
       s->func(s->context, buffer, len);
 
       for(i=0; i < y; i++)
-         stbiw__write_hdr_scanline(s, x, comp, scratch, data + comp*x*(stbi__flip_vertically_on_write ? y-1-i : i)*x);
+         stbiw__write_hdr_scanline(s, x, comp, scratch, data + comp*x*(stbi__flip_vertically_on_write ? y-1-i : i));
       STBIW_FREE(scratch);
       return 1;
    }


### PR DESCRIPTION
The width of the image is used twice to offset the data causing a segfault when writing an hdr image. This commit fixes the issue.