### PR TITLE
stb_vorbis seek (and invalid file) fixes

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -3507,7 +3507,7 @@ static int vorbis_pump_first_frame(stb_vorbis *f)
 }
 
 #ifndef STB_VORBIS_NO_PUSHDATA_API
-static int is_whole_packet_present(stb_vorbis *f, int end_page)
+static int is_whole_packet_present(stb_vorbis *f)
 {
    // make sure that we have the packet available before continuing...
    // this requires a full ogg parse, but we know we can fetch from f->stream
@@ -3527,8 +3527,6 @@ static int is_whole_packet_present(stb_vorbis *f, int end_page)
             break;
       }
       // either this continues, or it ends it...
-      if (end_page)
-         if (s < f->segment_count-1)             return error(f, VORBIS_invalid_stream);
       if (s == f->segment_count)
          s = -1; // set 'crosses page' flag
       if (p > f->stream_end)                     return error(f, VORBIS_need_more_data);
@@ -3561,8 +3559,6 @@ static int is_whole_packet_present(stb_vorbis *f, int end_page)
          if (q[s] < 255)
             break;
       }
-      if (end_page)
-         if (s < n-1)                            return error(f, VORBIS_invalid_stream);
       if (s == n)
          s = -1; // set 'crosses page' flag
       if (p > f->stream_end)                     return error(f, VORBIS_need_more_data);
@@ -3648,7 +3644,7 @@ static int start_decoder(vorb *f)
 
    #ifndef STB_VORBIS_NO_PUSHDATA_API
    if (IS_PUSH_MODE(f)) {
-      if (!is_whole_packet_present(f, TRUE)) {
+      if (!is_whole_packet_present(f)) {
          // convert error in ogg header to write type
          if (f->error == VORBIS_invalid_stream)
             f->error = VORBIS_invalid_setup;
@@ -4402,7 +4398,7 @@ int stb_vorbis_decode_frame_pushdata(
    f->error      = VORBIS__no_error;
 
    // check that we have the entire packet in memory
-   if (!is_whole_packet_present(f, FALSE)) {
+   if (!is_whole_packet_present(f)) {
       *samples = 0;
       return 0;
    }

--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -4707,14 +4707,16 @@ static int seek_to_sample_coarse(stb_vorbis *f, uint32 sample_number)
       }
 
       // if we've just found the last page again then we're in a tricky file,
-      // and we're close enough.
-      if (mid.page_start == right.page_start)
-         break;
-
-      if (sample_number < mid.last_decoded_sample)
-         right = mid;
-      else
-         left = mid;
+      // and we're close enough (if it wasn't an interpolation probe).
+      if (mid.page_start == right.page_start) {
+         if (probe >= 2)
+            break;
+      } else {
+         if (last_sample_limit < mid.last_decoded_sample)
+            right = mid;
+         else
+            left = mid;
+      }
 
       ++probe;
    }

--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -4664,8 +4664,11 @@ static int seek_to_sample_coarse(stb_vorbis *f, uint32 sample_number)
 
    // starting from the start is handled differently
    if (last_sample_limit <= left.last_decoded_sample) {
-      if (stb_vorbis_seek_start(f))
+      if (stb_vorbis_seek_start(f)) {
+         if (f->current_loc > sample_number)
+            return error(f, VORBIS_seek_failed);
          return 1;
+      }
       return 0;
    }
 
@@ -4841,8 +4844,8 @@ int stb_vorbis_seek_frame(stb_vorbis *f, unsigned int sample_number)
          flush_packet(f);
       }
    }
-   // the next frame will start with the sample
-   assert(f->current_loc == sample_number);
+   // the next frame should start with the sample
+   if (f->current_loc != sample_number) return error(f, VORBIS_seek_failed);
    return 1;
 }
 

--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -4721,7 +4721,7 @@ static int seek_to_sample_coarse(stb_vorbis *f, uint32 sample_number)
       // if we've just found the last page again then we're in a tricky file,
       // and we're close enough (if it wasn't an interpolation probe).
       if (mid.page_start == right.page_start) {
-         if (probe >= 2)
+         if (probe >= 2 || delta <= 65536)
             break;
       } else {
          if (last_sample_limit < mid.last_decoded_sample)


### PR DESCRIPTION
This is a collection of fixes - let me know if you'd like this broken up into separate PRs.

The most important fix is a bad check in `seek_to_sample_coarse` that causes errors when seeking near the end of some pages in many valid files (explained a bit more at https://github.com/nothings/stb/issues/580#issuecomment-536899401 )

The next two fixes are for files with audio data in the header pages. As described in #274 these files violate the spec, but it seems like enough people have had this problem (issues #259,  #580, #597 and #682) to fix it. The fix is different for pushdata, where we can just remove some validation, and pulldata, which already mostly worked, but broke `stb_vorbis_seek_start`.

I also fixed a theoretical bug in my seek code, where seeking near the end of a crazy file might end up doing a linear scan through the entire file. It's extremely unlikely such files exist, but I'd rather be safe.

Finally, I tested all these changes pretty thoroughly, downloading hundreds of Ogg Vorbis files from different sources using a modified version of [gamozolabs/flounder](https://github.com/gamozolabs/flounder). I found a handful of files on the internet had invalid ogg timing data which didn't match the vorbis data, and this failed assertions in the seek code, so I changed these asserts to soft errors.