### PR TITLE
Add #undef BUFFER_SIZE to avoid multiple definitions

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -5167,6 +5167,7 @@ static void compute_samples(int mask, short *output, int num_c, float **data, in
          output[o+i] = v;
       }
    }
+   #undef BUFFER_SIZE
 }
 
 static void compute_stereo_samples(short *output, int num_c, float **data, int d_offset, int len)
@@ -5206,6 +5207,7 @@ static void compute_stereo_samples(short *output, int num_c, float **data, int d
          output[o2+i] = v;
       }
    }
+   #undef BUFFER_SIZE
 }
 
 static void convert_samples_short(int buf_c, short **buffer, int b_offset, int data_c, float **data, int d_offset, int samples)


### PR DESCRIPTION
When including stb_vorbis.c in other C file that also defines `BUFFER_SIZE,` you get a warning:

```
warning: "BUFFER_SIZE" redefined
```

It is a quite common name. This is simply fixed by `#undef BUFFER_SIZE`
