### PR TITLE
Glyph layered color font support (CPAL/COLR)

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -1499,6 +1499,8 @@ static int stbtt_InitFont_internal(stbtt_fontinfo *info, unsigned char *data, in
       info->numGlyphs = 0xffff;
 
    info->svg = -1;
+   info->colr = -1;
+   info->cpal = -1;
 
    // find a cmap encoding table we understand *now* to avoid searching
    // later. (todo: could make this installable)


### PR DESCRIPTION
Continuing from https://github.com/nothings/stb/issues/512 this PR adds support for opentype's extension tables CPAL and COLR 

https://docs.microsoft.com/es-es/typography/opentype/spec/cpal (version 0 as it seems theres no fonts using CPAL v1)
https://docs.microsoft.com/es-es/typography/opentype/spec/colr

Also keeping an eye on CPAL/COLR spec proposals
https://github.com/googlefonts/colr-gradients-spec/blob/main/OFF_AMD2_WD.md

The tables load the first time when this new api is called imitating the SVG loading mechanism, Color palettes can also be used with SVG data as per specification. During the first lookup of COLR table i've choosen to pre swap the bytes on the Layer Records Table in order to be able to cast this memory for the operation result. This was not needed on CPAL since the union allows to access separate color components and BGRA color is what opengl/d3d uses. This may cause trouble in some marginal cases using 3rd party libs (harfbuzz-ot-color) to read this table AND using this api subset at the same time, i think the benefit of pre-swapping the table is far superior so the user dont have to use more api to read the values.

This api has been tested with:  `Segoe UI Emoji` (old/new),  `FlagsWorldColor`,  `FirefoxEmoji`, `RocherColor` and others.

If someone has a font specimen with CPAL v1 please reach me to update this PR, but this extension isn't very juicy anyway. (palette flags for dark/clear bg, and names)

New api proposed:
```c
//// Color palettes (CPAL) ///////////////////////////////////////////////////
typedef union {
    unsigned int color;
    struct {
        unsigned char b, g, r, a;
    } argb;
} stbtt_color;
STBTT_DEF bool stbtt_FontHasPalette(const stbtt_fontinfo *info);
STBTT_DEF unsigned short stbtt_FontPaletteCount(const stbtt_fontinfo *info);
STBTT_DEF unsigned short stbtt_FontPaletteGetColors(const stbtt_fontinfo *info, unsigned short paletteIndex, stbtt_color **colorPalette);
//// Glyph layers (COLR) /////////////////////////////////////////////////////
typedef struct {
    unsigned short glyphid, colorid;
} stbtt_glyphlayer;
STBTT_DEF bool stbtt_FontHasLayers(const stbtt_fontinfo *info);
STBTT_DEF unsigned short stbtt_GetGlyphLayers(const stbtt_fontinfo *info, unsigned short glypId, stbtt_glyphlayer **glyphLayer);
STBTT_DEF unsigned short stbtt_GetCodepointLayers(const stbtt_fontinfo *info, unsigned short codePoint, stbtt_glyphlayer **glyphLayer);
```

Test harness results (d3d9) - Original + Color + Glyph layers + Palette
- SegoeUI Emoji (new) 
![2021-04-18_23-18-46](https://user-images.githubusercontent.com/1850716/115161217-acd64d00-a09c-11eb-9ce0-0a5165215794.png)
- RocherColor "HelloSTB" where each letter uses a different palette
![image](https://user-images.githubusercontent.com/1850716/115161934-afd33c80-a0a0-11eb-8978-ebd3c9de8cb4.png)

