### PR TITLE
Support for custom stream using callbacks (i.e., C++ std::istream)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,29 +11,29 @@ by Jorge L. "VinoBS" Rodriguez, and stb_sprintf by Jeff Roberts.
 
 library    | lastest version | category | LoC | description
 --------------------- | ---- | -------- | --- | --------------------------------
-**[stb_vorbis.c](stb_vorbis.c)** | 1.14 | audio | 5462 | decode ogg vorbis files from file/memory to float/16-bit signed output
-**[stb_image.h](stb_image.h)** | 2.19 | graphics | 7462 | image loading/decoding from file/memory: JPG, PNG, TGA, BMP, PSD, GIF, HDR, PIC
-**[stb_truetype.h](stb_truetype.h)** | 1.19 | graphics | 4853 | parse, decode, and rasterize characters from truetype fonts
-**[stb_image_write.h](stb_image_write.h)** | 1.09 | graphics | 1568 | image writing to disk: PNG, TGA, BMP
+**[stb_vorbis.c](stb_vorbis.c)** | 1.15 | audio | 5479 | decode ogg vorbis files from file/memory to float/16-bit signed output
+**[stb_image.h](stb_image.h)** | 2.20 | graphics | 7529 | image loading/decoding from file/memory: JPG, PNG, TGA, BMP, PSD, GIF, HDR, PIC
+**[stb_truetype.h](stb_truetype.h)** | 1.20 | graphics | 4894 | parse, decode, and rasterize characters from truetype fonts
+**[stb_image_write.h](stb_image_write.h)** | 1.10 | graphics | 1625 | image writing to disk: PNG, TGA, BMP
 **[stb_image_resize.h](stb_image_resize.h)** | 0.95 | graphics | 2627 | resize images larger/smaller with good quality
-**[stb_rect_pack.h](stb_rect_pack.h)** | 0.11 | graphics | 624 | simple 2D rectangle packer with decent quality
-**[stb_sprintf.h](stb_sprintf.h)** | 1.05 | utility | 1833 | fast sprintf, snprintf for C/C++
+**[stb_rect_pack.h](stb_rect_pack.h)** | 0.99 | graphics | 619 | simple 2D rectangle packer with decent quality
+**[stb_sprintf.h](stb_sprintf.h)** | 1.06 | utility | 1860 | fast sprintf, snprintf for C/C++
 **[stretchy_buffer.h](stretchy_buffer.h)** | 1.03 | utility | 262 | typesafe dynamic array for C (i.e. approximation to vector<>), doesn't compile as C++
-**[stb_textedit.h](stb_textedit.h)** | 1.12 | user&nbsp;interface | 1404 | guts of a text editor for games etc implementing them from scratch
-**[stb_voxel_render.h](stb_voxel_render.h)** | 0.85 | 3D&nbsp;graphics | 3803 | Minecraft-esque voxel rendering "engine" with many more features
+**[stb_textedit.h](stb_textedit.h)** | 1.13 | user&nbsp;interface | 1404 | guts of a text editor for games etc implementing them from scratch
+**[stb_voxel_render.h](stb_voxel_render.h)** | 0.86 | 3D&nbsp;graphics | 3804 | Minecraft-esque voxel rendering "engine" with many more features
 **[stb_dxt.h](stb_dxt.h)** | 1.08b | 3D&nbsp;graphics | 728 | Fabian "ryg" Giesen's real-time DXT compressor
-**[stb_perlin.h](stb_perlin.h)** | 0.3 | 3D&nbsp;graphics | 316 | revised Perlin noise (3D input, 1D output)
+**[stb_perlin.h](stb_perlin.h)** | 0.4 | 3D&nbsp;graphics | 366 | revised Perlin noise (3D input, 1D output)
 **[stb_easy_font.h](stb_easy_font.h)** | 1.0 | 3D&nbsp;graphics | 303 | quick-and-dirty easy-to-deploy bitmap font for printing frame rate, etc
-**[stb_tilemap_editor.h](stb_tilemap_editor.h)** | 0.38 | game&nbsp;dev | 4172 | embeddable tilemap editor
+**[stb_tilemap_editor.h](stb_tilemap_editor.h)** | 0.39 | game&nbsp;dev | 4174 | embeddable tilemap editor
 **[stb_herringbone_wa...](stb_herringbone_wang_tile.h)** | 0.6 | game&nbsp;dev | 1220 | herringbone Wang tile map generator
 **[stb_c_lexer.h](stb_c_lexer.h)** | 0.09 | parsing | 962 | simplify writing parsers for C-like languages
 **[stb_divide.h](stb_divide.h)** | 0.91 | math | 419 | more useful 32-bit modulus e.g. "euclidean divide"
 **[stb_connected_comp...](stb_connected_components.h)** | 0.95 | misc | 1045 | incrementally compute reachability on grids
-**[stb.h](stb.h)** | 2.31 | misc | 14405 | helper functions for C, mostly redundant in C++; basically author's personal stuff
-**[stb_leakcheck.h](stb_leakcheck.h)** | 0.4 | misc | 186 | quick-and-dirty malloc/free leak-checking
+**[stb.h](stb.h)** | 2.32 | misc | 14469 | helper functions for C, mostly redundant in C++; basically author's personal stuff
+**[stb_leakcheck.h](stb_leakcheck.h)** | 0.5 | misc | 190 | quick-and-dirty malloc/free leak-checking
 
 Total libraries: 20  
-Total lines of C code: 53654
+Total lines of C code: 53979
 
 
 FAQ

--- a/stb.h
+++ b/stb.h
@@ -1,4 +1,4 @@
-/* stb.h - v2.31 - Sean's Tool Box -- public domain -- http://nothings.org/stb.h
+/* stb.h - v2.32 - Sean's Tool Box -- public domain -- http://nothings.org/stb.h
           no warranty is offered or implied; use this code at your own risk
 
    This is a single header file with a bunch of useful utilities
@@ -25,6 +25,7 @@
 
 Version History
 
+   2.32   stb_intcmprev, stb_uidict, fix random numbers on Linux
    2.31   stb_ucharcmp
    2.30   MinGW fix
    2.29   attempt to fix use of swprintf()
@@ -791,7 +792,7 @@ STB_EXTERN __declspec(dllimport) int __stdcall SetConsoleTextAttribute(void *, u
 static void stb__print_one(void *handle, char *s, int len)
 {
    if (len)
-      if (WriteConsoleA(handle, s, len, NULL,NULL))
+      if (0==WriteConsoleA(handle, s, len, NULL,NULL))
          fwrite(s, 1, len, stdout); // if it fails, maybe redirected, so do normal
 }
 
@@ -1543,6 +1544,7 @@ int stb_lowbit8(unsigned int n)
 
 
 STB_EXTERN int (*stb_intcmp(int offset))(const void *a, const void *b);
+STB_EXTERN int (*stb_intcmprev(int offset))(const void *a, const void *b);
 STB_EXTERN int (*stb_qsort_strcmp(int offset))(const void *a, const void *b);
 STB_EXTERN int (*stb_qsort_stricmp(int offset))(const void *a, const void *b);
 STB_EXTERN int (*stb_floatcmp(int offset))(const void *a, const void *b);
@@ -1558,6 +1560,13 @@ int stb__intcmp(const void *a, const void *b)
    const int p = *(const int *) ((const char *) a + stb__intcmpoffset);
    const int q = *(const int *) ((const char *) b + stb__intcmpoffset);
    return p < q ? -1 : p > q;
+}
+
+int stb__intcmprev(const void *a, const void *b)
+{
+   const int p = *(const int *) ((const char *) a + stb__intcmpoffset);
+   const int q = *(const int *) ((const char *) b + stb__intcmpoffset);
+   return q < p ? -1 : q > p;
 }
 
 int stb__ucharcmp(const void *a, const void *b)
@@ -1599,6 +1608,12 @@ int (*stb_intcmp(int offset))(const void *, const void *)
 {
    stb__intcmpoffset = offset;
    return &stb__intcmp;
+}
+
+int (*stb_intcmprev(int offset))(const void *, const void *)
+{
+   stb__intcmpoffset = offset;
+   return &stb__intcmprev;
 }
 
 int (*stb_ucharcmp(int offset))(const void *, const void *)
@@ -3092,13 +3107,13 @@ typedef struct
 // (internal) change the allocated length of the array
 #define stb_arr__grow(a,n)     (stb_arr_check(a), stb_arrhead(a)->len += (n))
 
-// add N new unitialized elements to the end of the array
+// add N new uninitialized elements to the end of the array
 #define stb_arr__addn(a,n)     /*lint --e(826)*/ \
                                ((stb_arr_len(a)+(n) > stb_arrcurmax(a))      \
                                  ? (stb__arr_addlen((void **) &(a),sizeof(*a),(n)),0) \
                                  : ((stb_arr__grow(a,n), 0)))
 
-// add N new unitialized elements to the end of the array, and return
+// add N new uninitialized elements to the end of the array, and return
 // a pointer to the first new one
 #define stb_arr_addn(a,n)      (stb_arr__addn((a),n),(a)+stb_arr_len(a)-(n))
 
@@ -4080,13 +4095,13 @@ static void STB_(N, rehash)(TYPE *a, int count)                               \
 #define STB_equal(a,b)  ((a) == (b))
 
 #define stb_define_hash(TYPE,N,KEY,EMPTY,DEL,HASH,VALUE)                      \
