### PR TITLE
Added assert(f->valid_bits >= n); on line 1604

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -1601,6 +1601,8 @@ static uint32 get_bits(vorb *f, int n)
       }
    }
 
+   assert(f->valid_bits >= n);
+   
    z = f->acc & ((1 << n)-1);
    f->acc >>= n;
    f->valid_bits -= n;

--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -1600,7 +1600,7 @@ static uint32 get_bits(vorb *f, int n)
          f->valid_bits += 8;
       }
    }
-   if (f->valid_bits < 0) return 0;
+
    z = f->acc & ((1 << n)-1);
    f->acc >>= n;
    f->valid_bits -= n;


### PR DESCRIPTION
I propose to remove this line because  f->valid_bits will never be less than zero since, in the while loop, you're adding 8 to it. Therefore, it will always evaluate to false. This is to help remove redundant code!