### PR TITLE
Suppress a warning about always true comparison

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -105,7 +105,7 @@ RECENT REVISION HISTORY:
     Oriol Ferrer Mesia      Josh Tobin         Matthew Gregan     github:phprus
     Julian Raschke          Gregory Mullen     Baldur Karlsson    github:poppolopoppo
     Christian Floisand      Kevin Schmidt      JR Smith           github:darealshinji
-    Blazej Dariusz Roszkowski                                     github:Michaelangel007
+    Blazej Dariusz Roszkowski Nicolas Sauzede                     github:Michaelangel007
 */
 
 #ifndef STBI_INCLUDE_STB_IMAGE_H
@@ -5111,7 +5111,7 @@ static int stbi__shiftsigned(unsigned int v, int shift, int bits)
       v <<= -shift;
    else
       v >>= shift;
-   STBI_ASSERT(v >= 0 && v < 256);
+   STBI_ASSERT(/*v >= 0 && */v < 256); // v is unsigned int, so '>= 0' is always true
    v >>= (8-bits);
    STBI_ASSERT(bits >= 0 && bits <= 8);
    return (int) ((unsigned) v * mul_table[bits]) >> shift_table[bits];


### PR DESCRIPTION
With nothings/stb 052dce1, in stb_image.h, I get this warning :
```
../stb/stb_image.h: In function ‘int stbi__shiftsigned(unsigned int, int, int)’:
../stb/stb_image.h:5114:18: error: comparison of unsigned expression >= 0 is always true [-Werror=type-limits]
 5114 |    STBI_ASSERT(v >= 0 && v < 256); // v is unsigned int, so '>= 0' is always true
      |                ~~^~~~
../stb/stb_image.h:5114:4: note: in expansion of macro ‘STBI_ASSERT’
 5114 |    STBI_ASSERT(v >= 0 && v < 256); // v is unsigned int, so '>= 0' is always true
      |    ^~~~~~~~~~~
```
Using this compiler :
```
$ g++ --version
g++ (Clear Linux OS for Intel Architecture) 9.2.1 20191001 gcc-9-branch@276412
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

This trivial, one liner, PR fixes just that (but leaves the commented test, to not lose the original intent)