### PR TITLE
stb_sprintf.h: fix unused-parameter warning

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -1392,6 +1392,7 @@ static char *stbsp__clamp_callback(char *buf, void *user, int len)
 
 static char * stbsp__count_clamp_callback( char * buf, void * user, int len )
 {
+   (void) buf;
    stbsp__context * c = (stbsp__context*)user;
 
    c->length += len;


### PR DESCRIPTION
avoid this warning:
```
./stb_sprintf.h:1393:51: warning: unused parameter ‘buf’ [-Wunused-parameter]
 1393 | static char * stbsp__count_clamp_callback( char * buf, void * user, int len )
      |                                            ~~~~~~~^~~
```
