### PR TITLE
tilemap_editor: Fix undefined variables

### DIFF
--- a/stb_tilemap_editor.h
+++ b/stb_tilemap_editor.h
@@ -2996,7 +2996,7 @@ static void stbte__tile_paint(stbte_tilemap *tm, int sx, int sy, int mapx, int m
       i = layer;
       if (i == tm->solo_layer || (!tm->layerinfo[i].hidden && tm->solo_layer < 0))
          if (data[i] >= 0)
-            STBTE_DRAW_TILE(x0,y0, (unsigned short) data[i], 0, tm->props[mapy][mapx]);
+            STBTE_DRAW_TILE(sx,sy, (unsigned short) data[i], 0, tm->props[mapy][mapx]);
    }
 }
 
@@ -3496,7 +3496,7 @@ static void stbte__tile_in_palette(stbte_tilemap *tm, int x, int y, int slot)
    switch (stbte__ui.event) {
       case STBTE__paint:
          stbte__draw_rect(x,y,x+tm->palette_spacing_x-1,y+tm->palette_spacing_x-1, STBTE_COLOR_TILEPALETTE_BACKGROUND);
-         STBTE_DRAW_TILE(x,y,t->id, slot == tm->cur_tile,0);
+         STBTE_DRAW_TILE(x,y,id, slot == tm->cur_tile,0);
          if (slot == tm->cur_tile)
             stbte__draw_frame_delayed(x-1,y-1,x+tm->palette_spacing_x,y+tm->palette_spacing_y, STBTE_COLOR_TILEPALETTE_OUTLINE);
          break;


### PR DESCRIPTION
I'm not sure if this is correct, but it does fix compilation and rendering.