### PR TITLE
Fix minor warnings emitted by PVS Studio.

### DIFF
--- a/stb_textedit.h
+++ b/stb_textedit.h
@@ -558,7 +558,6 @@ static void stb_textedit_find_charpos(StbFindState *find, STB_TEXTEDIT_STRING *s
 
    // now scan to find xpos
    find->x = r.x0;
-   i = 0;
    for (i=0; first+i < n; ++i)
       find->x += STB_TEXTEDIT_GETWIDTH(str, first, i);
 }

--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -2367,8 +2367,6 @@ static stbtt_int32  stbtt__GetGlyphClass(stbtt_uint8 *classDefTable, int glyph)
 
             if (glyph >= startGlyphID && glyph < startGlyphID + glyphCount)
                 return (stbtt_int32)ttUSHORT(classDef1ValueArray + 2 * (glyph - startGlyphID));
-
-            classDefTable = classDef1ValueArray + 2 * glyphCount;
         } break;
 
         case 2: {
@@ -2391,8 +2389,6 @@ static stbtt_int32  stbtt__GetGlyphClass(stbtt_uint8 *classDefTable, int glyph)
                 else
                     return (stbtt_int32)ttUSHORT(classRangeRecord + 4);
             }
-
-            classDefTable = classRangeRecords + 6 * classRangeCount;
         } break;
 
         default: {


### PR DESCRIPTION
Fix 3 warnings emitted by PVS Studio static analyzer for Visual Studio.

in stb_textedit.h:
- variable `i` is assigned twice.

in stb_truetype.h
- variable `classDefTable` assigned but never used afterwards.
Those assignments might be useful documentation in case of further modifications, and may be commented out instead.

(
FYI there are a dozen more warnings emitted by PVS Studio, the others being mostly false positive or less obvious to fix. Therefore those 3 fixes are a little superfluous in the sense that a user of PVS Studio will stumble on more. I can paste you the other warnings if you want.

PVS Studio offers free licence for open-source developers:
https://www.viva64.com/en/open-source-license/
)