### PR TITLE
stb_vorbis: Allocate memory for empty buffers in setup_malloc()

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -934,7 +934,7 @@ static void *make_block_array(void *mem, int count, int size)
 
 // sentinel buffer returned for empty setup_malloc()
 // declared const to catch illegal writes
-static const char setup_malloc_null_buffer[1];
+static const char setup_malloc_null_buffer[1] = { 0 };
 
 static void *setup_malloc(vorb *f, int sz)
 {

--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -942,7 +942,7 @@ static void *setup_malloc(vorb *f, int sz)
       f->setup_offset += sz;
       return p;
    }
-   return sz ? malloc(sz) : NULL;
+   return malloc(sz);
 }
 
 static void setup_free(vorb *f, void *p)


### PR DESCRIPTION
I had a valid file failing with `VORBIS_outofmem` as the comment list was empty and I wasn't using an allocation buffer causing `setup_malloc()` to return `NULL` that gets interpreted as an allocation failure. You _could_ return a sentinel value here and check against it in `setup_free()` as an optimization, but I'm not sure if it's worth the complexity as you'd want to use an allocation buffer if you care about performance anyway.

In my case `f->comment_list_length` was zero here, which I assume is valid. Applying the fix in the PR made `stb_vorbis` able to decode the file without any further issues.
```c
   f->comment_list = (char**)setup_malloc(f, sizeof(char*) * (f->comment_list_length));
   if (f->comment_list == NULL)                     return error(f, VORBIS_outofmem);
```
