### PR TITLE
remove + 1 from stb_strscpy and offset of -1 (n--) in readdir_raw

### DIFF
--- a/stb.h
+++ b/stb.h
@@ -1925,8 +1925,8 @@ size_t stb_strscpy(char *d, const char *s, size_t n)
       if (n) d[0] = 0;
       return 0;
    }
-   stb_p_strcpy_s(d,n+1,s);
-   return len + 1;
+   stb_p_strcpy_s(d,n,s);
+   return len;
 }
 
 const char *stb_plural(int n)
@@ -6150,7 +6150,6 @@ static char **readdir_raw(char *dir, int return_subdirs, char *mask)
    if (!n || n >= sizeof(buffer))
       return NULL;
    stb_fixpath(buffer);
-   n--;
 
    if (n > 0 && (buffer[n-1] != '/')) {
       buffer[n++] = '/';


### PR DESCRIPTION
Fix to buffer issue where stb_strscpy would use + 1 for buffer length when stb_p_strcpy_s is called, causing a stack variable corrupted issue.
Fix to readdir_raw to no longer account for stb_strscpy having + 1 in buffer length.
