### PR TITLE
Creating meson.build to allow easy use with meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,4 +14,6 @@ stb_dep = declare_dependency(
     version: meson.project_version()
 )
 
-meson.override_dependency('stb', stb_dep)
+if meson.version().version_compare('>=0.54.0')
+    meson.override_dependency('stb', stb_dep)
+endif

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,6 @@ project(
   'stb',
   'c',
   'cpp',
-  default_options : ['c_std=c11', 'cpp_std=c++17', 'b_lto=True'],
   version : '0.0.1',
   license : 'Mit'
 )

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,26 @@
+project(
+  'redhand',
+  'c',
+  'cpp',
+  default_options : ['c_std=c11', 'cpp_std=c++17', 'b_lto=True'],
+  version : '0.0.1',
+  license : 'Mit'
+)
+
+incdir = include_directories('.')
+
+stb = library(
+    'stb', 
+    '', 
+    version : meson.project_version(), 
+    soversion : '0',
+    include_directories : incdir
+)
+
+stb_dep = declare_dependency(
+    include_directories : incdir,
+    link_with : stb,
+    version: meson.project_version()
+)
+
+meson.override_dependency('stb', stb_dep)

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project(
-  'redhand',
+  'stb',
   'c',
   'cpp',
   default_options : ['c_std=c11', 'cpp_std=c++17', 'b_lto=True'],
@@ -9,17 +9,8 @@ project(
 
 incdir = include_directories('.')
 
-stb = library(
-    'stb', 
-    '', 
-    version : meson.project_version(), 
-    soversion : '0',
-    include_directories : incdir
-)
-
 stb_dep = declare_dependency(
     include_directories : incdir,
-    link_with : stb,
     version: meson.project_version()
 )
 


### PR DESCRIPTION
The title says it all.
There is only one new file with 17 lines that probably won't change in the near future.
This file allows developers to easily use stb with the meson build system.