### PR TITLE
Fix #1051 - memory leak in stb_vorbis

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -4507,6 +4507,7 @@ stb_vorbis *stb_vorbis_open_pushdata(
          *error = VORBIS_need_more_data;
       else
          *error = p.error;
+      vorbis_deinit(&p);
       return NULL;
    }
    f = vorbis_alloc(&p);


### PR DESCRIPTION
When start_decoder() fails it may already have allocated memory
for .vendor and/or .comment_list. Call vorbis_deinit() to free
any allocated memory.
