### PR TITLE
Fix infinite loops when using stdio callbacks

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -789,7 +789,12 @@ static int stbi__stdio_read(void *user, char *data, int size)
 
 static void stbi__stdio_skip(void *user, int n)
 {
+   int ch;
    fseek((FILE*) user, n, SEEK_CUR);
+   ch = fgetc((FILE*) user);  /* have to read a byte to reset feof()'s flag */
+   if (ch != EOF) {
+      ungetc(ch, (FILE *) user);  /* push byte back onto stream if valid. */
+   }
 }
 
 static int stbi__stdio_eof(void *user)

--- a/stb_image.h
+++ b/stb_image.h
@@ -799,7 +799,7 @@ static void stbi__stdio_skip(void *user, int n)
 
 static int stbi__stdio_eof(void *user)
 {
-   return feof((FILE*) user);
+   return feof((FILE*) user) || ferror((FILE *) user);
 }
 
 static stbi_io_callbacks stbi__stdio_callbacks =

--- a/stb_image.h
+++ b/stb_image.h
@@ -108,7 +108,7 @@ RECENT REVISION HISTORY:
     Julian Raschke          Gregory Mullen     Baldur Karlsson    github:poppolopoppo
     Christian Floisand      Kevin Schmidt      JR Smith           github:darealshinji
     Brad Weinberger         Matvey Cherevko                       github:Michaelangel007
-    Blazej Dariusz Roszkowski                  Alexander Veselov
+    Blazej Dariusz Roszkowski                  Alexander Veselov  Ryan C. Gordon
 */
 
 #ifndef STBI_INCLUDE_STB_IMAGE_H


### PR DESCRIPTION
This pull request fixes some cases where stb_image, with maliciously-crafted input, can get into an infinite loop if using the stdio callbacks, because stdio has some subtle quirks.

The fseek change is the most local fix for the described issue, but it's possible a better fix is not setting read_from_callbacks to zero, but I didn't want to risk unforeseen ramifications by messing with that.

I've been fuzzing stb_image after some discussion on Twitter, so there's probably going to be some other pull requests coming soon. Sorry in advance!  :)