### PR TITLE
 stb_truetype: reduce missing glyph duplication

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -46,6 +46,7 @@
 //       Rob Loach                  Cort Stratton
 //       Kenney Phillis Jr.         github:oyvindjam
 //       Brian Costabile            github:vassvik
+//       Ryan Griege
 //       
 // VERSION HISTORY
 //


### PR DESCRIPTION
When calling stbtt_PackFontRanges, multiple missing glyphs in the range of codepoints will cause multiple copies of the font's missing glyph to be added to the pixel buffer.  Instead, the first codepoint that maps to the missing glyph can add it to the pixel buffer, and all subsequent glyphs can simply copy the stbtt_packedchar data to reference the same region of the buffer.

This change does NOT prevent duplication in multiple calls to stbtt_PackFontRange(s) - that would require modifying the packing context, which could be nice but is a bit more intrusive.  I'm open to making the change, but it wasn't necessary for my use case and (I suspect) is a much less significant cause of duplication.

Or, maybe the way I'm using the library is pretty naive, and the missing glyphs are just a result.