### PR TITLE
Updates to snprintf to handle char32/char16

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -455,7 +455,6 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcbAny)(STBSP_SPRINTFCBANY *cal
                bf_w[1] = f[1];
                bf_w[2] = f[2];
                bf_w[3] = f[3];
-               bf = &bf_w[3];
             }
             stbsp__add4units(bf);
             f += 4;
@@ -1237,16 +1236,14 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcbAny)(STBSP_SPRINTFCBANY *cal
                      stbsp__push_char(bf, ' ');
                      --i;
                   }
-                  while (i >= 4) {
-                     if (size_per_char == 1)
-                        *(stbsp__uint32 *)bf = 0x20202020;
-                     else {
-                        ((stbsp__uint32 *)bf)[0] = 0x00200020;
-                        ((stbsp__uint32 *)bf)[1] = 0x00200020;
+                  if (size_per_char == 1) {
+                     char * bf_c = (char*)bf;
+                     while (i >= 4) {
+                        *(stbsp__uint32 *)bf_c = 0x20202020;
+                        i -= 4;
+                        bf_c++;
                      }
-
-                     stbsp__add4units(bf);
-                     i -= 4;
+                     bf = bf_c;
                   }
                   while (i) {
                      stbsp__push_char(bf, ' ');
@@ -1275,23 +1272,22 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcbAny)(STBSP_SPRINTFCBANY *cal
                stbsp__cb_buf_clamp(i, pr);
                pr -= i;
                if ((fl & STBSP__TRIPLET_COMMA) == 0) {
-                  while (i) {
-                     if ((((stbsp__uintptr)bf) & 3) == 0)
-                        break;
-                     
-                     stbsp__push_char(bf, '0');
-                     --i;
-                  }
-                  while (i >= 4) {
-                     if (size_per_char == 1)
-                        *(stbsp__uint32 *)bf = 0x30303030;
-                     else {
-                        ((stbsp__uint32 *)bf)[0] = 0x00300030;
-                        ((stbsp__uint32 *)bf)[1] = 0x00300030;
+                  if (size_per_char == 1) {
+                     char * bf_c = (char*)bf;
+                     while (i) {
+                        if ((((stbsp__uintptr)bf_c) & 3) == 0)
+                           break;
+                        
+                        bf_c[0] = '0';
+                        ++bf_c;
+                        --i;
                      }
-
-                     stbsp__add4units(bf);
-                     i -= 4;
+                     while (i >= 4) {
+                        *(stbsp__uint32 *)bf_c = 0x30303030;
+                        i -= 4;
+                        bf_c += 4;
+                     }
+                     bf = bf_c;
                   }
                }
                while (i) {
@@ -1358,22 +1354,20 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcbAny)(STBSP_SPRINTFCBANY *cal
             stbsp__int32 i;
             stbsp__cb_buf_clamp(i, tz);
             tz -= i;
-            while (i) {
-               if ((((stbsp__uintptr)bf) & 3) == 0)
-                  break;
-               stbsp__push_char(bf, '0');
-               --i;
-            }
-            while (i >= 4) {
-               if (size_per_char == 1)
-                  *(stbsp__uint32 *)bf = 0x30303030;
-               else {
-                  ((stbsp__uint32 *)bf)[0] = 0x00300030;
-                  ((stbsp__uint32 *)bf)[1] = 0x00300030;
+            if (size_per_char == 1) {
+               char * bf_c = (char*)bf;
+               while (i) {
+                  if ((((stbsp__uintptr)bf_c) & 3) == 0)
+                     break;
+                  bf_c[0] = '0';
+                  ++bf_c;
+                  --i;
                }
-
-               stbsp__add4units(bf);
-               i -= 4;
+               while (i >= 4) {
+                  *(stbsp__uint32 *)bf_c = 0x30303030;
+                  bf_c += 4;
+                  i -= 4;
+               }
             }
             while (i) {
                stbsp__push_char(bf, '0');
@@ -1402,22 +1396,23 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcbAny)(STBSP_SPRINTFCBANY *cal
                   stbsp__int32 i;
                   stbsp__cb_buf_clamp(i, fw);
                   fw -= i;
-                  while (i) {
-                     if ((((stbsp__uintptr)bf) & 3) == 0)
-                        break;
-                     stbsp__push_char(bf, ' ');
-                     --i;
-                  }
-                  while (i >= 4) {
-                     if (size_per_char == 1)
-                        *(stbsp__uint32 *)bf = 0x20202020;
-                     else {
-                        ((stbsp__uint32 *)bf)[0] = 0x00200020;
-                        ((stbsp__uint32 *)bf)[1] = 0x00200020;
+                  if (size_per_char == 1)
+                  {
+                     char * bf_c = (char*)bf;
+                     while (i) {
+                        if ((((stbsp__uintptr)bf_c) & 3) == 0)
+                           break;
+                        bf_c[0] = ' ';
+                        ++bf_c;
+                        --i;
                      }
+                     while (i >= 4) {
+                        *(stbsp__uint32 *)bf_c = 0x20202020;
 
-                     stbsp__add4units(bf);
-                     i -= 4;
+                        bf_c += 4;
+                        i -= 4;
+                     }
+					 bf = bf_c;
                   }
                   while (i--) {
                      stbsp__push_char(bf, ' ');

--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -390,7 +390,7 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcbAny)(STBSP_SPRINTFCBANY *cal
             bf = bf_w;                                    \
          } } while(0)
 
-      #define stbsp__add4units(bf) do {                   \
+      #define stbsp__advance4(bf) do {                    \
          if (size_per_char == 1) {                        \
             char * bf_c = (char*)bf;                      \
             bf_c += 4;                                    \
@@ -456,7 +456,7 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcbAny)(STBSP_SPRINTFCBANY *cal
                bf_w[2] = f[2];
                bf_w[3] = f[3];
             }
-            stbsp__add4units(bf);
+            stbsp__advance4(bf);
             f += 4;
          }
       }
@@ -1230,18 +1230,18 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcbAny)(STBSP_SPRINTFCBANY *cal
                while (fw > 0) {
                   stbsp__cb_buf_clamp(i, fw);
                   fw -= i;
-                  while (i) {
-                     if ((((stbsp__uintptr)bf) & 3) == 0)
-                        break;
-                     stbsp__push_char(bf, ' ');
-                     --i;
-                  }
                   if (size_per_char == 1) {
                      char * bf_c = (char*)bf;
+                     while (i) {
+                        if ((((stbsp__uintptr)bf_c) & 3) == 0)
+                           break;
+                        *bf_c++ = ' ';
+                        --i;
+                     }
                      while (i >= 4) {
                         *(stbsp__uint32 *)bf_c = 0x20202020;
+                        bf_c += 4;
                         i -= 4;
-                        bf_c++;
                      }
                      bf = bf_c;
                   }
@@ -1277,9 +1277,7 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcbAny)(STBSP_SPRINTFCBANY *cal
                      while (i) {
                         if ((((stbsp__uintptr)bf_c) & 3) == 0)
                            break;
-                        
-                        bf_c[0] = '0';
-                        ++bf_c;
+                        *bf_c++ = '0';
                         --i;
                      }
                      while (i >= 4) {
@@ -1359,8 +1357,7 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcbAny)(STBSP_SPRINTFCBANY *cal
                while (i) {
                   if ((((stbsp__uintptr)bf_c) & 3) == 0)
                      break;
-                  bf_c[0] = '0';
-                  ++bf_c;
+                  *bf_c++ = '0';
                   --i;
                }
                while (i >= 4) {
@@ -1402,17 +1399,15 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcbAny)(STBSP_SPRINTFCBANY *cal
                      while (i) {
                         if ((((stbsp__uintptr)bf_c) & 3) == 0)
                            break;
-                        bf_c[0] = ' ';
-                        ++bf_c;
+                        *bf_c++ = ' ';
                         --i;
                      }
                      while (i >= 4) {
                         *(stbsp__uint32 *)bf_c = 0x20202020;
-
                         bf_c += 4;
                         i -= 4;
                      }
-					 bf = bf_c;
+                     bf = bf_c;
                   }
                   while (i--) {
                      stbsp__push_char(bf, ' ');
@@ -1432,16 +1427,14 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcbAny)(STBSP_SPRINTFCBANY *cal
             if (us == 0)
                us = us_null;
             
-            do
+            while (us[0])
             {
                stbsp__chk_cb_buf(1);
                /* note, bf can change in chk_cb_buf */
                wchar_t * bf_w = (wchar_t *)bf; 
-               bf_w[0] = us[0];
-               bf_w++;
+               *bf_w++ = *us++;
                bf = bf_w;
-               us++;
-            } while (us[0]);
+            }
             break;
          }
       } // Fall-through
@@ -1488,7 +1481,7 @@ done:
 #undef stbsp__flush_cb
 #undef stbsp__cb_buf_clamp
 #undef stbsp__push_char
-#undef stbsp__add4units
+#undef stbsp__advance4
 
 // ============================================================================
 //   wrapper functions

--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -215,12 +215,14 @@ typedef char *STBSP_SPRINTFCB(char *buf, void *user, int len);
 typedef void *STBSP_SPRINTFCBANY(void *buf, void *user, int len);
 
 #ifdef STB_SPRINTF_MULTICHAR
-#if defined(__cplusplus) && (__cplusplus > 201103L) && !defined(stbsp__char16)
+#if !defined(stbsp__char16)
+#if defined(__cplusplus) && (__cplusplus > 201103L)
 #define stbsp__char16 char16_t
 #define stbsp__char32 char32_t
 #else
 #define stbsp__char16 unsigned short
 #define stbsp__char32 unsigned long
+#endif
 #endif
 
 typedef stbsp__char16 *STBSP_SPRINTFCBC16(stbsp__char16 *buf, void *user, int len);


### PR DESCRIPTION
Added support for char32, char16 as the destination buffer,
   Added '%S' support (char16 string)
   Added '%lS' support (char32 string)

created vsprintfcbAny
change vsprintfcb to use vsprintfcbAny
duplicated snprintf functions with 'c16/c32'

created 'stbsp__push_char' macro to handle the old *bf++ = c

All original signatures are the same,
I only erase the types at the lowest level. 
    ie *char**-> *void** , or 
   *stbsp__char32** -> *void**
   *stbsp__char16** -> *void**

I don't know if the older stats are impacted. any compiler should see
that size_per_char is either 1, or sizeof(char16/char32) and doesn't change during the function

I haven't had any problems on testing on my end.
The whole thing has to be enabled with STB_SPRINTF_MULTICHAR 1

Thanks,
Adam