### PR TITLE
Refactored stbi__load_gif_main to use STBI_REALLOC_SIZED instead of STBI_REALLOC

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -109,6 +109,7 @@ RECENT REVISION HISTORY:
     Christian Floisand      Kevin Schmidt      JR Smith           github:darealshinji
     Brad Weinberger         Matvey Cherevko                       github:Michaelangel007
     Blazej Dariusz Roszkowski                  Alexander Veselov
+    Luca Sas
 */
 
 #ifndef STBI_INCLUDE_STB_IMAGE_H
@@ -6683,6 +6684,8 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
       stbi_uc *two_back = 0;
       stbi__gif g;
       int stride;
+      int out_size = 0;
+      int delays_size = 0;
       memset(&g, 0, sizeof(g));
       if (delays) {
          *delays = 0;
@@ -6699,22 +6702,28 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
             stride = g.w * g.h * 4;
 
             if (out) {
-               void *tmp = (stbi_uc*) STBI_REALLOC( out, layers * stride );
+               void *tmp = (stbi_uc*) STBI_REALLOC_SIZED( out, out_size, layers * stride );
                if (NULL == tmp) {
                   STBI_FREE(g.out);
                   STBI_FREE(g.history);
                   STBI_FREE(g.background);
                   return stbi__errpuc("outofmem", "Out of memory");
                }
-               else
-                  out = (stbi_uc*) tmp;
+               else {
+                   out = (stbi_uc*) tmp;
+                   out_size = layers * stride;
+               }
+
                if (delays) {
-                  *delays = (int*) STBI_REALLOC( *delays, sizeof(int) * layers );
+                  *delays = (int*) STBI_REALLOC_SIZED( *delays, delays_size, sizeof(int) * layers );
+                  delays_size = layers * sizeof(int);
                }
             } else {
                out = (stbi_uc*)stbi__malloc( layers * stride );
+               out_size = layers * stride;
                if (delays) {
                   *delays = (int*) stbi__malloc( layers * sizeof(int) );
+                  delays_size = layers * sizeof(int);
                }
             }
             memcpy( out + ((layers - 1) * stride), u, stride );


### PR DESCRIPTION
This is a pretty straightforward fix. I introduce 2 new integer variables to keep track of the sizes of 2 buffers and replaced the calls to `STBI_REALLOC` with `STBI_REALLOC_SIZED`.

This also fixes issue #765