### PR TITLE
Fix issue 706

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -1476,17 +1476,13 @@ static int stbi_write_jpg_core(stbi__write_context *s, int width, int height, in
          for(x = 0; x < width; x += 8) {
             float YDU[64], UDU[64], VDU[64];
             for(row = y, pos = 0; row < y+8; ++row) {
-               int p;
-               if(row < height) {
-                  p = (stbi__flip_vertically_on_write ? (height-1-row) : row)*width*comp;
-               } else {
-                  // row >= height => use last input row (=> first if flipping)
-                  p = stbi__flip_vertically_on_write ? 0 : ((height-1)*width*comp);
-               }
+               // row >= height => use last input row
+               int clamped_row = (row < height) ? row : height - 1;
+               int base_p = (stbi__flip_vertically_on_write ? (height-1-clamped_row) : clamped_row)*width*comp;
                for(col = x; col < x+8; ++col, ++pos) {
                   float r, g, b;
                   // if col >= width => use pixel from last input column
-                  p += ((col < width) ? col : (width-1))*comp;
+                  int p = base_p + ((col < width) ? col : (width-1))*comp;
 
                   r = imageData[p+0];
                   g = imageData[p+ofsG];

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,6 +2,9 @@ INCLUDES = -I..
 CFLAGS = -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast -DSTB_DIVIDE_TEST
 CPPFLAGS = -Wno-write-strings -DSTB_DIVIDE_TEST
 
+#CFLAGS += -O -fsanitize=address
+
 all:
 	$(CC) $(INCLUDES) $(CFLAGS) ../stb_vorbis.c test_c_compilation.c test_c_lexer.c test_dxt.c test_easyfont.c test_image.c test_image_write.c test_perlin.c test_sprintf.c test_truetype.c test_voxel.c -lm
 	$(CC) $(INCLUDES) $(CPPFLAGS) test_cpp_compilation.cpp -lm -lstdc++
+	$(CC) $(INCLUDES) $(CFLAGS) image_write_test.c -lm -o image_write_test

--- a/tests/image_write_test.c
+++ b/tests/image_write_test.c
@@ -1,0 +1,50 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"
+
+// using an 'F' since it has no rotational symmetries, and 6x5
+// because it's a small, atypical size likely to trigger edge cases.
+//
+// conveniently, it's also small enough to fully fit inside a typical
+// directory listing thumbnail, which simplifies checking at a glance.
+static const char img6x5_template[] =
+   ".****."
+   ".*...."
+   ".***.."
+   ".*...."
+   ".*....";
+
+int main(int argc, char **argv)
+{
+   // make a RGB version of the template image
+   // use red on blue to detect R<->B swaps
+   unsigned char img6x5_rgb[6*5*3];
+   float img6x5_rgbf[6*5*3];
+   int i;
+
+   for (i = 0; i < 6*5; i++) {
+      int on = img6x5_template[i] == '*';
+      img6x5_rgb[i*3 + 0] = on ? 255 : 0;
+      img6x5_rgb[i*3 + 1] = 0;
+      img6x5_rgb[i*3 + 2] = on ? 0 : 255;
+
+      img6x5_rgbf[i*3 + 0] = on ? 1.0f : 0.0f;
+      img6x5_rgbf[i*3 + 1] = 0.0f;
+      img6x5_rgbf[i*3 + 2] = on ? 0.0f : 1.0f;
+   }
+
+   stbi_write_png("wr6x5_regular.png", 6, 5, 3, img6x5_rgb, 6*3);
+   stbi_write_bmp("wr6x5_regular.bmp", 6, 5, 3, img6x5_rgb);
+   stbi_write_tga("wr6x5_regular.tga", 6, 5, 3, img6x5_rgb);
+   stbi_write_jpg("wr6x5_regular.jpg", 6, 5, 3, img6x5_rgb, 95);
+   stbi_write_hdr("wr6x5_regular.hdr", 6, 5, 3, img6x5_rgbf);
+
+   stbi_flip_vertically_on_write(1);
+
+   stbi_write_png("wr6x5_flip.png", 6, 5, 3, img6x5_rgb, 6*3);
+   stbi_write_bmp("wr6x5_flip.bmp", 6, 5, 3, img6x5_rgb);
+   stbi_write_tga("wr6x5_flip.tga", 6, 5, 3, img6x5_rgb);
+   stbi_write_jpg("wr6x5_flip.jpg", 6, 5, 3, img6x5_rgb, 95);
+   stbi_write_hdr("wr6x5_flip.hdr", 6, 5, 3, img6x5_rgbf);
+
+   return 0;
+}


### PR DESCRIPTION
Also adding a simple tester app to hopefully reduce this kind of breakage in the future.

(This test works on x64 Linux using clang 7.0.0 with no ASan warnings.)
