### PR TITLE
stb_vorbis: Fix macro redefinition warning on MinGW.

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -599,7 +599,9 @@ enum STBVorbisError
    #undef __forceinline
    #endif
    #define __forceinline
+   #ifndef alloca
    #define alloca __builtin_alloca
+   #endif
 #elif !defined(_MSC_VER)
    #if __GNUC__
       #define __forceinline inline


### PR DESCRIPTION
Some distributions of MinGW define `alloca` themselves which causes warnings about stb_vorbis' `alloca` macro being a redefinition. This change just wraps it in a `#ifndef / #endif` block.