### PR TITLE
Remove trailing whitespace after backslash

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -248,7 +248,7 @@
 //   Documentation & header file        520 LOC  \___ 660 LOC documentation
 //   Sample code                        140 LOC  /
 //   Truetype parsing                   620 LOC  ---- 620 LOC TrueType
-//   Software rasterization             240 LOC  \                           
+//   Software rasterization             240 LOC  \
 //   Curve tessellation                 120 LOC   \__ 550 LOC Bitmap creation
 //   Bitmap management                  100 LOC   /
 //   Baked bitmap interface              70 LOC  /

--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -246,12 +246,12 @@
 // SOURCE STATISTICS (based on v0.6c, 2050 LOC)
 //
 //   Documentation & header file        520 LOC  \___ 660 LOC documentation
-//   Sample code                        140 LOC  /
+//   Sample code                        140 LOC  /    ...
 //   Truetype parsing                   620 LOC  ---- 620 LOC TrueType
-//   Software rasterization             240 LOC  \
+//   Software rasterization             240 LOC  \    ...
 //   Curve tessellation                 120 LOC   \__ 550 LOC Bitmap creation
-//   Bitmap management                  100 LOC   /
-//   Baked bitmap interface              70 LOC  /
+//   Bitmap management                  100 LOC   /   ...
+//   Baked bitmap interface              70 LOC  /    ...
 //   Font name matching & access        150 LOC  ---- 150 
 //   C runtime library abstraction       60 LOC  ----  60
 //


### PR DESCRIPTION
Remove trailing whitespace after backslash in `stb_truetype.h` that causes warnings on clang and GCC
"backslash and newline separated by space [-Wblackslash-newline-escape]"
 
Fixes https://github.com/nothings/stb/issues/707
