### PR TITLE
Prefer gpos over kern table. By default some newer font tools export …

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -2540,8 +2540,7 @@ STBTT_DEF int  stbtt_GetGlyphKernAdvance(const stbtt_fontinfo *info, int g1, int
 
    if (info->gpos)
       xAdvance += stbtt__GetGlyphGPOSInfoAdvance(info, g1, g2);
-
-   if (info->kern)
+   else if (info->kern)
       xAdvance += stbtt__GetGlyphKernInfoAdvance(info, g1, g2);
 
    return xAdvance;


### PR DESCRIPTION
…both tables(for backwards compatiblity) and it seems we should be using only gpos if both are available.(Or otherwise we get kern values * 2)
