### PR TITLE
Fix compiler error when using STB_C_LEX_0_IS_EOF in stb_c_lexer.h

### DIFF
--- a/stb_c_lexer.h
+++ b/stb_c_lexer.h
@@ -608,7 +608,7 @@ int stb_c_lexer_get_token(stb_lexer *lexer)
          // check for EOF
          STB_C_LEX_0_IS_EOF(
             if (*p == 0)
-               return stb__clex_eof(tok);
+               return stb__clex_eof(lexer);
          )
 
       single_char:


### PR DESCRIPTION
On line 611 in stb_c_lexer.h there is a variable "tok" used which does not exist, and should be "lexer" instead.