### PR TITLE
stb_sprintf.h: stdlib.h is not needed

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -176,7 +176,7 @@ PERFORMANCE vs MSVC 2008 32-/64-bit (GCC is even slower than MSVC):
 #endif
 #endif
 
-#include <stdarg.h> // for va_list()
+#include <stdarg.h> // for va_arg(), va_list()
 #include <stddef.h> // size_t, ptrdiff_t
 
 #ifndef STB_SPRINTF_MIN
@@ -199,8 +199,6 @@ STBSP__PUBLICDEF void STB_SPRINTF_DECORATE(set_separators)(char comma, char peri
 #endif // STB_SPRINTF_H_INCLUDE
 
 #ifdef STB_SPRINTF_IMPLEMENTATION
-
-#include <stdlib.h> // for va_arg()
 
 #define stbsp__uint32 unsigned int
 #define stbsp__int32 signed int


### PR DESCRIPTION
va_arg() is in stdarg.h, which is already being included