### PR TITLE
Added cast to match types

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -4120,7 +4120,7 @@ static int stbi__zhuffman_decode_slowpath(stbi__zbuf *a, stbi__zhuffman *z)
    if (s >= 16) return -1; // invalid code!
    // code size is s, so:
    b = (k >> (16-s)) - z->firstcode[s] + z->firstsymbol[s];
-   if (b >= sizeof (z->size)) return -1; // some data was corrupt somewhere!
+   if (b >= (int) sizeof (z->size)) return -1; // some data was corrupt somewhere!
    if (z->size[b] != s) return -1;  // was originally an assert, but report failure instead.
    a->code_buffer >>= s;
    a->num_bits -= s;

--- a/stb_image.h
+++ b/stb_image.h
@@ -6777,6 +6777,10 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
       int stride;
       int out_size = 0;
       int delays_size = 0;
+
+      STBI_NOTUSED(out_size);
+      STBI_NOTUSED(delays_size);
+
       memset(&g, 0, sizeof(g));
       if (delays) {
          *delays = 0;


### PR DESCRIPTION
Fixes issue #1019 : 
../../src/modules/image/stb_image.h: In function ‘int stbi__zhuffman_decode_slowpath(stbi__zbuf*, stbi__zhuffman*)’:
../../src/modules/image/stb_image.h:4123:10: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
 4123 |    if (b >= sizeof (z->size)) return -1; // some data was corrupt somewhere!
      |        ~~^~~~~~~~~~~~~~~~~~~