### PR TITLE
Quell -Wcast-align warnings from Clang

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -774,7 +774,7 @@ STBIWDEF int stbi_write_hdr(char const *filename, int x, int y, int comp, const 
 
 #ifndef STBIW_ZLIB_COMPRESS
 // stretchy buffer; stbiw__sbpush() == vector<>::push_back() -- stbiw__sbcount() == vector<>::size()
-#define stbiw__sbraw(a) ((int *) (a) - 2)
+#define stbiw__sbraw(a) ((int *) (void *) (a) - 2)
 #define stbiw__sbm(a)   stbiw__sbraw(a)[0]
 #define stbiw__sbn(a)   stbiw__sbraw(a)[1]
 

--- a/stretchy_buffer.h
+++ b/stretchy_buffer.h
@@ -188,7 +188,7 @@
 #define stb_sb_add(a,n)        (stb__sbmaybegrow(a,n), stb__sbn(a)+=(n), &(a)[stb__sbn(a)-(n)])
 #define stb_sb_last(a)         ((a)[stb__sbn(a)-1])
 
-#define stb__sbraw(a) ((int *) (a) - 2)
+#define stb__sbraw(a) ((int *) (void *) (a) - 2)
 #define stb__sbm(a)   stb__sbraw(a)[0]
 #define stb__sbn(a)   stb__sbraw(a)[1]
 


### PR DESCRIPTION
The `stbi__sbraw()` macro in stb_image_write.h causes Clang to spew about 24 warnings complaining that "cast from '`unsigned char *`' to '`int *`' increases required alignment from 1 to 4" when compiled with the `-Wcast-align` option.

In practice, this is spurious so long as `STBIW_MALLOC()` and` STBIW_REALLOC()` follow the usual alignment semantics for `malloc()` and `realloc()` in that they align sufficiently for any built-in type.

To quell the warning, we can cast through a `void` pointer as an intermediary.