### PR TITLE
Pad allocations in setup_{,temp_}malloc for 8-byte alignment

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -30,7 +30,7 @@
 //    Tom Beaumont       Ingo Leitgeb        Nicolas Guillemot
 //    Phillip Bennefall  Rohit               Thiago Goulart
 //    manxorist@github   saga musix          github:infatum
-//    Timur Gagiev       Maxwell Koo
+//    Timur Gagiev       Maxwell Koo         Peter Waller
 //
 // Partial history:
 //    1.17    - 2019-07-08 - fix CVE-2019-13217..CVE-2019-13223 (by ForAllSecure)
@@ -909,7 +909,7 @@ static void *make_block_array(void *mem, int count, int size)
 
 static void *setup_malloc(vorb *f, int sz)
 {
-   sz = (sz+3) & ~3;
+   sz = (sz+7) & ~7; // round up to nearest 8 for alignment of future allocs.
    f->setup_memory_required += sz;
    if (f->alloc.alloc_buffer) {
       void *p = (char *) f->alloc.alloc_buffer + f->setup_offset;
@@ -928,7 +928,7 @@ static void setup_free(vorb *f, void *p)
 
 static void *setup_temp_malloc(vorb *f, int sz)
 {
-   sz = (sz+3) & ~3;
+   sz = (sz+7) & ~7; // round up to nearest 8 for alignment of future allocs.
    if (f->alloc.alloc_buffer) {
       if (f->temp_offset - sz < f->setup_offset) return NULL;
       f->temp_offset -= sz;


### PR DESCRIPTION
4-byte alignment triggered warnings with clang and -fsanitize=undefined.

Fix #799.

As requested, I looked for a list of contributors to add myself to, but didn't immediately see one. Might be useful to update your pull request template to be explicit where to look.