### PR TITLE
stb_image, stb_image_write: fix gcc/clang sign-compare warnings

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -4120,7 +4120,7 @@ static int stbi__zhuffman_decode_slowpath(stbi__zbuf *a, stbi__zhuffman *z)
    if (s >= 16) return -1; // invalid code!
    // code size is s, so:
    b = (k >> (16-s)) - z->firstcode[s] + z->firstsymbol[s];
-   if (b >= sizeof (z->size)) return -1; // some data was corrupt somewhere!
+   if (b >= (int)sizeof(z->size)) return -1; // some data was corrupt somewhere!
    if (z->size[b] != s) return -1;  // was originally an assert, but report failure instead.
    a->code_buffer >>= s;
    a->num_bits -= s;

--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -397,7 +397,7 @@ static void stbiw__putc(stbi__write_context *s, unsigned char c)
 
 static void stbiw__write1(stbi__write_context *s, unsigned char a)
 {
-   if (s->buf_used + 1 > sizeof(s->buffer))
+   if (s->buf_used + 1 > (int)sizeof(s->buffer))
       stbiw__write_flush(s);
    s->buffer[s->buf_used++] = a;
 }
@@ -405,7 +405,7 @@ static void stbiw__write1(stbi__write_context *s, unsigned char a)
 static void stbiw__write3(stbi__write_context *s, unsigned char a, unsigned char b, unsigned char c)
 {
    int n;
-   if (s->buf_used + 3 > sizeof(s->buffer))
+   if (s->buf_used + 3 > (int)sizeof(s->buffer))
       stbiw__write_flush(s);
    n = s->buf_used;
    s->buf_used = n+3;


### PR DESCRIPTION
See #1100 . Fixes the following warnings on GCC 9.3.0 and clang 10.0.0:
```
[...]/stb_image.h: In function ‘int stbi__zhuffman_decode_slowpath(stbi__zbuf*, stbi__zhuffman*)’:
[...]/stb_image.h:4123:10: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
 4123 |    if (b >= sizeof (z->size)) return -1; // some data was corrupt somewhere!
      |        ~~^~~~~~~~~~~~~~~~~~~
[...]/stb_image_write.h: In function ‘void stbiw__write1(stbi__write_context*, unsigned char)’:
[...]/stb_image_write.h:400:24: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
  400 |    if (s->buf_used + 1 > sizeof(s->buffer))
      |        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
[...]/stb_image_write.h: In function ‘void stbiw__write3(stbi__write_context*, unsigned char, unsigned char, unsigned char)’:
[...]/stb_image_write.h:408:24: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
  408 |    if (s->buf_used + 3 > sizeof(s->buffer))
      |        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
```