### PR TITLE
stb_image_resize: Fix edge reflect overflow

### DIFF
--- a/stb_image_resize.h
+++ b/stb_image_resize.h
@@ -959,7 +959,7 @@ static int stbir__edge_wrap_slow(stbir_edge edge, int n, int max)
     {
         if (n < 0)
         {
-            if (n < max)
+            if (-n < max)
                 return -n;
             else
                 return max - 1;

--- a/stb_image_resize.h
+++ b/stb_image_resize.h
@@ -157,6 +157,7 @@
       Sean Barrett: API design, optimizations
       Aras Pranckevicius: bugfix
       Nathan Reed: warning fixes
+      Johannes Spohr: bugfix
 
    REVISIONS
       0.97 (2020-02-02) fixed warning


### PR DESCRIPTION
Noticed that my lowest mipmaps contained random colors after switching to STBIR_EDGE_REFLECT. I believe this is the correct fix, but please correct me if I'm wrong. Cheers!