### PR TITLE
stb_truetype: fix disregarded GPOS kern pairs

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -2486,7 +2486,7 @@ static stbtt_int32  stbtt__GetGlyphClass(stbtt_uint8 *classDefTable, int glyph)
         } break;
     }
 
-    return -1;
+    return 0;
 }
 
 // Define to STBTT_assert(x) if you want to break on unimplemented formats.
@@ -2593,12 +2593,10 @@ static stbtt_int32  stbtt__GetGlyphGPOSInfoAdvance(const stbtt_fontinfo *info, i
                             STBTT_GPOS_TODO_assert(valueFormat2 == 0);
                             if (valueFormat2 != 0) return 0;
 
-                            if (glyph1class >= 0 && glyph1class < class1Count && glyph2class >= 0 && glyph2class < class2Count) {
-                                stbtt_uint8 *class1Records = table + 16;
-                                stbtt_uint8 *class2Records = class1Records + 2 * (glyph1class * class2Count);
-                                stbtt_int16 xAdvance = ttSHORT(class2Records + 2 * glyph2class);
-                                return xAdvance;
-                            }
+                            stbtt_uint8 *class1Records = table + 16;
+                            stbtt_uint8 *class2Records = class1Records + 2 * (glyph1class * class2Count);
+                            stbtt_int16 xAdvance = ttSHORT(class2Records + 2 * glyph2class);
+                            return xAdvance;
                         } break;
 
                         default: {


### PR DESCRIPTION
stb_truetype incorrectly drops some kerning in the GPOS table (example at the end). The OpenType spec ([related section](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table)) specifies that in a ClassDef table, "All glyphs not assigned to a class fall into Class 0." In stb_truetype however, the function `stbtt__GetGlyphClass` returns -1 for glyphs with unassigned classes, so all their kerning info are disregarded. This patch fixes the bug.

Example: extract the kerning info from [Mali-Regular.ttf](https://github.com/google/fonts/blob/master/ofl/mali/Mali-Regular.ttf).

```c
#define STB_TRUETYPE_IMPLEMENTATION
#include "stb_truetype.h"
#include <stdio.h>

int main()
{
  stbtt_fontinfo font;
  static unsigned char buffer[1 << 20];

  fread(buffer, 1, sizeof buffer, fopen("Mali-Regular.ttf", "rb"));
  stbtt_InitFont(&font, buffer, 0);

  printf("VA %d\n", stbtt_GetCodepointKernAdvance(&font, 'V', 'A'));
  printf("AV %d\n", stbtt_GetCodepointKernAdvance(&font, 'A', 'V'));
  printf("CA %d\n", stbtt_GetCodepointKernAdvance(&font, 'C', 'A'));
  printf("AC %d\n", stbtt_GetCodepointKernAdvance(&font, 'A', 'C'));

  return 0;
}
```

Actual output:
```plain
VA -150
AV 0
CA 0
AC 0
```

Expected output (cross-checked with FontForge, fontTools `ttx`, and multiple GUI applications; corrected by the patch):
```plain
VA -150
AV -150
CA 0
AC -60
```

Details: the glyph "A" appears in the Coverage table but not in the ClassDef1 table, and thus falls into Class 0. Kern pairs with Class 0 as the first glyph are ignored in the unpatched version.