### PR TITLE
stb_easy_font: fix multiple definition errors

### DIFF
--- a/stb_easy_font.h
+++ b/stb_easy_font.h
@@ -78,7 +78,8 @@
 //
 // CONTRIBUTORS
 //
-//   github:vassvik  --  bug report
+//   github:vassvik    --  bug report
+//   github:podsvirov  --  fix multiple definition errors
 
 #if 0
 // SAMPLE CODE:
@@ -107,7 +108,7 @@ void print_string(float x, float y, char *text, float r, float g, float b)
 #include <stdlib.h>
 #include <math.h>
 
-struct stb_easy_font_info_struct {
+static struct stb_easy_font_info_struct {
     unsigned char advance;
     unsigned char h_seg;
     unsigned char v_seg;
@@ -138,7 +139,7 @@ struct stb_easy_font_info_struct {
     {  3,203,252 },  {  5,203,253 },  { 22,210,253 },  {  0,214,253 },
 };
 
-unsigned char stb_easy_font_hseg[214] = {
+static unsigned char stb_easy_font_hseg[214] = {
    97,37,69,84,28,51,2,18,10,49,98,41,65,25,81,105,33,9,97,1,97,37,37,36,
     81,10,98,107,3,100,3,99,58,51,4,99,58,8,73,81,10,50,98,8,73,81,4,10,50,
     98,8,25,33,65,81,10,50,17,65,97,25,33,25,49,9,65,20,68,1,65,25,49,41,
@@ -150,7 +151,7 @@ unsigned char stb_easy_font_hseg[214] = {
     84,73,57,41,49,25,33,65,81,9,97,1,97,25,33,65,81,57,33,25,41,25,
 };
 
-unsigned char stb_easy_font_vseg[253] = {
+static unsigned char stb_easy_font_vseg[253] = {
    4,2,8,10,15,8,15,33,8,15,8,73,82,73,57,41,82,10,82,18,66,10,21,29,1,65,
     27,8,27,9,65,8,10,50,97,74,66,42,10,21,57,41,29,25,14,81,73,57,26,8,8,
     26,66,3,8,8,15,19,21,90,58,26,18,66,18,105,89,28,74,17,8,73,57,26,21,
@@ -188,7 +189,7 @@ static int stb_easy_font_draw_segs(float x, float y, unsigned char *segs, int nu
     return offset;
 }
 
-float stb_easy_font_spacing_val = 0;
+static float stb_easy_font_spacing_val = 0;
 static void stb_easy_font_spacing(float spacing)
 {
    stb_easy_font_spacing_val = spacing;


### PR DESCRIPTION
There changes fix posible multiple definition errors when
include stb_easy_font.h header to more then one source file.

Closes #777
