### PR TITLE
Added missing prototype for stbtt_FindSVGDoc()

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -853,6 +853,7 @@ STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, s
 STBTT_DEF void stbtt_FreeShape(const stbtt_fontinfo *info, stbtt_vertex *vertices);
 // frees the data allocated above
 
+STBTT_DEF stbtt_uint8 *stbtt_FindSVGDoc(const stbtt_fontinfo *info, int gl);
 STBTT_DEF int stbtt_GetCodepointSVG(const stbtt_fontinfo *info, int unicode_codepoint, const char **svg);
 STBTT_DEF int stbtt_GetGlyphSVG(const stbtt_fontinfo *info, int gl, const char **svg);
 // fills svg with the character's SVG data.


### PR DESCRIPTION
Was getting an error:

./stb_truetype.h:2690:24: error: no previous prototype for function 'stbtt_FindSVGDoc' [-Werror,-Wmissing-prototypes]


Or may be it was intended to be static function?