### PR TITLE
fix possible bug in uniform sample code

### DIFF
--- a/stb_voxel_render.h
+++ b/stb_voxel_render.h
@@ -614,7 +614,7 @@ void setup_uniforms(GLuint shader, float camera_pos[4], GLuint tex1, GLuint tex2
       stbvox_uniform_info sui;
       if (stbvox_get_uniform_info(&sui, i)) {
          GLint loc = glGetUniformLocation(shader, sui.name);
-         if (loc != 0) {
+         if (loc != -1) {
             switch (i) {
                case STBVOX_UNIFORM_camera_pos: // only needed for fog
                   glUniform4fv(loc, sui.array_length, camera_pos);


### PR DESCRIPTION
I copied and pasted the uniform sample code for stb_voxel_render.h, but it was skipping the ambient value because that was mapped to location 0.  I suspect that this was supposed to check if the value was -1, indicating that there was no variable with that name (at least in the version of opengl I am using).