### PR TITLE
stb_image.h: Suppress warnings about out_size, delay_size

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -7212,8 +7212,8 @@ static int stbi__psd_is16(stbi__context *s)
        stbi__rewind( s );
        return 0;
    }
-   (void) stbi__get32be(s);
-   (void) stbi__get32be(s);
+   STBI_NOTUSED(stbi__get32be(s));
+   STBI_NOTUSED(stbi__get32be(s));
    depth = stbi__get16be(s);
    if (depth != 16) {
        stbi__rewind( s );

--- a/stb_image.h
+++ b/stb_image.h
@@ -115,6 +115,8 @@ RECENT REVISION HISTORY:
     Ryan C. Gordon          [reserved]                              [reserved]
                      DO NOT ADD YOUR NAME HERE
 
+                     Jacko Dirks
+
   To add your name to the credits, pick a random blank space in the middle and fill it.
   80% of merge conflicts on stb PRs are due to people adding their name at the end
   of the credits.
@@ -6777,6 +6779,10 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
       int stride;
       int out_size = 0;
       int delays_size = 0;
+
+      STBI_NOTUSED(out_size);
+      STBI_NOTUSED(delays_size);
+
       memset(&g, 0, sizeof(g));
       if (delays) {
          *delays = 0;


### PR DESCRIPTION
These two variables are unused in a Linux environment (the macros that use them actually do not
use them), which generate warnings. But the macros are set up like this
for compatibility with other environments, so that these warnings are
not easily avoided.
This fix just tells the compiler that these variables might not be used,
and that it should not warn, which seems the best of all worlds.