### PR TITLE
shputs duplicate insert: fix stale temp_key

### DIFF
--- a/stb_ds.h
+++ b/stb_ds.h
@@ -1378,6 +1378,8 @@ void *stbds_hmput_key(void *a, size_t elemsize, void *key, size_t keysize, int m
         if (bucket->hash[i] == hash) {
           if (stbds_is_key_equal(raw_a, elemsize, key, keysize, keyoffset, mode, bucket->index[i])) {
             stbds_temp(a) = bucket->index[i];
+            if (mode >= STBDS_HM_STRING)
+              stbds_temp_key(a) = * (char **) ((char *) raw_a + elemsize*bucket->index[i] + keyoffset);
             return STBDS_ARR_TO_HASH(a,elemsize);
           }
         } else if (bucket->hash[i] == 0) {

--- a/stb_ds.h
+++ b/stb_ds.h
@@ -379,6 +379,7 @@ CREDITS
     Andreas Molzer
     github:hashitaku
     github:srdjanstipic
+    Macoy Madson
 */
 
 #ifdef STBDS_UNIT_TESTS


### PR DESCRIPTION
Fix `temp_key` being stale on key re-insert. This pull request re-uses the existing key, which matches the previous behavior. Before the fix, there was a chance that `temp_key` would be the last inserted key, or effectively garbage data. This manifested for me in double frees and entries with incorrect keys.

See issue nothings#992 and pull request nothings#993.
