### PR TITLE
stb_image: fixed 'out' nulled but not freed upon failure

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -6589,7 +6589,15 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
             stride = g.w * g.h * 4; 
          
             if (out) {
-               out = (stbi_uc*) STBI_REALLOC( out, layers * stride ); 
+               void *tmp = (stbi_uc*) STBI_REALLOC( out, layers * stride );
+               if (NULL == tmp) {
+                  STBI_FREE(g.out);
+                  STBI_FREE(g.history);
+                  STBI_FREE(g.background);
+                  return stbi__errpuc("outofmem", "Out of memory");
+               }
+               else
+                  out = tmp;
                if (delays) {
                   *delays = (int*) STBI_REALLOC( *delays, sizeof(int) * layers ); 
                }


### PR DESCRIPTION
If realloc fails it returns NULL and out pointer becomes invalid. To
fix this it is necessary to store realloc return value in temporary
pointer and then compare it with NULL. If it equals NULL then return
error and source pointer will still valid.

This error was caught by cppcheck:
Common realloc mistake: 'out' nulled but not freed upon failure.