### PR TITLE
stb_vorbis: fix -Wmaybe-uninitialized warnings in get_seek_page_info.

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -34,6 +34,7 @@
 //    github:audinowho   Dougall Johnson     David Reid
 //    github:Clownacy    Pedro J. Estebanez  Remi Verschelde
 //    AnthoFoxo          github:morlat       Gabriel Ravier
+//    Alice Rowan
 //
 // Partial history:
 //    1.22    - 2021-07-11 - various small fixes
@@ -4649,10 +4650,12 @@ static int get_seek_page_info(stb_vorbis *f, ProbedPage *z)
    z->page_start = stb_vorbis_get_file_offset(f);
 
    // parse the header
-   getn(f, header, 27);
+   if (!getn(f, header, 27))
+      return 0;
    if (header[0] != 'O' || header[1] != 'g' || header[2] != 'g' || header[3] != 'S')
       return 0;
-   getn(f, lacing, header[26]);
+   if (!getn(f, lacing, header[26]))
+      return 0;
 
    // determine the length of the payload
    len = 0;


### PR DESCRIPTION
The first of what should be several patches I'm porting from libxmp: with some configurations that I haven't 100% pinned down, line 4653 can cause compilers to emit -Wmaybe-uninitialized warnings. The easy fix for this (and potentially other UMRs in this function) is to just check the return values of the two uses of `getn` in this function.