### PR TITLE
Fix bare backslash n as being a valid whitespace character.

### DIFF
--- a/stb_include.h
+++ b/stb_include.h
@@ -95,7 +95,7 @@ static void stb_include_free_includes(include_info *array, int len)
 
 static int stb_include_isspace(int ch)
 {
-   return (ch == ' ' || ch == '\t' || ch == '\r' || ch == 'n');
+   return (ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n');
 }
 
 // find location of all #include and #inject


### PR DESCRIPTION
The current implementation has trouble with the `#inject` feature on *nix systems.  Didn't add name to authors list because it was only one line.