### PR TITLE
stb_image: fix build errors

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -108,7 +108,7 @@ RECENT REVISION HISTORY:
     Julian Raschke          Gregory Mullen     Baldur Karlsson    github:poppolopoppo
     Christian Floisand      Kevin Schmidt      JR Smith           github:darealshinji
     Brad Weinberger         Matvey Cherevko                       github:Michaelangel007
-    Blazej Dariusz Roszkowski                  Alexander Veselov
+    Blazej Dariusz Roszkowski                  Alexander Veselov  Daemyung Jang
 */
 
 #ifndef STBI_INCLUDE_STB_IMAGE_H
@@ -1670,7 +1670,7 @@ static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int r
       unsigned char *dest = good + j * x * req_comp;
 
       #define STBI__COMBO(a,b)  ((a)*8+(b))
-      #define STBI__CASE(a,b)   case STBI__COMBO(a,b): for(i=x-1; i >= 0; --i, src += a, dest += b)
+      #define STBI__CASE(a,b)   case STBI__COMBO((a),(b)): for(i=x-1; i >= 0; --i, src += a, dest += b)
       // convert source image with img_n components to one with req_comp components;
       // avoid switch per pixel, so use switch per scanline and massive macros
       switch (STBI__COMBO(img_n, req_comp)) {
@@ -1727,7 +1727,7 @@ static stbi__uint16 *stbi__convert_format16(stbi__uint16 *data, int img_n, int r
       stbi__uint16 *dest = good + j * x * req_comp;
 
       #define STBI__COMBO(a,b)  ((a)*8+(b))
-      #define STBI__CASE(a,b)   case STBI__COMBO(a,b): for(i=x-1; i >= 0; --i, src += a, dest += b)
+      #define STBI__CASE(a,b)   case STBI__COMBO((a),(b)): for(i=x-1; i >= 0; --i, src += a, dest += b)
       // convert source image with img_n components to one with req_comp components;
       // avoid switch per pixel, so use switch per scanline and massive macros
       switch (STBI__COMBO(img_n, req_comp)) {


### PR DESCRIPTION
Build errors are generated on Microsoft (R) C/C++ Optimizing Compiler Version 19.26.28806 for x64.

Error messages are below:
stb_image.h(1681,10): error C2196: case value '17' already used
stb_image.h(1683,10): error C2196: case value '12' already used
stb_image.h(1684,10): error C2196: case value '9' already used
stb_image.h(1685,10): error C2196: case value '10' already used
stb_image.h(1688,10): error C2196: case value '33' already used
stb_image.h(1738,10): error C2196: case value '17' already used
stb_image.h(1740,10): error C2196: case value '12' already used
stb_image.h(1741,10): error C2196: case value '9' already used
stb_image.h(1742,10): error C2196: case value '10' already used
stb_image.h(1745,10): error C2196: case value '33' already used