### PR TITLE
Fix recent optimisation; bring back pre-existing logic.

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -1486,11 +1486,11 @@ static int stbi_write_jpg_core(stbi__write_context *s, int width, int height, in
                for(col = x; col < x+8; ++col, ++pos) {
                   float r, g, b;
                   // if col >= width => use pixel from last input column
-                  p += ((col < width) ? col : (width-1))*comp;
+                  int q = p + ((col < width) ? col : (width-1))*comp;
 
-                  r = imageData[p+0];
-                  g = imageData[p+ofsG];
-                  b = imageData[p+ofsB];
+                  r = imageData[q+0];
+                  g = imageData[q+ofsG];
+                  b = imageData[q+ofsB];
                   YDU[pos]=+0.29900f*r+0.58700f*g+0.11400f*b-128;
                   UDU[pos]=-0.16874f*r-0.33126f*g+0.50000f*b;
                   VDU[pos]=+0.50000f*r-0.41869f*g-0.08131f*b;


### PR DESCRIPTION
It seems to me that https://github.com/nothings/stb/commit/e5d4d6fcce00ba8c4ec2ca0dec4c0d0b804d89fb#diff-469d4cb48b9965801e6c8cb7b92e46fe introduced a logic issue, by repeatedly incrementing `p`? InI now see reproducible SIGSEVs. This fix, while likely suboptimal, does at least revert the regression.