### PR TITLE
fix building by MSVC for Windows 10 on ARM

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -748,8 +748,11 @@ static int stbi__sse2_available(void)
 
 #ifdef STBI_NEON
 #include <arm_neon.h>
-// assume GCC or Clang on ARM targets
+#ifdef _MSC_VER
+#define STBI_SIMD_ALIGN(type, name) __declspec(align(16)) type name
+#else
 #define STBI_SIMD_ALIGN(type, name) type name __attribute__((aligned(16)))
+#endif
 #endif
 
 #ifndef STBI_SIMD_ALIGN


### PR DESCRIPTION
I recently enabled NEON support for Windows 10 on ARM for Ogre3D project, https://github.com/OGRECave/ogre-next/, and this is all that was needed to build STB with MSVC for ARM64.