-   stb_define_hash_base(STB_noprefix, TYPE,STB_nofields,N,NC,0.85f,              \
+   stb_define_hash_base(STB_noprefix, TYPE,STB_nofields,N,NC,0.85f,           \
               KEY,EMPTY,DEL,STB_nocopy,STB_nodelete,STB_nosafe,               \
               STB_equal,STB_equal,HASH,                                       \
               VALUE,STB_nonullvalue,0)
 
 #define stb_define_hash_vnull(TYPE,N,KEY,EMPTY,DEL,HASH,VALUE,VNULL)          \
-   stb_define_hash_base(STB_noprefix, TYPE,STB_nofields,N,NC,0.85f,              \
+   stb_define_hash_base(STB_noprefix, TYPE,STB_nofields,N,NC,0.85f,           \
               KEY,EMPTY,DEL,STB_nocopy,STB_nodelete,STB_nosafe,               \
               STB_equal,STB_equal,HASH,                                       \
               VALUE,STB_nullvalue,VNULL)
@@ -4101,12 +4116,14 @@ static void STB_(N, rehash)(TYPE *a, int count)                               \
 
 stb_declare_hash(STB_EXTERN, stb_ptrmap, stb_ptrmap_, void *, void *)
 stb_declare_hash(STB_EXTERN, stb_idict, stb_idict_, stb_int32, stb_int32)
+stb_declare_hash(STB_EXTERN, stb_uidict, stbi_uidict_, stb_uint32, stb_uint32)
 
 STB_EXTERN void        stb_ptrmap_delete(stb_ptrmap *e, void (*free_func)(void *));
 STB_EXTERN stb_ptrmap *stb_ptrmap_new(void);
 
 STB_EXTERN stb_idict * stb_idict_new_size(int size);
 STB_EXTERN void        stb_idict_remove_all(stb_idict *e);
+STB_EXTERN void        stb_uidict_reset(stb_uidict *e);
 
 #ifdef STB_DEFINE
 
@@ -4163,6 +4180,23 @@ void stb_idict_remove_all(stb_idict *e)
    for (n=0; n < e->limit; ++n)
       e->table[n].k = STB_IEMPTY;
    e->has_empty = e->has_del = 0;
+   e->count = 0;
+   e->deleted = 0;
+}
+
+stb_define_hash_base(STB_noprefix, stb_uidict, STB_nofields, stb_uidict_,stb_uidict_,0.85f,
+              stb_int32,0xffffffff,0xfffffffe,STB_nocopy,STB_nodelete,STB_nosafe,
+              STB_equal,STB_equal,
+              return stb_rehash_improved(k);,stb_uint32,STB_nonullvalue,0)
+
+void stb_uidict_reset(stb_uidict *e)
+{
+   int n;
+   for (n=0; n < e->limit; ++n)
+      e->table[n].k = 0xffffffff;
+   e->has_empty = e->has_del = 0;
+   e->count = 0;
+   e->deleted = 0;
 }
 #endif
 
@@ -5934,6 +5968,9 @@ char **stb_getopt_param(int *argc, char **argv, char *param)
             while (i < *argc)
                argv[j++] = argv[i++];
             break;
+         } else if (argv[i][1] == '-') {
+            // copy argument through including initial '-' for clarity
+            stb_arr_push(opts, strdup(argv[i]));
          } else {
             int k;
             char *q = argv[i];  // traverse options list
@@ -6595,15 +6632,23 @@ STB_EXTERN __declspec(dllimport) long __stdcall  RegOpenKeyExA ( HKEY hKey, cons
 #define STB__REG_KEY_ALL_ACCESS       0x000f003f
 #define STB__REG_KEY_READ             0x00020019
 
+#ifdef _M_AMD64
+#define STB__HKEY_CURRENT_USER        0x80000001ull
+#define STB__HKEY_LOCAL_MACHINE       0x80000002ull
+#else
+#define STB__HKEY_CURRENT_USER        0x80000001
+#define STB__HKEY_LOCAL_MACHINE       0x80000002
+#endif
+
 void *stb_reg_open(char *mode, char *where)
 {
    long res;
    HKEY base;
    HKEY zreg;
    if (!stb_stricmp(mode+1, "cu") || !stb_stricmp(mode+1, "hkcu"))
-      base = (HKEY) 0x80000001; // HKCU
+      base = (HKEY) STB__HKEY_CURRENT_USER;
    else if (!stb_stricmp(mode+1, "lm") || !stb_stricmp(mode+1, "hklm"))
-      base = (HKEY) 0x80000002; // HKLM
+      base = (HKEY) STB__HKEY_LOCAL_MACHINE;
    else
       return NULL;
 
@@ -7011,6 +7056,8 @@ static void stb__dirtree_load_db(char *filename, stb_dirtree *data, char *dir)
    fclose(f);
 }
 
+FILE *hlog;
+
 static int stb__dircount, stb__dircount_mask, stb__showfile;
 static void stb__dirtree_scandir(char *path, time_t last_time, stb_dirtree *active)
 {
@@ -7036,9 +7083,9 @@ static void stb__dirtree_scandir(char *path, time_t last_time, stb_dirtree *acti
       swprintf(full_path, L"%s/*", stb__from_utf8(path));
 #else
    if (has_slash)
-      swprintf(full_path, 1024, L"%s*", stb__from_utf8(path));
+      swprintf((wchar_t *) full_path, (size_t) 1024, L"%s*", (wchar_t *) stb__from_utf8(path));
    else
-      swprintf(full_path, 1024, L"%s/*", stb__from_utf8(path));
+      swprintf((wchar_t *) full_path, (size_t) 1024, L"%s/*", (wchar_t *) stb__from_utf8(path));
 #endif
 
    // it's possible this directory is already present: that means it was in the
@@ -7056,14 +7103,14 @@ static void stb__dirtree_scandir(char *path, time_t last_time, stb_dirtree *acti
    n = stb_arr_lastn(active->dirs);
 
    if (stb__showfile) printf("[");
-   if( (hFile = _wfindfirsti64( full_path, &c_file )) != -1L ) {
+   if( (hFile = _wfindfirsti64( (wchar_t *) full_path, &c_file )) != -1L ) {
       do {
          if (stb__showfile) printf(")");
          if (c_file.attrib & _A_SUBDIR) {
             // ignore subdirectories starting with '.', e.g. "." and ".."
             if (c_file.name[0] != '.') {
                char *new_path = (char *) full_path;
-               char *temp = stb__to_utf8(c_file.name);
+               char *temp = stb__to_utf8((stb__wchar *) c_file.name);
 
                if (has_slash)
                   sprintf(new_path, "%s%s", path, temp);
@@ -7073,14 +7120,30 @@ static void stb__dirtree_scandir(char *path, time_t last_time, stb_dirtree *acti
                if (stb__dircount_mask) {
                   ++stb__dircount;
                   if (!(stb__dircount & stb__dircount_mask)) {
-                     printf("%s\r", new_path);
+                     char dummy_path[128], *pad;
+                     stb_strncpy(dummy_path, new_path, sizeof(dummy_path)-1);
+                     if (strlen(dummy_path) > 96) {
+                        strcpy(dummy_path+96/2-1, "...");
+                        strcpy(dummy_path+96/2+2, new_path + strlen(new_path)-96/2+2);
+                     }
+                     pad = dummy_path + strlen(dummy_path);
+                     while (pad < dummy_path+98)
+                        *pad++ = ' ';
+                     *pad = 0;
+                     printf("%s\r", dummy_path);
+                     #if 0
+                     if (hlog == 0) {
+                        hlog = fopen("c:/x/temp.log", "w");
+                        fprintf(hlog, "%s\n", dummy_path);
+                     }
+                     #endif
                   }
                }
 
                stb__dirtree_scandir(new_path, c_file.time_write, active);
             }
          } else {
-            char *temp = stb__to_utf8(c_file.name);
+            char *temp = stb__to_utf8((stb__wchar *) c_file.name);
             stb__dirtree_add_file(temp, n, c_file.size, c_file.time_write, active);
          }
          if (stb__showfile) printf("(");
@@ -7113,12 +7176,12 @@ static int stb__dirtree_update_db(stb_dirtree *db, stb_dirtree *active)
       if (0 == _stat(db->dirs[i].path, &info)) {
          if (info.st_mode & _S_IFDIR) {
             // it's still a directory, as expected
-            int n = abs(info.st_mtime - db->dirs[i].last_modified);
+            int n = abs((int) (info.st_mtime - db->dirs[i].last_modified));
             if (n > 1 && n != 3600) {  // the 3600 is a hack because sometimes this jumps for no apparent reason, even when no time zone or DST issues are at play
                // it's changed! force a rescan
                // we don't want to scan it until we've stat()d its
                // subdirs, though, so we queue it
-               if (stb__showfile) printf("Changed: %s - %08x:%08x\n", db->dirs[i].path, db->dirs[i].last_modified, info.st_mtime);
+               if (stb__showfile) printf("Changed: %s - %08x:%08x\n", db->dirs[i].path, (unsigned int) db->dirs[i].last_modified, (unsigned int) info.st_mtime);
                stb_arr_push(rescan, i);
                // update the last_mod time
                db->dirs[i].last_modified = info.st_mtime;
@@ -7259,7 +7322,7 @@ stb_dirtree *stb_dirtree_get_dir(char *dir, char *cache_dir)
 stb_dirtree *stb_dirtree_get(char *dir)
 {
    char cache_dir[256];
-   strcpy(cache_dir, "c:/stb");
+   strcpy(cache_dir, "c:/bindata");
    #ifdef STB_HAS_REGISTRY
    {
       void *reg = stb_reg_open("rHKLM", "Software\\SilverSpaceship\\stb");
@@ -8206,44 +8269,44 @@ int stb_ps_eq(stb_ps *p0, stb_ps *p1)
 //               Random Numbers via Meresenne Twister or LCG
 //
 
-STB_EXTERN unsigned long stb_srandLCG(unsigned long seed);
-STB_EXTERN unsigned long stb_randLCG(void);
+STB_EXTERN unsigned int  stb_srandLCG(unsigned long seed);
+STB_EXTERN unsigned int  stb_randLCG(void);
 STB_EXTERN double        stb_frandLCG(void);
 
-STB_EXTERN void          stb_srand(unsigned long seed);
-STB_EXTERN unsigned long stb_rand(void);
+STB_EXTERN void          stb_srand(unsigned int seed);
+STB_EXTERN unsigned int  stb_rand(void);
 STB_EXTERN double        stb_frand(void);
 STB_EXTERN void          stb_shuffle(void *p, size_t n, size_t sz,
                                         unsigned long seed);
 STB_EXTERN void stb_reverse(void *p, size_t n, size_t sz);
 
-STB_EXTERN unsigned long stb_randLCG_explicit(unsigned long seed);
+STB_EXTERN unsigned int  stb_randLCG_explicit(unsigned int  seed);
 
 #define stb_rand_define(x,y)                                         \
                                                                      \
-   unsigned long x(void)                                             \
+   unsigned int  x(void)                                             \
    {                                                                 \
-      static unsigned long stb__rand = y;                            \
+      static unsigned int  stb__rand = y;                            \
       stb__rand = stb__rand * 2147001325 + 715136305; /* BCPL */     \
       return 0x31415926 ^ ((stb__rand >> 16) + (stb__rand << 16));   \
    }
 
 #ifdef STB_DEFINE
-unsigned long stb_randLCG_explicit(unsigned long seed)
+unsigned int  stb_randLCG_explicit(unsigned int seed)
 {
    return seed * 2147001325 + 715136305;
 }
 
-static unsigned long stb__rand_seed=0;
+static unsigned int  stb__rand_seed=0;
 
-unsigned long stb_srandLCG(unsigned long seed)
+unsigned int  stb_srandLCG(unsigned long seed)
 {
-   unsigned long previous = stb__rand_seed;
+   unsigned int  previous = stb__rand_seed;
    stb__rand_seed = seed;
    return previous;
 }
 
-unsigned long stb_randLCG(void)
+unsigned int  stb_randLCG(void)
 {
    stb__rand_seed = stb__rand_seed * 2147001325 + 715136305; // BCPL generator
    // shuffle non-random bits to the middle, and xor to decorrelate with seed
@@ -8284,17 +8347,17 @@ void stb_reverse(void *p, size_t n, size_t sz)
 // public domain Mersenne Twister by Michael Brundage
 #define STB__MT_LEN       624
 
-int stb__mt_index = STB__MT_LEN*sizeof(unsigned long)+1;
-unsigned long stb__mt_buffer[STB__MT_LEN];
+int stb__mt_index = STB__MT_LEN*sizeof(int)+1;
+unsigned int stb__mt_buffer[STB__MT_LEN];
 
-void stb_srand(unsigned long seed)
+void stb_srand(unsigned int seed)
 {
    int i;
-   unsigned long old = stb_srandLCG(seed);
+   unsigned int old = stb_srandLCG(seed);
    for (i = 0; i < STB__MT_LEN; i++)
       stb__mt_buffer[i] = stb_randLCG();
    stb_srandLCG(old);
-   stb__mt_index = STB__MT_LEN*sizeof(unsigned long);
+   stb__mt_index = STB__MT_LEN*sizeof(unsigned int);
 }
 
 #define STB__MT_IA           397
@@ -8305,15 +8368,15 @@ void stb_srand(unsigned long seed)
 #define STB__TWIST(b,i,j)    ((b)[i] & STB__UPPER_MASK) | ((b)[j] & STB__LOWER_MASK)
 #define STB__MAGIC(s)        (((s)&1)*STB__MATRIX_A)
 
-unsigned long stb_rand()
+unsigned int stb_rand()
 {
-   unsigned long * b = stb__mt_buffer;
+   unsigned int  * b = stb__mt_buffer;
    int idx = stb__mt_index;
-   unsigned long s,r;
+   unsigned int  s,r;
    int i;
 	
-   if (idx >= STB__MT_LEN*sizeof(unsigned long)) {
-      if (idx > STB__MT_LEN*sizeof(unsigned long))
+   if (idx >= STB__MT_LEN*sizeof(unsigned int)) {
+      if (idx > STB__MT_LEN*sizeof(unsigned int))
          stb_srand(0);
       idx = 0;
       i = 0;
@@ -8329,9 +8392,9 @@ unsigned long stb_rand()
       s = STB__TWIST(b, STB__MT_LEN-1, 0);
       b[STB__MT_LEN-1] = b[STB__MT_IA-1] ^ (s >> 1) ^ STB__MAGIC(s);
    }
-   stb__mt_index = idx + sizeof(unsigned long);
+   stb__mt_index = idx + sizeof(unsigned int);
    
-   r = *(unsigned long *)((unsigned char *)b + idx);
+   r = *(unsigned int *)((unsigned char *)b + idx);
    
    r ^= (r >> 11);
    r ^= (r << 7) & 0x9D2C5680;
@@ -8620,7 +8683,7 @@ static void STB_(FUNCNAME,_ins_sort)(TYPE *p, int n)                          \
                                                                               \
 static void STB_(FUNCNAME,_quicksort)(TYPE *p, int n)                         \
 {                                                                             \
-   /* threshhold for transitioning to insertion sort */                       \
+   /* threshold for transitioning to insertion sort */                       \
    while (n > 12) {                                                           \
       TYPE *a,*b,t;                                                           \
       int c01,c12,c,m,i,j;                                                    \
@@ -12401,7 +12464,7 @@ STB_EXTERN int stb_bgio_stat    (char *filename, stb_bgstat *result)
 //   everywhere is 3MB. (That is, if you allocate 1 object of each size,
 //   you'll use 3MB.)
 
-#if defined(STB_DEFINE) && (defined(_WIN32) || defined(STB_FASTMALLOC))
+#if defined(STB_DEFINE) && ((defined(_WIN32) && !defined(_M_AMD64)) || defined(STB_FASTMALLOC))
 
 #ifdef _WIN32
    #ifndef _WINDOWS_
@@ -13012,6 +13075,7 @@ char * stb__string_constant(char *file, int line, char *x)
 
 
 #ifdef STB_STUA
+#error "STUA is no longer supported"
 //////////////////////////////////////////////////////////////////////////
 //
 //  stua: little scripting language
@@ -13801,7 +13865,7 @@ static void stu__pop_func_comp(void)
 
 // if an id is a reference to an outer lexical scope, this
 // function returns the "name" of it, and updates the stack
-// structures to make sure the names are propogated in.
+// structures to make sure the names are propagated in.
 static int stu__nonlocal_id(stua_obj var_obj)
 {
    stua_obj dummy, var = var_obj;
@@ -13816,7 +13880,7 @@ static int stu__nonlocal_id(stua_obj var_obj)
    for (i=0; i < stb_arr_len(stu__pfunc.non_local_refs); ++i)
       if (stu__pfunc.non_local_refs[i] == j) return j-n;
    stb_arr_push(stu__pfunc.non_local_refs, j-n);
-   // now make sure all the parents propogate it down
+   // now make sure all the parents propagate it down
    for (k=n-1; k > 1; --k) {
       if (j-k >= 0) return j-n; // comes direct from this parent
       for(i=0; i < stb_arr_len(func_stack[k].non_local_refs); ++i)

--- a/stb_dxt.h
+++ b/stb_dxt.h
@@ -190,7 +190,7 @@ static void stb__DitherBlock(unsigned char *dest, unsigned char *block)
   int err[8],*ep1 = err,*ep2 = err+4, *et;
   int ch,y;
 
-  // process channels seperately
+  // process channels separately
   for (ch=0; ch<3; ++ch) {
       unsigned char *bp = block+ch, *dp = dest+ch;
       unsigned char *quant = (ch == 1) ? stb__QuantGTab+8 : stb__QuantRBTab+8;

--- a/stb_leakcheck.h
+++ b/stb_leakcheck.h
@@ -1,4 +1,4 @@
-// stb_leakcheck.h - v0.4 - quick & dirty malloc leak-checking - public domain
+// stb_leakcheck.h - v0.5 - quick & dirty malloc leak-checking - public domain
 // LICENSE
 //
 //   See end of file.
@@ -58,8 +58,8 @@ void stb_leakcheck_free(void *ptr)
          mi->prev->next = mi->next;
       if (mi->next)
          mi->next->prev = mi->prev;
-      #endif
       free(mi);
+      #endif
    }
 }
 
@@ -89,21 +89,25 @@ void *stb_leakcheck_realloc(void *ptr, size_t sz, const char *file, int line)
    }
 }
 
-static void stblkck_internal_print(const char *reason, const char *file,  int line, size_t size, void *ptr)
+static void stblkck_internal_print(const char *reason, stb_leakcheck_malloc_info *mi)
 {
-#if (defined(_MSC_VER) && _MSC_VER < 1900) /* 1900=VS 2015 */ || defined(__MINGW32__)
+#if defined(_MSC_VER) && _MSC_VER < 1900 // 1900=VS 2015
    // Compilers that use the old MS C runtime library don't have %zd
    // and the older ones don't even have %lld either... however, the old compilers
    // without "long long" don't support 64-bit targets either, so here's the
    // compromise:
-   #if defined(_MSC_VER) && _MSC_VER < 1400 // before VS 2005
-      printf("%-6s: %s (%4d): %8d bytes at %p\n", reason, file, line, (int)size, ptr);
+   #if _MSC_VER < 1400 // before VS 2005
+      printf("%s: %s (%4d): %8d bytes at %p\n", reason, mi->file, mi->line, (int)mi->size, (void*)(mi+1));
    #else
-      printf("%-6s: %s (%4d): %8lld bytes at %p\n", reason, file, line, (long long)size, ptr);
+      printf("%s: %s (%4d): %16lld bytes at %p\n", reason, mi->file, mi->line, (long long)mi->size, (void*)(mi+1));
    #endif
 #else
    // Assume we have %zd on other targets.
-   printf("%-6s: %s (%4d): %zd bytes at %p\n", reason, file, line, size, ptr);
+   #ifdef __MINGW32__
+      __mingw_printf("%s: %s (%4d): %zd bytes at %p\n", reason, mi->file, mi->line, mi->size, (void*)(mi+1));
+   #else
+      printf("%s: %s (%4d): %zd bytes at %p\n", reason, mi->file, mi->line, mi->size, (void*)(mi+1));
+   #endif
 #endif
 }
 
@@ -112,16 +116,14 @@ void stb_leakcheck_dumpmem(void)
    stb_leakcheck_malloc_info *mi = mi_head;
    while (mi) {
       if ((ptrdiff_t) mi->size >= 0)
-         stblkck_internal_print("LEAKED", mi->file, mi->line, mi->size, mi+1);
-         printf("LEAKED: %s (%4d): %8d bytes at %p\n", mi->file, mi->line, (int) mi->size, mi+1);
+         stblkck_internal_print("LEAKED", mi);
       mi = mi->next;
    }
    #ifdef STB_LEAKCHECK_SHOWALL
    mi = mi_head;
    while (mi) {
       if ((ptrdiff_t) mi->size < 0)
-         stblkck_internal_print("FREED", mi->file, mi->line, ~mi->size, mi+1);
-         printf("FREED : %s (%4d): %8d bytes at %p\n", mi->file, mi->line, (int) ~mi->size, mi+1);
+         stblkck_internal_print("FREED ", mi);
       mi = mi->next;
    }
    #endif
@@ -130,6 +132,8 @@ void stb_leakcheck_dumpmem(void)
 
 #ifndef INCLUDE_STB_LEAKCHECK_H
 #define INCLUDE_STB_LEAKCHECK_H
+
+#include <stdlib.h> // we want to define the macros *after* stdlib to avoid a slew of errors
 
 #define malloc(sz)    stb_leakcheck_malloc(sz, __FILE__, __LINE__)
 #define free(p)       stb_leakcheck_free(p)

--- a/stb_perlin.h
+++ b/stb_perlin.h
@@ -1,4 +1,4 @@
-// stb_perlin.h - v0.3 - perlin noise
+// stb_perlin.h - v0.4 - perlin noise
 // public domain single-file C implementation by Sean Barrett
 //
 // LICENSE
@@ -32,6 +32,19 @@
 // details of the implementation, even if you ask for larger or no
 // wrapping.)
 //
+// float  stb_perlin_noise3_seed( float x,
+//                                float y,
+//                                float z,
+//                                int   x_wrap=0,
+//                                int   y_wrap=0,
+//                                int   z_wrap=0,
+//                                int   seed)
+//
+// As above, but 'seed' selects from multiple different variations of the
+// noise function. The current implementation only uses the bottom 8 bits
+// of 'seed', but possibly in the future more bits will be used.
+//
+//
 // Fractal Noise:
 //
 // Three common fractal noise functions are included, which produce 
@@ -40,16 +53,13 @@
 // 'octaves' times, so this parameter will affect runtime.
 //
 // float stb_perlin_ridge_noise3(float x, float y, float z,
-//                               float lacunarity, float gain, float offset, int octaves,
-//                               int x_wrap, int y_wrap, int z_wrap);
+//                               float lacunarity, float gain, float offset, int octaves)
 //
 // float stb_perlin_fbm_noise3(float x, float y, float z,
-//                             float lacunarity, float gain, int octaves,
-//                             int x_wrap, int y_wrap, int z_wrap);
+//                             float lacunarity, float gain, int octaves)
 //
 // float stb_perlin_turbulence_noise3(float x, float y, float z,
-//                                    float lacunarity, float gain,int octaves,
-//                                    int x_wrap, int y_wrap, int z_wrap);
+//                                    float lacunarity, float gain, int octaves)
 //
 // Typical values to start playing with:
 //     octaves    =   6     -- number of "octaves" of noise3() to sum
@@ -60,6 +70,7 @@
 //
 // Contributors:
 //    Jack Mott - additional noise functions
+//    Jordan Peck - seeded noise
 //
 
 
@@ -67,18 +78,19 @@
 extern "C" {
 #endif
 extern float stb_perlin_noise3(float x, float y, float z, int x_wrap, int y_wrap, int z_wrap);
-extern float stb_perlin_ridge_noise3(float x, float y, float z,float lacunarity, float gain, float offset, int octaves,int x_wrap, int y_wrap, int z_wrap);
-extern float stb_perlin_fbm_noise3(float x, float y, float z,float lacunarity, float gain, int octaves,int x_wrap, int y_wrap, int z_wrap);
-extern float stb_perlin_turbulence_noise3(float x, float y, float z, float lacunarity, float gain, int octaves,int x_wrap, int y_wrap, int z_wrap);
+extern float stb_perlin_ridge_noise3(float x, float y, float z, float lacunarity, float gain, float offset, int octaves);
+extern float stb_perlin_fbm_noise3(float x, float y, float z, float lacunarity, float gain, int octaves);
+extern float stb_perlin_turbulence_noise3(float x, float y, float z, float lacunarity, float gain, int octaves);
 #ifdef __cplusplus
 }
 #endif
 
 #ifdef STB_PERLIN_IMPLEMENTATION
 
+#include <math.h> // fabs()
+
 // not same permutation table as Perlin's reference to avoid copyright issues;
 // Perlin's table can be found at http://mrl.nyu.edu/~perlin/noise/
-// @OPTIMIZE: should this be unsigned char instead of int for cache?
 static unsigned char stb__perlin_randtab[512] =
 {
    23, 125, 161, 52, 103, 117, 70, 37, 247, 101, 203, 169, 124, 126, 44, 123, 
@@ -115,6 +127,51 @@ static unsigned char stb__perlin_randtab[512] =
    131, 11, 163, 99, 234, 81, 227, 147, 156, 176, 17, 142, 69, 12, 110, 62, 
    27, 255, 0, 194, 59, 116, 242, 252, 19, 21, 187, 53, 207, 129, 64, 135, 
    61, 40, 167, 237, 102, 223, 106, 159, 197, 189, 215, 137, 36, 32, 22, 5,  
+}; 
+
+
+// perlin's gradient has 12 cases so some get used 1/16th of the time
+// and some 2/16ths. We reduce bias by changing those fractions
+// to 5/64ths and 6/64ths
+
+// this array is designed to match the previous implementation
+// of gradient hash: indices[stb__perlin_randtab[i]&63]
+static unsigned char stb__perlin_randtab_grad_idx[512] =
+{
+    7, 9, 5, 0, 11, 1, 6, 9, 3, 9, 11, 1, 8, 10, 4, 7,
+    8, 6, 1, 5, 3, 10, 9, 10, 0, 8, 4, 1, 5, 2, 7, 8,
+    7, 11, 9, 10, 1, 0, 4, 7, 5, 0, 11, 6, 1, 4, 2, 8,
+    8, 10, 4, 9, 9, 2, 5, 7, 9, 1, 7, 2, 2, 6, 11, 5,
+    5, 4, 6, 9, 0, 1, 1, 0, 7, 6, 9, 8, 4, 10, 3, 1,
+    2, 8, 8, 9, 10, 11, 5, 11, 11, 2, 6, 10, 3, 4, 2, 4,
+    9, 10, 3, 2, 6, 3, 6, 10, 5, 3, 4, 10, 11, 2, 9, 11,
+    1, 11, 10, 4, 9, 4, 11, 0, 4, 11, 4, 0, 0, 0, 7, 6,
+    10, 4, 1, 3, 11, 5, 3, 4, 2, 9, 1, 3, 0, 1, 8, 0,
+    6, 7, 8, 7, 0, 4, 6, 10, 8, 2, 3, 11, 11, 8, 0, 2,
+    4, 8, 3, 0, 0, 10, 6, 1, 2, 2, 4, 5, 6, 0, 1, 3,
+    11, 9, 5, 5, 9, 6, 9, 8, 3, 8, 1, 8, 9, 6, 9, 11,
+    10, 7, 5, 6, 5, 9, 1, 3, 7, 0, 2, 10, 11, 2, 6, 1,
+    3, 11, 7, 7, 2, 1, 7, 3, 0, 8, 1, 1, 5, 0, 6, 10,
+    11, 11, 0, 2, 7, 0, 10, 8, 3, 5, 7, 1, 11, 1, 0, 7,
+    9, 0, 11, 5, 10, 3, 2, 3, 5, 9, 7, 9, 8, 4, 6, 5,
+
+    // and a second copy so we don't need an extra mask or static initializer
+    7, 9, 5, 0, 11, 1, 6, 9, 3, 9, 11, 1, 8, 10, 4, 7,
+    8, 6, 1, 5, 3, 10, 9, 10, 0, 8, 4, 1, 5, 2, 7, 8,
+    7, 11, 9, 10, 1, 0, 4, 7, 5, 0, 11, 6, 1, 4, 2, 8,
+    8, 10, 4, 9, 9, 2, 5, 7, 9, 1, 7, 2, 2, 6, 11, 5,
+    5, 4, 6, 9, 0, 1, 1, 0, 7, 6, 9, 8, 4, 10, 3, 1,
+    2, 8, 8, 9, 10, 11, 5, 11, 11, 2, 6, 10, 3, 4, 2, 4,
+    9, 10, 3, 2, 6, 3, 6, 10, 5, 3, 4, 10, 11, 2, 9, 11,
+    1, 11, 10, 4, 9, 4, 11, 0, 4, 11, 4, 0, 0, 0, 7, 6,
+    10, 4, 1, 3, 11, 5, 3, 4, 2, 9, 1, 3, 0, 1, 8, 0,
+    6, 7, 8, 7, 0, 4, 6, 10, 8, 2, 3, 11, 11, 8, 0, 2,
+    4, 8, 3, 0, 0, 10, 6, 1, 2, 2, 4, 5, 6, 0, 1, 3,
+    11, 9, 5, 5, 9, 6, 9, 8, 3, 8, 1, 8, 9, 6, 9, 11,
+    10, 7, 5, 6, 5, 9, 1, 3, 7, 0, 2, 10, 11, 2, 6, 1,
+    3, 11, 7, 7, 2, 1, 7, 3, 0, 8, 1, 1, 5, 0, 6, 10,
+    11, 11, 0, 2, 7, 0, 10, 8, 3, 5, 7, 1, 11, 1, 0, 7,
+    9, 0, 11, 5, 10, 3, 2, 3, 5, 9, 7, 9, 8, 4, 6, 5,
 };
 
 static float stb__perlin_lerp(float a, float b, float t)
@@ -124,12 +181,12 @@ static float stb__perlin_lerp(float a, float b, float t)
 
 static int stb__perlin_fastfloor(float a)
 {
-	int ai = (int) a;
-	return (a < ai) ? ai-1 : ai;
+    int ai = (int) a;
+    return (a < ai) ? ai-1 : ai;
 }
 
 // different grad function from Perlin's, but easy to modify to match reference
-static float stb__perlin_grad(int hash, float x, float y, float z)
+static float stb__perlin_grad(int grad_idx, float x, float y, float z)
 {
    static float basis[12][4] =
    {
@@ -147,26 +204,11 @@ static float stb__perlin_grad(int hash, float x, float y, float z)
       {  0,-1,-1 },
    };
 
-   // perlin's gradient has 12 cases so some get used 1/16th of the time
-   // and some 2/16ths. We reduce bias by changing those fractions
-   // to 5/64ths and 6/64ths, and the same 4 cases get the extra weight.
-   static unsigned char indices[64] =
-   {
-      0,1,2,3,4,5,6,7,8,9,10,11,
-      0,9,1,11,
-      0,1,2,3,4,5,6,7,8,9,10,11,
-      0,1,2,3,4,5,6,7,8,9,10,11,
-      0,1,2,3,4,5,6,7,8,9,10,11,
-      0,1,2,3,4,5,6,7,8,9,10,11,
-   };
-
-   // if you use reference permutation table, change 63 below to 15 to match reference
-   // (this is why the ordering of the table above is funky)
-   float *grad = basis[indices[hash & 63]];
+   float *grad = basis[grad_idx];
    return grad[0]*x + grad[1]*y + grad[2]*z;
 }
 
-float stb_perlin_noise3(float x, float y, float z, int x_wrap, int y_wrap, int z_wrap)
+float stb_perlin_noise3_internal(float x, float y, float z, int x_wrap, int y_wrap, int z_wrap, unsigned char seed)
 {
    float u,v,w;
    float n000,n001,n010,n011,n100,n101,n110,n111;
@@ -190,22 +232,22 @@ float stb_perlin_noise3(float x, float y, float z, int x_wrap, int y_wrap, int z
    y -= py; v = stb__perlin_ease(y);
    z -= pz; w = stb__perlin_ease(z);
 
-   r0 = stb__perlin_randtab[x0];
-   r1 = stb__perlin_randtab[x1];
+   r0 = stb__perlin_randtab[x0+seed];
+   r1 = stb__perlin_randtab[x1+seed];
 
    r00 = stb__perlin_randtab[r0+y0];
    r01 = stb__perlin_randtab[r0+y1];
    r10 = stb__perlin_randtab[r1+y0];
    r11 = stb__perlin_randtab[r1+y1];
 
-   n000 = stb__perlin_grad(stb__perlin_randtab[r00+z0], x  , y  , z   );
-   n001 = stb__perlin_grad(stb__perlin_randtab[r00+z1], x  , y  , z-1 );
-   n010 = stb__perlin_grad(stb__perlin_randtab[r01+z0], x  , y-1, z   );
-   n011 = stb__perlin_grad(stb__perlin_randtab[r01+z1], x  , y-1, z-1 );
-   n100 = stb__perlin_grad(stb__perlin_randtab[r10+z0], x-1, y  , z   );
-   n101 = stb__perlin_grad(stb__perlin_randtab[r10+z1], x-1, y  , z-1 );
-   n110 = stb__perlin_grad(stb__perlin_randtab[r11+z0], x-1, y-1, z   );
-   n111 = stb__perlin_grad(stb__perlin_randtab[r11+z1], x-1, y-1, z-1 );
+   n000 = stb__perlin_grad(stb__perlin_randtab_grad_idx[r00+z0], x  , y  , z   );
+   n001 = stb__perlin_grad(stb__perlin_randtab_grad_idx[r00+z1], x  , y  , z-1 );
+   n010 = stb__perlin_grad(stb__perlin_randtab_grad_idx[r01+z0], x  , y-1, z   );
+   n011 = stb__perlin_grad(stb__perlin_randtab_grad_idx[r01+z1], x  , y-1, z-1 );
+   n100 = stb__perlin_grad(stb__perlin_randtab_grad_idx[r10+z0], x-1, y  , z   );
+   n101 = stb__perlin_grad(stb__perlin_randtab_grad_idx[r10+z1], x-1, y  , z-1 );
+   n110 = stb__perlin_grad(stb__perlin_randtab_grad_idx[r11+z0], x-1, y-1, z   );
+   n111 = stb__perlin_grad(stb__perlin_randtab_grad_idx[r11+z1], x-1, y-1, z-1 );
 
    n00 = stb__perlin_lerp(n000,n001,w);
    n01 = stb__perlin_lerp(n010,n011,w);
@@ -218,7 +260,17 @@ float stb_perlin_noise3(float x, float y, float z, int x_wrap, int y_wrap, int z
    return stb__perlin_lerp(n0,n1,u);
 }
 
-float stb_perlin_ridge_noise3(float x, float y, float z,float lacunarity, float gain, float offset, int octaves,int x_wrap, int y_wrap, int z_wrap)
+float stb_perlin_noise3(float x, float y, float z, int x_wrap, int y_wrap, int z_wrap)
+{
+    return stb_perlin_noise3_internal(x,y,z,x_wrap,y_wrap,z_wrap,0);
+}
+
+float stb_perlin_noise3_seed(float x, float y, float z, int x_wrap, int y_wrap, int z_wrap, int seed)
+{
+    return stb_perlin_noise3_internal(x,y,z,x_wrap,y_wrap,z_wrap, (unsigned char) seed);
+}
+
+float stb_perlin_ridge_noise3(float x, float y, float z, float lacunarity, float gain, float offset, int octaves)
 {
    int i;
    float frequency = 1.0f;
@@ -227,9 +279,8 @@ float stb_perlin_ridge_noise3(float x, float y, float z,float lacunarity, float 
    float sum = 0.0f;
 
    for (i = 0; i < octaves; i++) {
-      float r = (float)(stb_perlin_noise3(x*frequency,y*frequency,z*frequency,x_wrap,y_wrap,z_wrap));
-      r = r<0 ? -r : r; // fabs()
-      r = offset - r;
+      float r = stb_perlin_noise3_internal(x*frequency,y*frequency,z*frequency,0,0,0,(unsigned char)i);
+      r = offset - (float) fabs(r);
       r = r*r;
       sum += r*amplitude*prev;
       prev = r;
@@ -239,7 +290,7 @@ float stb_perlin_ridge_noise3(float x, float y, float z,float lacunarity, float 
    return sum;
 }
 
-float stb_perlin_fbm_noise3(float x, float y, float z,float lacunarity, float gain, int octaves,int x_wrap, int y_wrap, int z_wrap)
+float stb_perlin_fbm_noise3(float x, float y, float z, float lacunarity, float gain, int octaves)
 {
    int i;
    float frequency = 1.0f;
@@ -247,14 +298,14 @@ float stb_perlin_fbm_noise3(float x, float y, float z,float lacunarity, float ga
    float sum = 0.0f;
    
    for (i = 0; i < octaves; i++) {
-      sum += stb_perlin_noise3(x*frequency,y*frequency,z*frequency,x_wrap,y_wrap,z_wrap)*amplitude;
+      sum += stb_perlin_noise3_internal(x*frequency,y*frequency,z*frequency,0,0,0,(unsigned char)i)*amplitude;
       frequency *= lacunarity;
       amplitude *= gain;
    }
    return sum;
 }
 
-float stb_perlin_turbulence_noise3(float x, float y, float z, float lacunarity, float gain, int octaves,int x_wrap, int y_wrap, int z_wrap)
+float stb_perlin_turbulence_noise3(float x, float y, float z, float lacunarity, float gain, int octaves)
 {
    int i;
    float frequency = 1.0f;
@@ -262,9 +313,8 @@ float stb_perlin_turbulence_noise3(float x, float y, float z, float lacunarity, 
    float sum = 0.0f;
    
    for (i = 0; i < octaves; i++) {
-      float r = stb_perlin_noise3(x*frequency,y*frequency,z*frequency,x_wrap,y_wrap,z_wrap)*amplitude;
-      r = r<0 ? -r : r; // fabs()
-      sum += r;
+      float r = stb_perlin_noise3_internal(x*frequency,y*frequency,z*frequency,0,0,0,(unsigned char)i)*amplitude;
+      sum += (float) fabs(r);
       frequency *= lacunarity;
       amplitude *= gain;
    }

--- a/stb_rect_pack.h
+++ b/stb_rect_pack.h
@@ -1,4 +1,4 @@
-// stb_rect_pack.h - v0.11 - public domain - rectangle packing
+// stb_rect_pack.h - v0.99 - public domain - rectangle packing
 // Sean Barrett 2014
 //
 // Useful for e.g. packing rectangular textures into an atlas.
@@ -34,6 +34,7 @@
 //
 // Version history:
 //
+//     0.99  (2019-02-07)  warning fixes
 //     0.11  (2017-03-03)  return packing success/fail result
 //     0.10  (2016-10-25)  remove cast-away-const to avoid warnings
 //     0.09  (2016-08-27)  fix compiler warnings
@@ -492,17 +493,14 @@ static stbrp__findresult stbrp__skyline_pack_rectangle(stbrp_context *context, i
    STBRP_ASSERT(cur->next == NULL);
 
    {
-      stbrp_node *L1 = NULL, *L2 = NULL;
       int count=0;
       cur = context->active_head;
       while (cur) {
-         L1 = cur;
          cur = cur->next;
          ++count;
       }
       cur = context->free_head;
       while (cur) {
-         L2 = cur;
          cur = cur->next;
          ++count;
       }
@@ -544,9 +542,6 @@ STBRP_DEF int stbrp_pack_rects(stbrp_context *context, stbrp_rect *rects, int nu
    // we use the 'was_packed' field internally to allow sorting/unsorting
    for (i=0; i < num_rects; ++i) {
       rects[i].was_packed = i;
-      #ifndef STBRP_LARGE_RECTS
-      STBRP_ASSERT(rects[i].w <= 0xffff && rects[i].h <= 0xffff);
-      #endif
    }
 
    // sort according to heuristic

--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -1,4 +1,4 @@
-// stb_sprintf - v1.05 - public domain snprintf() implementation
+// stb_sprintf - v1.06 - public domain snprintf() implementation
 // originally by Jeff Roberts / RAD Game Tools, 2015/10/20
 // http://github.com/nothings/stb
 //
@@ -11,10 +11,13 @@
 // Contributors (bugfixes):
 //    github:d26435
 //    github:trex78
+//    github:account-login
 //    Jari Komppa (SI suffixes)
 //    Rohit Nirmal
 //    Marcin Wojdyr
 //    Leonard Ritter
+//    Stefano Zanotti
+//    Adam Allison
 //
 // LICENSE:
 //
@@ -159,6 +162,7 @@ PERFORMANCE vs MSVC 2008 32-/64-bit (GCC is even slower than MSVC):
 #endif
 
 #include <stdarg.h> // for va_list()
+#include <stddef.h> // size_t, ptrdiff_t
 
 #ifndef STB_SPRINTF_MIN
 #define STB_SPRINTF_MIN 512 // how many characters per callback
@@ -224,9 +228,18 @@ static stbsp__int32 stbsp__real_to_parts(stbsp__int64 *bits, stbsp__int32 *expo,
 
 static char stbsp__period = '.';
 static char stbsp__comma = ',';
-static char stbsp__digitpair[201] =
-   "0001020304050607080910111213141516171819202122232425262728293031323334353637383940414243444546474849505152535455565758596061626364656667686970717273747576"
-   "7778798081828384858687888990919293949596979899";
+static struct
+{
+   short temp; // force next field to be 2-byte aligned
+   char pair[201];
+} stbsp__digitpair =
+{
+  0,
+   "00010203040506070809101112131415161718192021222324"
+   "25262728293031323334353637383940414243444546474849"
+   "50515253545556575859606162636465666768697071727374"
+   "75767778798081828384858687888990919293949596979899"
+};
 
 STBSP__PUBLICDEF void STB_SPRINTF_DECORATE(set_separators)(char pcomma, char pperiod)
 {
@@ -332,7 +345,17 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
             if (callback)
                if ((STB_SPRINTF_MIN - (int)(bf - buf)) < 4)
                   goto schk1;
-            *(stbsp__uint32 *)bf = v;
+            #ifdef STB_SPRINTF_NOUNALIGNED
+                if(((stbsp__uintptr)bf) & 3) {
+                    bf[0] = f[0];
+                    bf[1] = f[1];
+                    bf[2] = f[2];
+                    bf[3] = f[3];
+                } else
+            #endif
+            {
+                *(stbsp__uint32 *)bf = v;
+            }
             bf += 4;
             f += 4;
          }
@@ -437,6 +460,7 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
          break;
       // are we 64-bit (unix style)
       case 'l':
+         fl |= ((sizeof(long) == 8) ? STBSP__INTMAX : 0);
          ++f;
          if (f[0] == 'l') {
             fl |= STBSP__INTMAX;
@@ -445,13 +469,16 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
          break;
       // are we 64-bit on intmax? (c99)
       case 'j':
-         fl |= STBSP__INTMAX;
+         fl |= (sizeof(size_t) == 8) ? STBSP__INTMAX : 0;
          ++f;
          break;
       // are we 64-bit on size_t or ptrdiff_t? (c99)
       case 'z':
+         fl |= (sizeof(ptrdiff_t) == 8) ? STBSP__INTMAX : 0;
+         ++f;
+         break;
       case 't':
-         fl |= ((sizeof(char *) == 8) ? STBSP__INTMAX : 0);
+         fl |= (sizeof(ptrdiff_t) == 8) ? STBSP__INTMAX : 0;
          ++f;
          break;
       // are we 64-bit (msft style)
@@ -666,11 +693,11 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
                --pr; // when using %e, there is one digit before the decimal
             goto doexpfromg;
          }
-         // this is the insane action to get the pr to match %g sematics for %f
+         // this is the insane action to get the pr to match %g semantics for %f
          if (dp > 0) {
             pr = (dp < (stbsp__int32)l) ? l - dp : 0;
          } else {
-            pr = -dp + ((pr > (stbsp__int32)l) ? l : pr);
+            pr = -dp + ((pr > (stbsp__int32)l) ? (stbsp__int32) l : pr);
          }
          goto dofloatfromg;
 
@@ -1030,7 +1057,7 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
             if ((fl & STBSP__TRIPLET_COMMA) == 0) {
                do {
                   s -= 2;
-                  *(stbsp__uint16 *)s = *(stbsp__uint16 *)&stbsp__digitpair[(n % 100) * 2];
+                  *(stbsp__uint16 *)s = *(stbsp__uint16 *)&stbsp__digitpair.pair[(n % 100) * 2];
                   n /= 100;
                } while (n);
             }
@@ -1428,7 +1455,7 @@ static stbsp__int32 stbsp__real_to_parts(stbsp__int64 *bits, stbsp__int32 *expo,
    *bits = b & ((((stbsp__uint64)1) << 52) - 1);
    *expo = (stbsp__int32)(((b >> 52) & 2047) - 1023);
 
-   return (stbsp__int32)(b >> 63);
+   return (stbsp__int32)((stbsp__uint64) b >> 63);
 }
 
 static double const stbsp__bot[23] = {
@@ -1638,7 +1665,7 @@ static stbsp__int32 stbsp__real_to_str(char const **start, stbsp__uint32 *len, c
    d = value;
    STBSP__COPYFP(bits, d);
    expo = (stbsp__int32)((bits >> 52) & 2047);
-   ng = (stbsp__int32)(bits >> 63);
+   ng = (stbsp__int32)((stbsp__uint64) bits >> 63);
    if (ng)
       d = -d;
 
@@ -1748,7 +1775,7 @@ static stbsp__int32 stbsp__real_to_str(char const **start, stbsp__uint32 *len, c
       }
       while (n) {
          out -= 2;
-         *(stbsp__uint16 *)out = *(stbsp__uint16 *)&stbsp__digitpair[(n % 100) * 2];
+         *(stbsp__uint16 *)out = *(stbsp__uint16 *)&stbsp__digitpair.pair[(n % 100) * 2];
          n /= 100;
          e += 2;
       }

--- a/stb_textedit.h
+++ b/stb_textedit.h
@@ -1,4 +1,4 @@
-// stb_textedit.h - v1.12  - public domain - Sean Barrett
+// stb_textedit.h - v1.13  - public domain - Sean Barrett
 // Development of this library was sponsored by RAD Game Tools
 //
 // This C header file implements the guts of a multi-line text-editing
@@ -29,6 +29,7 @@
 //
 // VERSION HISTORY
 //
+//   1.13 (2019-02-07) fix bug in undo size management
 //   1.12 (2018-01-29) user can change STB_TEXTEDIT_KEYTYPE, fix redo to avoid crash
 //   1.11 (2017-03-03) fix HOME on last line, dragging off single-line textfield
 //   1.10 (2016-10-25) supress warnings about casting away const with -Wcast-qual
@@ -86,8 +87,8 @@
 //   moderate sizes. The undo system does no memory allocations, so
 //   it grows STB_TexteditState by the worst-case storage which is (in bytes):
 //
-//        [4 + sizeof(STB_TEXTEDIT_POSITIONTYPE)] * STB_TEXTEDIT_UNDOSTATE_COUNT
-//      +      sizeof(STB_TEXTEDIT_CHARTYPE)      * STB_TEXTEDIT_UNDOCHAR_COUNT
+//        [4 + 3 * sizeof(STB_TEXTEDIT_POSITIONTYPE)] * STB_TEXTEDIT_UNDOSTATE_COUNT
+//      +          sizeof(STB_TEXTEDIT_CHARTYPE)      * STB_TEXTEDIT_UNDOCHAR_COUNT
 //
 //
 // Implementation mode:
@@ -110,7 +111,7 @@
 // Symbols that must be the same in header-file and implementation mode:
 //
 //     STB_TEXTEDIT_CHARTYPE             the character type
-//     STB_TEXTEDIT_POSITIONTYPE         small type that a valid cursor position
+//     STB_TEXTEDIT_POSITIONTYPE         small type that is a valid cursor position
 //     STB_TEXTEDIT_UNDOSTATECOUNT       the number of undo states to allow
 //     STB_TEXTEDIT_UNDOCHARCOUNT        the number of characters to store in the undo buffer
 //
@@ -295,9 +296,9 @@ typedef struct
 {
    // private data
    STB_TEXTEDIT_POSITIONTYPE  where;
-   short           insert_length;
-   short           delete_length;
-   short           char_storage;
+   STB_TEXTEDIT_POSITIONTYPE  insert_length;
+   STB_TEXTEDIT_POSITIONTYPE  delete_length;
+   int                        char_storage;
 } StbUndoRecord;
 
 typedef struct
@@ -306,7 +307,7 @@ typedef struct
    StbUndoRecord          undo_rec [STB_TEXTEDIT_UNDOSTATECOUNT];
    STB_TEXTEDIT_CHARTYPE  undo_char[STB_TEXTEDIT_UNDOCHARCOUNT];
    short undo_point, redo_point;
-   short undo_char_point, redo_char_point;
+   int undo_char_point, redo_char_point;
 } StbUndoState;
 
 typedef struct
@@ -558,7 +559,6 @@ static void stb_textedit_find_charpos(StbFindState *find, STB_TEXTEDIT_STRING *s
 
    // now scan to find xpos
    find->x = r.x0;
-   i = 0;
    for (i=0; first+i < n; ++i)
       find->x += STB_TEXTEDIT_GETWIDTH(str, first, i);
 }
@@ -688,7 +688,7 @@ static void stb_textedit_prep_selection_at_cursor(STB_TexteditState *state)
 static int stb_textedit_cut(STB_TEXTEDIT_STRING *str, STB_TexteditState *state)
 {
    if (STB_TEXT_HAS_SELECTION(state)) {
-      stb_textedit_delete_selection(str,state); // implicity clamps
+      stb_textedit_delete_selection(str,state); // implicitly clamps
       state->has_preferred_x = 0;
       return 1;
    }
@@ -740,7 +740,7 @@ retry:
                   state->has_preferred_x = 0;
                }
             } else {
-               stb_textedit_delete_selection(str,state); // implicity clamps
+               stb_textedit_delete_selection(str,state); // implicitly clamps
                if (STB_TEXTEDIT_INSERTCHARS(str, state->cursor, &ch, 1)) {
                   stb_text_makeundo_insert(state, state->cursor, 1);
                   ++state->cursor;
@@ -1096,11 +1096,11 @@ static void stb_textedit_discard_undo(StbUndoState *state)
       if (state->undo_rec[0].char_storage >= 0) {
          int n = state->undo_rec[0].insert_length, i;
          // delete n characters from all other records
-         state->undo_char_point = state->undo_char_point - (short) n;  // vsnet05
+         state->undo_char_point -= n;
          STB_TEXTEDIT_memmove(state->undo_char, state->undo_char + n, (size_t) (state->undo_char_point*sizeof(STB_TEXTEDIT_CHARTYPE)));
          for (i=0; i < state->undo_point; ++i)
             if (state->undo_rec[i].char_storage >= 0)
-               state->undo_rec[i].char_storage = state->undo_rec[i].char_storage - (short) n; // vsnet05 // @OPTIMIZE: get rid of char_storage and infer it
+               state->undo_rec[i].char_storage -= n; // @OPTIMIZE: get rid of char_storage and infer it
       }
       --state->undo_point;
       STB_TEXTEDIT_memmove(state->undo_rec, state->undo_rec+1, (size_t) (state->undo_point*sizeof(state->undo_rec[0])));
@@ -1120,12 +1120,12 @@ static void stb_textedit_discard_redo(StbUndoState *state)
       if (state->undo_rec[k].char_storage >= 0) {
          int n = state->undo_rec[k].insert_length, i;
          // move the remaining redo character data to the end of the buffer
-         state->redo_char_point = state->redo_char_point + (short) n; // vsnet05
+         state->redo_char_point += n;
          STB_TEXTEDIT_memmove(state->undo_char + state->redo_char_point, state->undo_char + state->redo_char_point-n, (size_t) ((STB_TEXTEDIT_UNDOCHARCOUNT - state->redo_char_point)*sizeof(STB_TEXTEDIT_CHARTYPE)));
          // adjust the position of all the other records to account for above memmove
          for (i=state->redo_point; i < k; ++i)
             if (state->undo_rec[i].char_storage >= 0)
-               state->undo_rec[i].char_storage += (short) n; // vsnet05
+               state->undo_rec[i].char_storage += n;
       }
       // now move all the redo records towards the end of the buffer; the first one is at 'redo_point'
       STB_TEXTEDIT_memmove(state->undo_rec + state->redo_point+1, state->undo_rec + state->redo_point, (size_t) ((STB_TEXTEDIT_UNDOSTATECOUNT - state->redo_point)*sizeof(state->undo_rec[0])));
@@ -1165,15 +1165,15 @@ static STB_TEXTEDIT_CHARTYPE *stb_text_createundo(StbUndoState *state, int pos, 
       return NULL;
 
    r->where = pos;
-   r->insert_length = (short) insert_len;
-   r->delete_length = (short) delete_len;
+   r->insert_length = (STB_TEXTEDIT_POSITIONTYPE) insert_len;
+   r->delete_length = (STB_TEXTEDIT_POSITIONTYPE) delete_len;
 
    if (insert_len == 0) {
       r->char_storage = -1;
       return NULL;
    } else {
       r->char_storage = state->undo_char_point;
-      state->undo_char_point = state->undo_char_point + (short) insert_len;
+      state->undo_char_point += insert_len;
       return &state->undo_char[r->char_storage];
    }
 }
@@ -1222,7 +1222,7 @@ static void stb_text_undo(STB_TEXTEDIT_STRING *str, STB_TexteditState *state)
          r = &s->undo_rec[s->redo_point-1];
 
          r->char_storage = s->redo_char_point - u.delete_length;
-         s->redo_char_point = s->redo_char_point - (short) u.delete_length;
+         s->redo_char_point = s->redo_char_point - u.delete_length;
 
          // now save the characters
          for (i=0; i < u.delete_length; ++i)

--- a/stb_tilemap_editor.h
+++ b/stb_tilemap_editor.h
@@ -1,4 +1,4 @@
-// stb_tilemap_editor.h - v0.38 - Sean Barrett - http://nothings.org/stb
+// stb_tilemap_editor.h - v0.39 - Sean Barrett - http://nothings.org/stb
 // placed in the public domain - not copyrighted - first released 2014-09
 //
 // Embeddable tilemap editor for C/C++
@@ -168,7 +168,7 @@
 //      #define STB_TILEMAP_EDITOR_IMPLEMENTATION
 //      // this triggers the implementation
 //
-//      void STBTE_DRAW_RECT(int x0, int y0, int x1, int y1, uint color);
+//      void STBTE_DRAW_RECT(int x0, int y0, int x1, int y1, unsigned int color);
 //      // this must draw a filled rectangle (exclusive on right/bottom)
 //      // color = (r<<16)|(g<<8)|(b)
 //      
@@ -251,7 +251,7 @@
 //
 //   The following symbols set static limits which determine how much
 //   memory will be allocated for the editor. You can override them
-//   by making similiar definitions, but memory usage will increase.
+//   by making similar definitions, but memory usage will increase.
 //
 //      #define STBTE_MAX_TILEMAP_X      200   // max 4096
 //      #define STBTE_MAX_TILEMAP_Y      200   // max 4096
@@ -396,7 +396,7 @@ extern void stbte_tick(stbte_tilemap *tm, float time_in_seconds_since_last_frame
 //  user input
 //
 
-// if you're using SDL, call the next function for SDL_MOUSEMOVE, SDL_MOUSEBUTTON, SDL_MOUSEWHEEL;
+// if you're using SDL, call the next function for SDL_MOUSEMOTION, SDL_MOUSEBUTTONDOWN, SDL_MOUSEBUTTONUP, SDL_MOUSEWHEEL;
 // the transformation lets you scale from SDL mouse coords to stb_tilemap_editor coords
 extern void stbte_mouse_sdl(stbte_tilemap *tm, const void *sdl_event, float xscale, float yscale, int xoffset, int yoffset);
 
@@ -404,6 +404,8 @@ extern void stbte_mouse_sdl(stbte_tilemap *tm, const void *sdl_event, float xsca
 extern void stbte_mouse_move(stbte_tilemap *tm, int x, int y, int shifted, int scrollkey);
 extern void stbte_mouse_button(stbte_tilemap *tm, int x, int y, int right, int down, int shifted, int scrollkey);
 extern void stbte_mouse_wheel(stbte_tilemap *tm, int x, int y, int vscroll);
+
+// note: at the moment, mouse wheel events (SDL_MOUSEWHEEL) are ignored.
 
 // for keyboard, define your own mapping from keys to the following actions.
 // this is totally optional, as all features are accessible with the mouse
@@ -2250,7 +2252,7 @@ enum
    STBTE__prop_int,
 };
 
-// id is:      [      24-bit data     : 7-bit identifer ]
+// id is:      [      24-bit data     : 7-bit identifier ]
 // map id is:  [  12-bit y : 12 bit x : 7-bit identifier ]
 
 #define STBTE__ID(n,p)     ((n) + ((p)<<7))
@@ -2878,7 +2880,7 @@ static void stbte__drag_update(stbte_tilemap *tm, int mapx, int mapy, int copy_p
             stbte__set_link(tm, mapx, mapy, -1, -1, STBTE__undo_record);
          else if (moved || (copied && written)) {
             // if we move the target, we update to point to the new target;
-            // or, if we copy the target and the source is part ofthe copy, then update to new target
+            // or, if we copy the target and the source is part of the copy, then update to new target
             int x = k->x + (stbte__ui.drag_dest_x - stbte__ui.drag_x);
             int y = k->y + (stbte__ui.drag_dest_y - stbte__ui.drag_y);
             if (!(x >= 0 && y >= 0 && x < tm->max_x && y < tm->max_y))

--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -1,4 +1,4 @@
-// stb_truetype.h - v1.19 - public domain
+// stb_truetype.h - v1.20 - public domain
 // authored from 2009-2016 by Sean Barrett / RAD Game Tools
 //
 //   This library processes TrueType files:
@@ -49,6 +49,7 @@
 //       
 // VERSION HISTORY
 //
+//   1.20 (2019-02-07) PackFontRange skips missing codepoints; GetScaleFontVMetrics()
 //   1.19 (2018-02-11) GPOS kerning, STBTT_fmod
 //   1.18 (2018-01-29) add missing function
 //   1.17 (2017-07-23) make more arguments const; doc fix
@@ -75,7 +76,7 @@
 //
 // USAGE
 //
-//   Include this file in whatever places neeed to refer to it. In ONE C/C++
+//   Include this file in whatever places need to refer to it. In ONE C/C++
 //   file, write:
 //      #define STB_TRUETYPE_IMPLEMENTATION
 //   before the #include of this file. This expands out the actual
@@ -247,8 +248,8 @@
 //   Documentation & header file        520 LOC  \___ 660 LOC documentation
 //   Sample code                        140 LOC  /
 //   Truetype parsing                   620 LOC  ---- 620 LOC TrueType
-//   Software rasterization             240 LOC  \                           .
-//   Curve tesselation                  120 LOC   \__ 550 LOC Bitmap creation
+//   Software rasterization             240 LOC  \                           
+//   Curve tessellation                 120 LOC   \__ 550 LOC Bitmap creation
 //   Bitmap management                  100 LOC   /
 //   Baked bitmap interface              70 LOC  /
 //   Font name matching & access        150 LOC  ---- 150 
@@ -556,6 +557,8 @@ STBTT_DEF void stbtt_GetBakedQuad(const stbtt_bakedchar *chardata, int pw, int p
 //
 // It's inefficient; you might want to c&p it and optimize it.
 
+STBTT_DEF void stbtt_GetScaledFontVMetrics(const unsigned char *fontdata, int index, float size, float *ascent, float *descent, float *lineGap);
+// Query the font vertical metrics without having to create a font first.
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -641,6 +644,12 @@ STBTT_DEF void stbtt_PackSetOversampling(stbtt_pack_context *spc, unsigned int h
 // To use with PackFontRangesGather etc., you must set it before calls
 // call to PackFontRangesGatherRects.
 
+STBTT_DEF void stbtt_PackSetSkipMissingCodepoints(stbtt_pack_context *spc, int skip);
+// If skip != 0, this tells stb_truetype to skip any codepoints for which
+// there is no corresponding glyph. If skip=0, which is the default, then
+// codepoints without a glyph recived the font's "missing character" glyph,
+// typically an empty box by convention.
+
 STBTT_DEF void stbtt_GetPackedQuad(const stbtt_packedchar *chardata, int pw, int ph,  // same data as above
                                int char_index,             // character to display
                                float *xpos, float *ypos,   // pointers to current position in screen pixel space
@@ -669,6 +678,7 @@ struct stbtt_pack_context {
    int   height;
    int   stride_in_bytes;
    int   padding;
+   int   skip_missing;
    unsigned int   h_oversample, v_oversample;
    unsigned char *pixels;
    void  *nodes;
@@ -694,7 +704,7 @@ STBTT_DEF int stbtt_GetFontOffsetForIndex(const unsigned char *data, int index);
 // file will only define one font and it always be at offset 0, so it will
 // return '0' for index 0, and -1 for all other indices.
 
-// The following structure is defined publically so you can declare one on
+// The following structure is defined publicly so you can declare one on
 // the stack or as a global or etc, but you should treat it as opaque.
 struct stbtt_fontinfo
 {
@@ -733,6 +743,7 @@ STBTT_DEF int stbtt_FindGlyphIndex(const stbtt_fontinfo *info, int unicode_codep
 // and you want a speed-up, call this function with the character you're
 // going to process, then use glyph-based functions instead of the
 // codepoint-based functions.
+// Returns 0 if the character codepoint is not defined in the font.
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -820,7 +831,7 @@ STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, s
 // returns # of vertices and fills *vertices with the pointer to them
 //   these are expressed in "unscaled" coordinates
 //
-// The shape is a series of countours. Each one starts with
+// The shape is a series of contours. Each one starts with
 // a STBTT_moveto, then consists of a series of mixed
 // STBTT_lineto and STBTT_curveto segments. A lineto
 // draws a line from previous endpoint to its x,y; a curveto
@@ -916,7 +927,7 @@ STBTT_DEF unsigned char * stbtt_GetGlyphSDF(const stbtt_fontinfo *info, float sc
 STBTT_DEF unsigned char * stbtt_GetCodepointSDF(const stbtt_fontinfo *info, float scale, int codepoint, int padding, unsigned char onedge_value, float pixel_dist_scale, int *width, int *height, int *xoff, int *yoff);
 // These functions compute a discretized SDF field for a single character, suitable for storing
 // in a single-channel texture, sampling with bilinear filtering, and testing against
-// larger than some threshhold to produce scalable fonts.
+// larger than some threshold to produce scalable fonts.
 //        info              --  the font
 //        scale             --  controls the size of the resulting SDF bitmap, same as it would be creating a regular bitmap
 //        glyph/codepoint   --  the character to generate the SDF for
@@ -2463,6 +2474,7 @@ static stbtt_int32  stbtt__GetGlyphGPOSInfoAdvance(const stbtt_fontinfo *info, i
                             if (valueFormat2 != 0) return 0;
 
                             STBTT_assert(coverageIndex < pairSetCount);
+                            STBTT__NOTUSED(pairSetCount);
 
                             needle=glyph2;
                             r=pairValueCount-1;
@@ -3160,7 +3172,13 @@ static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result, stbtt__edge *e,
          if (e->y0 != e->y1) {
             stbtt__active_edge *z = stbtt__new_active(&hh, e, off_x, scan_y_top, userdata);
             if (z != NULL) {
-               STBTT_assert(z->ey >= scan_y_top);
+               if (j == 0 && off_y != 0) {
+                  if (z->ey < scan_y_top) {
+                     // this can happen due to subpixel positioning and some kind of fp rounding error i think
+                     z->ey = scan_y_top;
+                  }
+               }
+               STBTT_assert(z->ey >= scan_y_top); // if we get really unlucky a tiny bit of an edge can be out of bounds
                // insert at front
                z->next = active;
                active = z;
@@ -3229,7 +3247,7 @@ static void stbtt__sort_edges_ins_sort(stbtt__edge *p, int n)
 
 static void stbtt__sort_edges_quicksort(stbtt__edge *p, int n)
 {
-   /* threshhold for transitioning to insertion sort */
+   /* threshold for transitioning to insertion sort */
    while (n > 12) {
       stbtt__edge t;
       int c01,c12,c,m,i,j;
@@ -3364,7 +3382,7 @@ static void stbtt__add_point(stbtt__point *points, int n, float x, float y)
    points[n].y = y;
 }
 
-// tesselate until threshhold p is happy... @TODO warped to compensate for non-linear stretching
+// tessellate until threshold p is happy... @TODO warped to compensate for non-linear stretching
 static int stbtt__tesselate_curve(stbtt__point *points, int *num_points, float x0, float y0, float x1, float y1, float x2, float y2, float objspace_flatness_squared, int n)
 {
    // midpoint
@@ -3789,6 +3807,7 @@ STBTT_DEF int stbtt_PackBegin(stbtt_pack_context *spc, unsigned char *pixels, in
    spc->stride_in_bytes = stride_in_bytes != 0 ? stride_in_bytes : pw;
    spc->h_oversample = 1;
    spc->v_oversample = 1;
+   spc->skip_missing = 0;
 
    stbrp_init_target(context, pw-padding, ph-padding, nodes, num_nodes);
 
@@ -3812,6 +3831,11 @@ STBTT_DEF void stbtt_PackSetOversampling(stbtt_pack_context *spc, unsigned int h
       spc->h_oversample = h_oversample;
    if (v_oversample <= STBTT_MAX_OVERSAMPLE)
       spc->v_oversample = v_oversample;
+}
+
+STBTT_DEF void stbtt_PackSetSkipMissingCodepoints(stbtt_pack_context *spc, int skip)
+{
+   spc->skip_missing = skip;
 }
 
 #define STBTT__OVER_MASK  (STBTT_MAX_OVERSAMPLE-1)
@@ -3967,13 +3991,17 @@ STBTT_DEF int stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, const stb
          int x0,y0,x1,y1;
          int codepoint = ranges[i].array_of_unicode_codepoints == NULL ? ranges[i].first_unicode_codepoint_in_range + j : ranges[i].array_of_unicode_codepoints[j];
          int glyph = stbtt_FindGlyphIndex(info, codepoint);
-         stbtt_GetGlyphBitmapBoxSubpixel(info,glyph,
-                                         scale * spc->h_oversample,
-                                         scale * spc->v_oversample,
-                                         0,0,
-                                         &x0,&y0,&x1,&y1);
-         rects[k].w = (stbrp_coord) (x1-x0 + spc->padding + spc->h_oversample-1);
-         rects[k].h = (stbrp_coord) (y1-y0 + spc->padding + spc->v_oversample-1);
+         if (glyph == 0 && spc->skip_missing) {
+            rects[k].w = rects[k].h = 0;
+         } else {
+            stbtt_GetGlyphBitmapBoxSubpixel(info,glyph,
+                                            scale * spc->h_oversample,
+                                            scale * spc->v_oversample,
+                                            0,0,
+                                            &x0,&y0,&x1,&y1);
+            rects[k].w = (stbrp_coord) (x1-x0 + spc->padding + spc->h_oversample-1);
+            rects[k].h = (stbrp_coord) (y1-y0 + spc->padding + spc->v_oversample-1);
+         }
          ++k;
       }
    }
@@ -4026,7 +4054,7 @@ STBTT_DEF int stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, const
       sub_y = stbtt__oversample_shift(spc->v_oversample);
       for (j=0; j < ranges[i].num_chars; ++j) {
          stbrp_rect *r = &rects[k];
-         if (r->was_packed) {
+         if (r->was_packed && r->w != 0 && r->h != 0) {
             stbtt_packedchar *bc = &ranges[i].chardata_for_range[j];
             int advance, lsb, x0,y0,x1,y1;
             int codepoint = ranges[i].array_of_unicode_codepoints == NULL ? ranges[i].first_unicode_codepoint_in_range + j : ranges[i].array_of_unicode_codepoints[j];
@@ -4138,6 +4166,19 @@ STBTT_DEF int stbtt_PackFontRange(stbtt_pack_context *spc, const unsigned char *
    range.chardata_for_range          = chardata_for_range;
    range.font_size                   = font_size;
    return stbtt_PackFontRanges(spc, fontdata, font_index, &range, 1);
+}
+
+STBTT_DEF void stbtt_GetScaledFontVMetrics(const unsigned char *fontdata, int index, float size, float *ascent, float *descent, float *lineGap)
+{
+   int i_ascent, i_descent, i_lineGap;
+   float scale;
+   stbtt_fontinfo info;
+   stbtt_InitFont(&info, fontdata, stbtt_GetFontOffsetForIndex(fontdata, index));
+   scale = size > 0 ? stbtt_ScaleForPixelHeight(&info, size) : stbtt_ScaleForMappingEmToPixels(&info, -size);
+   stbtt_GetFontVMetrics(&info, &i_ascent, &i_descent, &i_lineGap);
+   *ascent  = (float) i_ascent  * scale;
+   *descent = (float) i_descent * scale;
+   *lineGap = (float) i_lineGap * scale;
 }
 
 STBTT_DEF void stbtt_GetPackedQuad(const stbtt_packedchar *chardata, int pw, int ph, int char_index, float *xpos, float *ypos, stbtt_aligned_quad *q, int align_to_integer)

--- a/stb_voxel_render.h
+++ b/stb_voxel_render.h
@@ -1,4 +1,4 @@
-// stb_voxel_render.h - v0.85 - Sean Barrett, 2015 - public domain
+// stb_voxel_render.h - v0.86 - Sean Barrett, 2015 - public domain
 //
 // This library helps render large-scale "voxel" worlds for games,
 // in this case, one with blocks that can have textures and that
@@ -192,6 +192,7 @@
 //
 // VERSION HISTORY
 //
+//   0.86   (2019-02-07)  fix typos in comments
 //   0.85   (2017-03-03)  add block_selector (by guitarfreak)
 //   0.84   (2016-04-02)  fix GLSL syntax error on glModelView path
 //   0.83   (2015-09-13)  remove non-constant struct initializers to support more compilers
@@ -276,7 +277,7 @@ extern "C" {
 //        NOT IMPLEMENTED! Define HLSL shaders instead of GLSL shaders
 //
 //    STBVOX_CONFIG_PREFER_TEXBUFFER
-//        Stores many of the uniform arrays in texture buffers intead,
+//        Stores many of the uniform arrays in texture buffers instead,
 //        so they can be larger and may be more efficient on some hardware.
 //
 //    STBVOX_CONFIG_LIGHTING_SIMPLE
@@ -1066,7 +1067,7 @@ enum
 // split into two triangles, each with their own normal/lighting.
 // (Note that since all output from stb_voxel_render is quad meshes,
 // triangles are actually rendered as degenerate quads.) In this case,
-// the distinction betwen STBVOX_GEOM_floor_vheight_03 and
+// the distinction between STBVOX_GEOM_floor_vheight_03 and
 // STBVOX_GEOM_floor_vheight_12 comes into play; the former introduces
 // an edge from the SW to NE corner (i.e. from <0,0,?> to <1,1,?>),
 // while the latter introduces an edge from the NW to SE corner

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,5 +3,5 @@ CFLAGS = -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast -DSTB_DIVIDE_TEST
 CPPFLAGS = -Wno-write-strings -DSTB_DIVIDE_TEST
 
 all:
-	$(CC) $(INCLUDES) $(CFLAGS) ../stb_vorbis.c test_c_compilation.c -lm
+	$(CC) $(INCLUDES) $(CFLAGS) ../stb_vorbis.c test_c_compilation.c test_c_lexer.c test_dxt.c test_easyfont.c test_image.c test_image_write.c test_perlin.c test_sprintf.c test_truetype.c test_voxel.c -lm
 	$(CC) $(INCLUDES) $(CPPFLAGS) test_cpp_compilation.cpp -lm -lstdc++

--- a/tests/image_test.c
+++ b/tests/image_test.c
@@ -1,3 +1,5 @@
+#define STBI_WINDOWS_UTF8
+
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
 
@@ -84,7 +86,7 @@ int main(int argc, char **argv)
          int w2,h2,n2;
          unsigned char *data;
          printf("%s\n", argv[i]);
-         res = stbi_info(argv[1], &w2, &h2, &n2);
+         res = stbi_info(argv[i], &w2, &h2, &n2);
          data = stbi_load(argv[i], &w, &h, &n, 4); if (data) free(data); else printf("Failed &n\n");
          data = stbi_load(argv[i], &w, &h,  0, 1); if (data) free(data); else printf("Failed 1\n");
          data = stbi_load(argv[i], &w, &h,  0, 2); if (data) free(data); else printf("Failed 2\n");

--- a/tests/image_test.dsp
+++ b/tests/image_test.dsp
@@ -41,7 +41,8 @@ RSC=rc.exe
 # PROP Intermediate_Dir "Release"
 # PROP Target_Dir ""
 # ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /c
-# ADD CPP /nologo /W3 /GX /O2 /I ".." /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /c
+# ADD CPP /nologo /W3 /GX /O2 /I ".." /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /FD /c
+# SUBTRACT CPP /YX
 # ADD BASE RSC /l 0x409 /d "NDEBUG"
 # ADD RSC /l 0x409 /d "NDEBUG"
 BSC32=bscmake.exe

--- a/tests/prerelease/stb_lib.h
+++ b/tests/prerelease/stb_lib.h
@@ -1250,13 +1250,13 @@ typedef struct
 // (internal) change the allocated length of the array
 #define stb_arr__grow(a,n)     (stb_arr_check(a), stb_arrhead(a)->len += (n))
 
-// add N new unitialized elements to the end of the array
+// add N new uninitialized elements to the end of the array
 #define stb_arr__addn(a,n)     /*lint --e(826)*/ \
                                ((stb_arr_len(a)+(n) > stb_arrcurmax(a))      \
                                  ? (stb__arr_addlen((void **) &(a),sizeof(*a),(n)),0) \
                                  : ((stb_arr__grow(a,n), 0)))
 
-// add N new unitialized elements to the end of the array, and return
+// add N new uninitialized elements to the end of the array, and return
 // a pointer to the first new one
 #define stb_arr_addn(a,n)      (stb_arr__addn((a),n),(a)+stb_arr_len(a)-(n))
 

--- a/tests/stb.c
+++ b/tests/stb.c
@@ -13,12 +13,13 @@
 #include <crtdbg.h>
 #endif
 
-#define STB_STUA
 //#define STB_FASTMALLOC
 #ifdef _DEBUG
 #define STB_MALLOC_WRAPPER_DEBUG
 #endif
+#ifndef _M_AMD64
 #define STB_NPTR
+#endif
 #define STB_DEFINE
 #include "stb.h"
 
@@ -119,7 +120,7 @@ void test_classes(void)
   return;
 }
 
-
+#ifdef STB_STUA
 void test_script(void)
 {
    stua_run_script(
@@ -193,6 +194,7 @@ void test_script(void)
       " // final comment with no newline"
    );
 }
+#endif
 
 #ifdef STB_THREADS
 extern void __stdcall Sleep(unsigned long);
@@ -1490,7 +1492,7 @@ int main(int argc, char **argv)
    }
 
    // the hardcoded compressed lengths being verified _could_
-   // change if you changed the compresser parameters; but pure
+   // change if you changed the compressor parameters; but pure
    // performance optimizations shouldn't change them
    p = stb_file("data/cantrbry.zip", &len2);
    if (p) {
@@ -2254,11 +2256,13 @@ void test_packed_floats(void)
 void do_compressor(int argc,char**argv)
 {
    char *p;
+   size_t slen;
    int len;
 
    int window;
    if (argc == 2) {
-      p = stb_file(argv[1], &len);
+      p = stb_file(argv[1], &slen);
+      len = (int) slen;
       if (p) {
          int dlen, clen = stb_compress_tofile("data/dummy.bin", p, len);
          char *q = stb_decompress_fromfile("data/dummy.bin", &dlen);
@@ -2278,7 +2282,8 @@ void do_compressor(int argc,char**argv)
 
    window = atoi(argv[1]);
    if (window && argc == 4) {
-      p = stb_file(argv[3], &len);
+      p = stb_file(argv[3], &slen);
+      len = (int) slen;
       if (p) {
          stb_compress_hashsize(window);
          stb_compress_tofile(argv[2], p, len);
@@ -2506,10 +2511,10 @@ void first_for_prod_plus_sym(stb_bitset **first, stb_bitset *out, short *prod, i
    stb_bitset_unioneq_changed(out, first[symbol], symset);
 }
 
-#define Item(p,c,t)       ((void *) (((t) << 18) + ((c) << 12) + ((p) << 2)))
-#define ItemProd(i)       ((((uint32) (i)) >> 2) & 1023)
-#define ItemCursor(i)     ((((uint32) (i)) >> 12) & 63)
-#define ItemLookahead(i)  (((uint32) (i)) >> 18)
+#define Item(p,c,t)       ((void *) (size_t) (((t) << 18) + ((c) << 12) + ((p) << 2)))
+#define ItemProd(i)       ((((uint32) (size_t) (i)) >> 2) & 1023)
+#define ItemCursor(i)     ((((uint32) (size_t) (i)) >> 12) & 63)
+#define ItemLookahead(i)  (((uint32) (size_t) (i)) >> 18)
 
 static void pc(stb_ps *p)
 {

--- a/tests/stb.dsp
+++ b/tests/stb.dsp
@@ -158,6 +158,10 @@ SOURCE=..\stb_sprintf.h
 # End Source File
 # Begin Source File
 
+SOURCE=.\stb_static.c
+# End Source File
+# Begin Source File
+
 SOURCE=..\stb_textedit.h
 # End Source File
 # Begin Source File

--- a/tests/stb_cpp.cpp
+++ b/tests/stb_cpp.cpp
@@ -2,9 +2,10 @@
 #define WIN32_LEAN_AND_MEAN
 //#include <windows.h>
 #include <conio.h>
-#define STB_STUA
 #define STB_DEFINE
+#ifndef _M_AMD64
 #define STB_NPTR
+#endif
 #define STB_ONLY
 #include "stb.h"
 //#include "stb_file.h"

--- a/tools/unicode.c
+++ b/tools/unicode.c
@@ -28,7 +28,7 @@
 //        the cluster. Repeat for trimmed & special-trimmed. In the first case, find
 //        previous instances of the cluster (allow don't-care to match in either
 //        direction), both aligned and mis-aligned; in the latter, starting where
-//        things start or mis-aligned. Build an index table specifiying the
+//        things start or mis-aligned. Build an index table specifying the
 //        location of each cluster (and its length). Allow an extra indirection here;
 //        the full-sized index can index a smaller table which has the actual offset
 //        (and lengths).


### PR DESCRIPTION
1. added stb_vorbis_open() to the API. This function receives a stream handle and four callbacks to manipulate a custom stream fgetc_cb, fseek_cb, ftell_cb, fread_cb. The stream is not closed along with decoder handler.

2. stb_vorbis_open_file()/filename()/file_section() are all using above callbacks with default values (i.e., stdio's fgetc, fseek, ftell, fread, fclose). There is an overload to mantain the existing API interface without callbacks as parameters.

3. supressed USE_MEMORY() as this is no longer necessary, the callbacks are set when a handler is created.

4. As an example, I'm using the callback open() to play from an C++ std::istream with the following callbacks supplied as parameters:

```cpp
int fgetc_cb(void *h) {
	auto stream = (std::istream *)h;
	return stream->get();
}

int fseek_cb(void *h, long int off, int dir) {
	auto stream = (std::istream *)h;
	stream->seekg(off, (std::ios_base::seekdir)dir);
	return 0;
}

long int ftell_cb(void *h) {
	auto stream = (std::istream *)h;
	return stream->tellg();
}

size_t fread_cb(void *buf, size_t len, size_t count, void *h) {
	auto stream = (std::istream *)h;
	size_t ret = stream->read((char *)buf, len*count).gcount();
	return ret == (len*count)?count:0;
}

auto stream = std::fstream("filename.ogg", std::ios::binary|std::ios::in);
auto stbvHandle = stb_vorbis_open(&stream, &err, nullptr, fgetc_cb, fseek_cb, ftell_cb, fread_cb);
```
