### PR TITLE
stb_vorbis.c: Fix missing update to 64-bit alignment

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -31,7 +31,7 @@
 //    Phillip Bennefall  Rohit               Thiago Goulart
 //    github:manxorist   saga musix          github:infatum
 //    Timur Gagiev       Maxwell Koo         Peter Waller
-//    github:audinowho   Dougall Johnson
+//    github:audinowho   Dougall Johnson     Pedro J. Estébanez
 //
 // Partial history:
 //    1.19    - 2020-02-05 - warnings
@@ -961,7 +961,7 @@ static void *setup_temp_malloc(vorb *f, int sz)
 static void setup_temp_free(vorb *f, void *p, int sz)
 {
    if (f->alloc.alloc_buffer) {
-      f->temp_offset += (sz+3)&~3;
+      f->temp_offset += (sz+7)&~7;
       return;
    }
    free(p);


### PR DESCRIPTION
After updating this file to 1.19 we started having crashes in Godot engine.

It seems there was a change to 64-bit alignment that missed `setup_temp_free()`. This PR fixes the crashes caused by that.

Greetings from Godot!