### PR TITLE
stb_image: Pacify some MSVC warnings.

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -3659,7 +3659,7 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp
       int k;
       unsigned int i,j;
       stbi_uc *output;
-      stbi_uc *coutput[4];
+      stbi_uc *coutput[4] = { NULL, NULL, NULL, NULL };
 
       stbi__resample res_comp[4];
 


### PR DESCRIPTION
Convince the compiler's dataflow analysis that yes, we are not
reading uninitialized values of coutput.

Fixes issue #608.