### PR TITLE
Fix comparison of different signs.

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -4120,7 +4120,7 @@ static int stbi__zhuffman_decode_slowpath(stbi__zbuf *a, stbi__zhuffman *z)
    if (s >= 16) return -1; // invalid code!
    // code size is s, so:
    b = (k >> (16-s)) - z->firstcode[s] + z->firstsymbol[s];
-   if (b >= sizeof (z->size)) return -1; // some data was corrupt somewhere!
+   if (b >= (int) sizeof (z->size)) return -1; // some data was corrupt somewhere!
    if (z->size[b] != s) return -1;  // was originally an assert, but report failure instead.
    a->code_buffer >>= s;
    a->num_bits -= s;


### PR DESCRIPTION
Addresses a compiler warning on comparing integers of different signs:
```
/home/bram/src/stb/stb_image.h:4123:10: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
   if (b >= sizeof (z->size)) return -1; // some data was corrupt somewhere!
```
