### PR TITLE
stbi: fix thread local selector

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -574,13 +574,13 @@ STBIDEF int   stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const ch
 #ifndef STBI_NO_THREAD_LOCALS
    #if defined(__cplusplus) &&  __cplusplus >= 201103L
       #define STBI_THREAD_LOCAL       thread_local
-   #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
-      #define STBI_THREAD_LOCAL       _Thread_local
-   #elif defined(__GNUC__)
+   #elif defined(__GNUC__) && __GNUC__ < 5
       #define STBI_THREAD_LOCAL       __thread
    #elif defined(_MSC_VER)
       #define STBI_THREAD_LOCAL       __declspec(thread)
-#endif
+   #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
+      #define STBI_THREAD_LOCAL       _Thread_local
+   #endif
 #endif
 
 #ifdef _MSC_VER

--- a/stb_image.h
+++ b/stb_image.h
@@ -581,6 +581,12 @@ STBIDEF int   stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const ch
    #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
       #define STBI_THREAD_LOCAL       _Thread_local
    #endif
+
+   #ifndef STBI_THREAD_LOCAL
+      #if defined(__GNUC__)
+        #define STBI_THREAD_LOCAL       __thread
+      #endif
+   #endif
 #endif
 
 #ifdef _MSC_VER


### PR DESCRIPTION
* GCC < 5 supports __thread and GCC >= 5 supports C11 with _Thread_local
* Skip _Thread_local for MSVC because it may not be supported

---

See https://github.com/nothings/stb/issues/967

---

Also I have found these:

1. [Bug 203066 _Thread_local detection is broken with GCC < 4.9](https://lists.freebsd.org/pipermail/freebsd-standards/2015-September/003092.html)
2. [ _Thread_local detection is broken with GCC < 4.9](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=203066)

I have updated thread selector like this:

before:

```C
#ifndef STBI_NO_THREAD_LOCALS
   #if defined(__cplusplus) &&  __cplusplus >= 201103L
      #define STBI_THREAD_LOCAL       thread_local
   #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
      #define STBI_THREAD_LOCAL       _Thread_local
   #elif defined(__GNUC__)
      #define STBI_THREAD_LOCAL       __thread
   #elif defined(_MSC_VER)
      #define STBI_THREAD_LOCAL       __declspec(thread)
#endif
#endif
```

after:

```C
#ifndef STBI_NO_THREAD_LOCALS
   #if defined(__cplusplus) &&  __cplusplus >= 201103L
      #define STBI_THREAD_LOCAL       thread_local
   #elif defined(__GNUC__) && __GNUC__ < 5
      #define STBI_THREAD_LOCAL       __thread
   #elif defined(_MSC_VER)
      #define STBI_THREAD_LOCAL       __declspec(thread)
   #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
      #define STBI_THREAD_LOCAL       _Thread_local
   #endif
#endif
```

Now if GCC's version is lower than 5 e.g. 4.8 than __thread will be used. Because AFAIK, C11 is supported since GCC 5.