### PR TITLE
stb_image_write.h: Fixed compiler warnings

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -140,6 +140,7 @@ CREDITS:
       Ivan Tikhonov
       github:ignotion
       Adam Schackart
+      Taylor Holberton
 
 LICENSE
 

--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -397,7 +397,7 @@ static void stbiw__putc(stbi__write_context *s, unsigned char c)
 
 static void stbiw__write1(stbi__write_context *s, unsigned char a)
 {
-   if (s->buf_used + 1 > sizeof(s->buffer))
+   if (s->buf_used + 1 > ((int) sizeof(s->buffer)))
       stbiw__write_flush(s);
    s->buffer[s->buf_used++] = a;
 }
@@ -405,7 +405,7 @@ static void stbiw__write1(stbi__write_context *s, unsigned char a)
 static void stbiw__write3(stbi__write_context *s, unsigned char a, unsigned char b, unsigned char c)
 {
    int n;
-   if (s->buf_used + 3 > sizeof(s->buffer))
+   if (s->buf_used + 3 > ((int) sizeof(s->buffer)))
       stbiw__write_flush(s);
    n = s->buf_used;
    s->buf_used = n+3;


### PR DESCRIPTION
Replicate with gcc -Wall -Wextra -fsyntax-only stb_image_write.h