### PR TITLE
stb_ds: fix bug where arraddn would return index instead of pointer

### DIFF
--- a/stb_ds.h
+++ b/stb_ds.h
@@ -370,6 +370,7 @@ CREDITS
     Andy Durdin
     Shane Liesegang
     Vinh Truong
+    Gustav Olsson
 */
 
 #ifdef STBDS_UNIT_TESTS
@@ -521,7 +522,7 @@ extern void * stbds_shmode_func(size_t elemsize, int mode);
 #define stbds_arrput(a,v)     (stbds_arrmaybegrow(a,1), (a)[stbds_header(a)->length++] = (v))
 #define stbds_arrpush         stbds_arrput  // synonym
 #define stbds_arrpop(a)       (stbds_header(a)->length--, (a)[stbds_header(a)->length])
-#define stbds_arraddn(a,n)    (stbds_arrmaybegrow(a,n), stbds_header(a)->length += (n), stbds_header(a)->length-(n))
+#define stbds_arraddn(a,n)    (stbds_arrmaybegrow(a,n), stbds_header(a)->length += (n), &(a)[stbds_header(a)->length-(n)])
 #define stbds_arrlast(a)      ((a)[stbds_header(a)->length-1])
 #define stbds_arrfree(a)      ((void) ((a) ? STBDS_FREE(NULL,stbds_header(a)) : (void)0), (a)=NULL)
 #define stbds_arrdel(a,i)     stbds_arrdeln(a,i,1)


### PR DESCRIPTION
I ported some code over from `stretchy_buffer` to `stb_ds` and found that `arraddn` returns _the index_ of the first of the newly added items instead of a pointer to it (as it states in the documentation).

This PR makes the behavior consistent with what is stated in the documentation and with stretchy_buffer's `sb_add` implementation.