### PR TITLE
Fixes #1041

### DIFF
--- a/stb_textedit.h
+++ b/stb_textedit.h
@@ -87,8 +87,8 @@
 //   moderate sizes. The undo system does no memory allocations, so
 //   it grows STB_TexteditState by the worst-case storage which is (in bytes):
 //
-//        [4 + 3 * sizeof(STB_TEXTEDIT_POSITIONTYPE)] * STB_TEXTEDIT_UNDOSTATE_COUNT
-//      +          sizeof(STB_TEXTEDIT_CHARTYPE)      * STB_TEXTEDIT_UNDOCHAR_COUNT
+//        [4 + 3 * sizeof(STB_TEXTEDIT_POSITIONTYPE)] * STB_TEXTEDIT_UNDOSTATECOUNT
+//      +          sizeof(STB_TEXTEDIT_CHARTYPE)      * STB_TEXTEDIT_UNDOCHARCOUNT
 //
 //
 // Implementation mode:


### PR DESCRIPTION
Fixes typos in `stb_textedit.h`

In the header comments `STB_TEXTEDIT_UNDOSTATECOUNT` is misspelled as `STB_TEXTEDIT_UNDOSTATE_COUNT` and `STB_TEXTEDIT_UNDOCHARCOUNT` is misspelled as `STB_UNDOCHAR_COUNT.`


