### PR TITLE
stb_image: fix CRC reading at the end of IEND chunk in png file

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -91,7 +91,7 @@ RECENT REVISION HISTORY:
     Carmelo J Fdez-Aguera
 
  Bug & warning fixes
-    Marc LeBlanc            David Woo          Guillaume George   Martins Mozeiko
+    Marc LeBlanc            David Woo          Guillaume George   Martins Mozeiko        Alexander Veselov
     Christpher Lloyd        Jerry Jansson      Joseph Thomson     Phil Jordan
     Dave Moore              Roy Eltham         Hayaki Saito       Nathan Reed
     Won Chun                Luke Graham        Johan Duparc       Nick Verigakis
@@ -4942,6 +4942,8 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
                ++s->img_n;
             }
             STBI_FREE(z->expanded); z->expanded = NULL;
+            // end of PNG chunk, read and skip CRC
+            stbi__get32be(s);
             return 1;
          }
 


### PR DESCRIPTION
### The problem
stb consistently under reads last 4 bytes of *png file. 

### Why this happends
in function `stbi__parse_png_file` we have a code:
```c++
static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
{
...
   for (;;) {
      stbi__pngchunk c = stbi__get_chunk_header(s);
      switch(c.type) {
        ...
        case STBI__PNG_TYPE('I','E','N','D'): {
            ...
            return 1; // <--- CRC-read, will be skipped because of this 'return'
        }
      }
      ...
      stbi__get32be(s); // for normal chunk stb reading CRC here
   }
}
```

### Why this is a problem
In my video-game I have a screen-shoot inside save-file binary:
```
[ header ][ png-priview ][ data ]
```
And to make it work I need a byte-exact png-reader/writer.
