### PR TITLE
expose STBRP__MAXVAL define even if STB_RECT_PACK_IMPLEMENTATION isn't defined

### DIFF
--- a/stb_rect_pack.h
+++ b/stb_rect_pack.h
@@ -67,6 +67,12 @@
 #define STBRP_DEF extern
 #endif
 
+#ifdef STBRP_LARGE_RECTS
+#define STBRP__MAXVAL  0xffffffff
+#else
+#define STBRP__MAXVAL  0xffff
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -537,12 +543,6 @@ static int rect_original_order(const void *a, const void *b)
    const stbrp_rect *q = (const stbrp_rect *) b;
    return (p->was_packed < q->was_packed) ? -1 : (p->was_packed > q->was_packed);
 }
-
-#ifdef STBRP_LARGE_RECTS
-#define STBRP__MAXVAL  0xffffffff
-#else
-#define STBRP__MAXVAL  0xffff
-#endif
 
 STBRP_DEF int stbrp_pack_rects(stbrp_context *context, stbrp_rect *rects, int num_rects)
 {


### PR DESCRIPTION
e.g. i intend to limit packed rect boundaries by STBRP__MAXVAL for backward compability in my header file (font.h for example) but i doesn't need full implemetation because this header included in other files where stb_rectpack.h will be unused, so it makes me possible to include "std_rectpack.h" in my font.h to use `STBRP__MAXVAL` define and define STB_RECT_PACK_IMPLEMENTATION before including font.h in font.cpp file where implementation used