### PR TITLE
fix: stb_sprintf - gcc defines __powerpc64__

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -18,6 +18,7 @@
 //    Leonard Ritter
 //    Stefano Zanotti
 //    Adam Allison
+//    Markus Kolb
 //
 // LICENSE:
 //

--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -200,7 +200,7 @@ STBSP__PUBLICDEF void STB_SPRINTF_DECORATE(set_separators)(char comma, char peri
 #define stbsp__uint16 unsigned short
 
 #ifndef stbsp__uintptr
-#if defined(__ppc64__) || defined(__aarch64__) || defined(_M_X64) || defined(__x86_64__) || defined(__x86_64)
+#if defined(__ppc64__) || defined(__powerpc64__) || defined(__aarch64__) || defined(_M_X64) || defined(__x86_64__) || defined(__x86_64)
 #define stbsp__uintptr stbsp__uint64
 #else
 #define stbsp__uintptr stbsp__uint32


### PR DESCRIPTION
fixes #806