### PR TITLE
typo in credit comment

### DIFF
--- a/stb_ds.h
+++ b/stb_ds.h
@@ -325,7 +325,7 @@ CREDITS
 
   Bugfixes:
     Andy Durdin
-    Shane Liesgang
+    Shane Liesegang
     Vinh Truong
 */
 


### PR DESCRIPTION
This is the opposite of urgent or even that important, but just for the sake of my vanity, my name was misspelled here. 