### PR TITLE
Fix for buffer bugs in stb__splitpath_raw and stb_strncpy

### DIFF
--- a/stb.h
+++ b/stb.h
@@ -2009,7 +2009,7 @@ char *stb_trimwhite(char *s)
 char *stb_strncpy(char *s, char *t, int n)
 {
    stb_p_strncpy_s(s,n+1,t,n);
-   s[n-1] = 0;
+   s[n] = 0;
    return s;
 }
 
@@ -2457,8 +2457,7 @@ static char *stb__splitpath_raw(char *buffer, char *path, int flag)
    }
 
    if (len) { stb_p_strcpy_s(buffer, sizeof(buffer), "./"); return buffer; }
-   stb_p_strncpy_s(buffer, y-x+1, path+x, y-x);
-   buffer[y-x] = 0;
+   stb_strncpy(buffer, path+x, y-x);
    return buffer;
 }
 

--- a/stb.h
+++ b/stb.h
@@ -200,6 +200,7 @@ CREDITS
   github:infatum
   Dave Butler (Croepha)
   Ethan Lee (flibitijibibo)
+  Brian Collins
 */
 
 #include <stdarg.h>

--- a/stb.h
+++ b/stb.h
@@ -2457,7 +2457,7 @@ static char *stb__splitpath_raw(char *buffer, char *path, int flag)
    }
 
    if (len) { stb_p_strcpy_s(buffer, sizeof(buffer), "./"); return buffer; }
-   stb_strncpy(buffer, path+x, y-x);
+   stb_strncpy(buffer, path+int(x), int(y-x));
    return buffer;
 }
 

--- a/stb.h
+++ b/stb.h
@@ -2439,7 +2439,7 @@ static char *stb__splitpath_raw(char *buffer, char *path, int flag)
    } else {
       x = f2;
       if (flag & STB_EXT_NO_PERIOD)
-         if (buffer[x] == '.')
+         if (path[x] == '.')
             ++x;
    }
 
@@ -2456,7 +2456,7 @@ static char *stb__splitpath_raw(char *buffer, char *path, int flag)
    }
 
    if (len) { stb_p_strcpy_s(buffer, sizeof(buffer), "./"); return buffer; }
-   stb_p_strncpy_s(buffer, sizeof(buffer),path+x, y-x);
+   stb_p_strncpy_s(buffer, y-x+1, path+x, y-x);
    buffer[y-x] = 0;
    return buffer;
 }


### PR DESCRIPTION
The stb__splitpath_raw function was incorrectly referring to buffer instead of path while parsing, and was passing the size of the buffer pointer (4 or 8 bytes) rather than the size of the buffer itself, which was causing a crash. Ideally the public interface would take the size of the destination buffer as a parameter also, but in lieu of that, changed to use stb_strncpy because it appeared to already be dealing with this by just assuming target buffer size is n+1.

Also, stb_strncpy had an off-by-1 bug that was truncating the last valid character of the string.