### PR TITLE
Allowing Compound Glyphs with `numberOfContours < -1`

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -1757,7 +1757,7 @@ static int stbtt__GetGlyphShapeTT(const stbtt_fontinfo *info, int glyph_index, s
          }
       }
       num_vertices = stbtt__close_shape(vertices, num_vertices, was_off, start_off, sx,sy,scx,scy,cx,cy);
-   } else if (numberOfContours == -1) {
+   } else if (numberOfContours < 0) {
       // Compound shapes.
       int more = 1;
       stbtt_uint8 *comp = data + g + 10;
@@ -1834,9 +1834,6 @@ static int stbtt__GetGlyphShapeTT(const stbtt_fontinfo *info, int glyph_index, s
          // More components ?
          more = flags & (1<<5);
       }
-   } else if (numberOfContours < 0) {
-      // @TODO other compound variations?
-      STBTT_assert(0);
    } else {
       // numberOfCounters == 0, do nothing
    }


### PR DESCRIPTION
While it is recommended that the numberOfContours are set to -1 for compound glyphs, it is allowed to have any negative value. Source: https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6glyf.html

However, I don't know if this happens in practice.
