### PR TITLE
stb_image.h: fix warning about unused function 'stbi__err'

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -106,6 +106,7 @@ RECENT REVISION HISTORY:
     Julian Raschke          Gregory Mullen     Baldur Karlsson    github:poppolopoppo
     Christian Floisand      Kevin Schmidt      JR Smith           github:darealshinji
     Blazej Dariusz Roszkowski                                     github:Michaelangel007
+    Matvey Cherevko
 */
 
 #ifndef STBI_INCLUDE_STB_IMAGE_H
@@ -881,11 +882,13 @@ STBIDEF const char *stbi_failure_reason(void)
    return stbi__g_failure_reason;
 }
 
+#ifndef STBI_NO_FAILURE_STRINGS
 static int stbi__err(const char *str)
 {
    stbi__g_failure_reason = str;
    return 0;
 }
+#endif
 
 static void *stbi__malloc(size_t size)
 {


### PR DESCRIPTION
Fixes issue #746.