### PR TITLE
stb_truetype: fixes SDF rendering artifacts with some fonts

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -1759,9 +1759,11 @@ static int stbtt__GetGlyphShapeTT(const stbtt_fontinfo *info, int glyph_index, s
          y     = (stbtt_int16) vertices[off+i].y;
 
          if (next_move == i) {
-            if (i != 0)
+            if (i != 0) {
+               if (i == n-1) break;
                num_vertices = stbtt__close_shape(vertices, num_vertices, was_off, start_off, sx,sy,scx,scy,cx,cy);
-
+            }
+            
             // now start the new one
             start_off = !(flags & 1);
             if (start_off) {


### PR DESCRIPTION
Affects e.g. DejaVuSans' "u" and Calibri's "&".

Before and after:
![dejavusans](https://user-images.githubusercontent.com/1294616/103366336-a9559080-4ac2-11eb-986a-edeef9ff1e84.png)

Fix based on: https://bugzilla.gnome.org/show_bug.cgi?id=665384
