### PR TITLE
Fixes writing alpha-channel for BMP

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -467,11 +467,20 @@ static int stbiw__outfile(stbi__write_context *s, int rgb_dir, int vdir, int x, 
 
 static int stbi_write_bmp_core(stbi__write_context *s, int x, int y, int comp, const void *data)
 {
-   int pad = (-x*3) & 3;
-   return stbiw__outfile(s,-1,-1,x,y,comp,1,(void *) data,0,pad,
-           "11 4 22 4" "4 44 22 444444",
-           'B', 'M', 14+40+(x*3+pad)*y, 0,0, 14+40,  // file header
-            40, x,y, 1,24, 0,0,0,0,0,0);             // bitmap header
+   if (comp == 4) {
+      int pad = (-x*4) & 4;
+      return stbiw__outfile(s,-1,-1,x,y,comp,1,(void *) data,1,pad,
+              "11 4 22 4" "4 44 22 444444",
+              'B', 'M', 14+40+(x*4+pad)*y, 0,0, 14+40,  // file header
+               40, x,y, 1,32, 0,0,0,0,0,0);             // bitmap header
+   }
+   else {
+      int pad = (-x*3) & 3;
+      return stbiw__outfile(s,-1,-1,x,y,comp,1,(void *) data,0,pad,
+              "11 4 22 4" "4 44 22 444444",
+              'B', 'M', 14+40+(x*3+pad)*y, 0,0, 14+40,  // file header
+               40, x,y, 1,24, 0,0,0,0,0,0);             // bitmap header
+   }
 }
 
 STBIWDEF int stbi_write_bmp_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const void *data)


### PR DESCRIPTION
See https://github.com/nothings/stb/issues/368

An alternative approach could be to calculate values from the `comp`-variable. Adding a separate path for RGBA seemed like the most pragmatic approach though, as 24bit/32bit are the most common uses for the format.