### PR TITLE
stb_textedit: Fix paste failure handling breaking undo stack (could lead to freezes)

### DIFF
--- a/stb_textedit.h
+++ b/stb_textedit.h
@@ -708,9 +708,7 @@ static int stb_textedit_paste_internal(STB_TEXTEDIT_STRING *str, STB_TexteditSta
       state->has_preferred_x = 0;
       return 1;
    }
-   // remove the undo since we didn't actually insert the characters
-   if (state->undostate.undo_point)
-      --state->undostate.undo_point;
+   // note: paste failure will leave deleted selection, may be restored with an undo (see https://github.com/nothings/stb/issues/734 for details)
    return 0;
 }
 


### PR DESCRIPTION
This implement "Fix v1" described in #734 on the ground that it is simple.
(I can change it to "Fix v2" if deemed preferable)

Ended up spending a few hours researching and confirming this but in terms of crediting note that the actual fix was first suggested by Edward @Unit2Ed in #734.

----

**The failure conditions that are fixed are:**

(A)
- pasting does happen but WITHOUT a selection, stb_textedit_delete_selection() doesn't insert a undo point
- insertion fails
- code erroneously removed undo point

and

(B)
- pasting happens with a selection, but undo point cannot be created (deleted text larger than STB_TEXTEDIT_UNDOCHARCOUNT).
- insertion fails
- code erroneously removed undo point

----

**Repro**

https://github.com/ocornut/imgui/issues/4038 has a repro which should be easy to replicate outside of Dear ImGui (by using same inputs sequence and same buffer size). Dear ImGui doesn't change the default value of `STB_TEXTEDIT_UNDOCHARCOUNT`/`STB_TEXTEDIT_UNDOSTATECOUNT`.

