### PR TITLE
Fixed a memory leak in example code

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -331,6 +331,9 @@ int main(int argc, char **argv)
          putchar(" .:ioVM@"[bitmap[j*w+i]>>5]);
       putchar('\n');
    }
+   
+   stbtt_FreeBitmap(bitmap, NULL);
+   
    return 0;
 }
 #endif 


### PR DESCRIPTION
The example code previously created a bitmap via `stbtt_GetCodepointBitmap` but never freed it, effectively creating a memory leak. This commit calls the proper stbtt free function `stbtt_FreeBitmap`.
