### PR TITLE
Fix VS2019 warning

### DIFF
--- a/stb_image_resize.h
+++ b/stb_image_resize.h
@@ -1238,7 +1238,7 @@ static float* stbir__get_decode_buffer(stbir__info* stbir_info)
     return &stbir_info->decode_buffer[stbir_info->horizontal_filter_pixel_margin * stbir_info->channels];
 }
 
-#define STBIR__DECODE(type, colorspace) ((type) * (STBIR_MAX_COLORSPACES) + (colorspace))
+#define STBIR__DECODE(type, colorspace) ((int)(type) * (STBIR_MAX_COLORSPACES) + (int)(colorspace))
 
 static void stbir__decode_scanline(stbir__info* stbir_info, int n)
 {


### PR DESCRIPTION
VS2019 on /W4 warns about applying '*' to enums. Fixed by casting to int.