### PR TITLE
fix test_sprintf.c

### DIFF
--- a/tests/test_sprintf.c
+++ b/tests/test_sprintf.c
@@ -3,8 +3,6 @@
 
 #if USE_STB
 # include "stb_sprintf.h"
-//# define STB_SPRINTF_IMPLEMENTATION
-# include "stb_sprintf.h"
 # define SPRINTF stbsp_sprintf
 # define SNPRINTF stbsp_snprintf
 #else
@@ -44,6 +42,12 @@ typedef ptrdiff_t ssize_t;
 #define CHECK1(str, v1                                ) { int ret = SPRINTF(buf, v1                                ); CHECK_END(str); }
 
 #ifdef TEST_SPRINTF
+
+#if USE_STB
+# define STB_SPRINTF_IMPLEMENTATION
+# include "stb_sprintf.h"
+#endif
+
 int main()
 {
    char buf[1024];

--- a/tests/test_sprintf.c
+++ b/tests/test_sprintf.c
@@ -111,10 +111,10 @@ int main()
 #if __STDC_VERSION__ >= 199901L
 #if USE_STB
    CHECK4("Inf Inf NaN", "%g %G %f", INFINITY, INFINITY, NAN);
-   CHECK1("N", "%.1g", NAN);
+   CHECK2("N", "%.1g", NAN);
 #else
    CHECK4("inf INF nan", "%g %G %f", INFINITY, INFINITY, NAN);
-   CHECK1("nan", "%.1g", NAN);
+   CHECK2("nan", "%.1g", NAN);
 #endif
 #endif
 

--- a/tests/test_sprintf.c
+++ b/tests/test_sprintf.c
@@ -150,9 +150,9 @@ int main()
    assert(strncmp(buf, "37778931862957161709568.000000", 17) == 0);
    n = SNPRINTF(buf, 10, "number %f", 123.456789);
    assert(strcmp(buf, "number 12") == 0);
-   assert(n == (USE_STB ? 9 : 17));  // written vs would-be written bytes
+   assert(n == 17);  // would-be written bytes
    n = SNPRINTF(buf, 0, "7 chars");
-   assert(n == (USE_STB ? 0 : 7));
+   assert(n == 7);
    // stb_sprintf uses internal buffer of 512 chars - test longer string
    assert(SPRINTF(buf, "%d  %600s", 3, "abc") == 603);
    assert(strlen(buf) == 603);


### PR DESCRIPTION
Thanks for merging the test_sprintf PR yesterday. I'd like to add three commits:

* fix compilation (CHECK1 -> CHECK2)
* update expected return values from stbsp_snprintf - it now returns the same value as snprintf, i.e. the number of characters that would be printed if the buffer was big enough
* if `TEST_SPRINTF` is defined include the implementation (I hope it doesn't affect other possible uses of test_sprintf.c), so that this test only can be run with:

      cc -I. -DTEST_SPRINTF tests/test_sprintf.c && ./a.out