### PR TITLE
stb_vorbis.c - Use `__NEWLIB__` for detecting alloca.h

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -577,7 +577,7 @@ enum STBVorbisError
    #if defined(_MSC_VER) || defined(__MINGW32__)
       #include <malloc.h>
    #endif
-   #if defined(__linux__) || defined(__linux) || defined(__EMSCRIPTEN__)
+   #if defined(__linux__) || defined(__linux) || defined(__EMSCRIPTEN__) || defined(__NEWLIB__)
       #include <alloca.h>
    #endif
 #else // STB_VORBIS_NO_CRT

--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -31,7 +31,7 @@
 //    Phillip Bennefall  Rohit               Thiago Goulart
 //    github:manxorist   saga musix          github:infatum
 //    Timur Gagiev       Maxwell Koo         Peter Waller
-//    github:audinowho   Dougall Johnson
+//    github:audinowho   Dougall Johnson     github:Clownacy
 //
 // Partial history:
 //    1.19    - 2020-02-05 - warnings


### PR DESCRIPTION
This is needed for `stb_vorbis.c` to compile for the Wii U using devkitPro.

This should theoretically also fix compilation for the Nintendo Switch, 3DS, and Wii (with devkitPro, that is) as they all use Newlib.

Newlib is also used by Cygwin:
https://cygwin.com/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/include/alloca.h;h=5d36318914282280b353aed457e1b1f64947b584;hb=HEAD

And the Google Native Client:
https://chromium.googlesource.com/native_client/nacl-newlib/+/refs/heads/master/newlib/libc/include/alloca.h

As you can see from these links, they both provide `alloca.h` as well, so it appears to be a safe bet that `alloca.h` is available in Newlib.