### PR TITLE
stb_rect_pack: making functions cdecl for msvc qsort

### DIFF
--- a/stb_rect_pack.h
+++ b/stb_rect_pack.h
@@ -215,8 +215,10 @@ struct stbrp_context
 
 #ifdef _MSC_VER
 #define STBRP__NOTUSED(v)  (void)(v)
+#define STBRP__CDECL       __cdecl
 #else
 #define STBRP__NOTUSED(v)  (void)sizeof(v)
+#define STBRP__CDECL
 #endif
 
 enum
@@ -519,7 +521,7 @@ static stbrp__findresult stbrp__skyline_pack_rectangle(stbrp_context *context, i
    return res;
 }
 
-static int rect_height_compare(const void *a, const void *b)
+static int STBRP__CDECL rect_height_compare(const void *a, const void *b)
 {
    const stbrp_rect *p = (const stbrp_rect *) a;
    const stbrp_rect *q = (const stbrp_rect *) b;
@@ -530,7 +532,7 @@ static int rect_height_compare(const void *a, const void *b)
    return (p->w > q->w) ? -1 : (p->w < q->w);
 }
 
-static int rect_original_order(const void *a, const void *b)
+static int STBRP__CDECL rect_original_order(const void *a, const void *b)
 {
    const stbrp_rect *p = (const stbrp_rect *) a;
    const stbrp_rect *q = (const stbrp_rect *) b;


### PR DESCRIPTION
(redoing #1160 without the branch fuckup)

Hello,

If you use stb_rect_pack without redefining `STBRP_SORT` it'll call `qsort()`, which expect the compare function to be using CDECL calling convention. If the default calling convention of the compile unit is not cdecl, compiler will choke on calling qsort `rect_height_compare()` and `rect_original_order()`.

I solved this on my side by adding a `STBRP__CDECL ` to those functions, based on the ground it won't hurt if those functions are always cdecl. 

Grepping `qsort` in stb/ folder the only other uses are: stb.h (ignoring) and stb_vorbis.c, which for the 2 functions used with `qsort()` does a similar thing:
```cpp
#ifdef _MSC_VER
#define STBV_CDECL __cdecl
#else
#define STBV_CDECL
#endif

static int STBV_CDECL uint32_compare(const void *p, const void *q)
{
   uint32 x = * (uint32 *) p;
   uint32 y = * (uint32 *) q;
   return x < y ? -1 : x > y;
}
```