### PR TITLE
stb_ds.h: update docs and changes overwritten by merge commit

### DIFF
--- a/stb_ds.h
+++ b/stb_ds.h
@@ -95,7 +95,9 @@ DOCUMENTATION
           Removes the final element of the array and returns it.
 
       arrput:
+      arrpush:
         T arrput(T* a, T b);
+        T arrpush(T* a, T b);
           Appends the item b to the end of array a. Returns b.
 
       arrins:
@@ -145,6 +147,10 @@ DOCUMENTATION
         size_t arrcap(T* a);
           Returns the number of total elements the array can contain without
           needing to be reallocated.
+
+      arrlast:
+        T arrlast(T* a);
+          Returns the last element in the array.
 
   Hash maps & String hash maps
 
@@ -382,6 +388,7 @@ CREDITS
     Macoy Madson
     Andreas Vennstrom
     Tobias Mansfield-Williams
+    Tiago Chaves
 */
 
 #ifdef STBDS_UNIT_TESTS
@@ -546,9 +553,8 @@ extern void * stbds_shmode_func(size_t elemsize, int mode);
 #define stbds_arraddn(a,n)     ((void)(stbds_arraddnindex(a, n)))    // deprecated, use one of the following instead:
 #define stbds_arraddnptr(a,n)  (stbds_arrmaybegrow(a,n), (n) ? (stbds_header(a)->length += (n), &(a)[stbds_header(a)->length-(n)]) : (a))
 #define stbds_arraddnindex(a,n)(stbds_arrmaybegrow(a,n), (n) ? (stbds_header(a)->length += (n), stbds_header(a)->length-(n)) : stbds_arrlen(a))
-#define stbds_arraddnoff       stbds_arraddnindex
 #define stbds_arrlast(a)       ((a)[stbds_header(a)->length-1])
-#define stbds_arrfree(a)       ((void) ((a) ? STBDS_FREE(NULL,stbds_header(a)) : (void)0), (a)=NULL)
+#define stbds_arrfree(a)       ((void) ((a) ? stbds_arrfreef(a) : (void)0), (a)=NULL)
 #define stbds_arrdel(a,i)      stbds_arrdeln(a,i,1)
 #define stbds_arrdeln(a,i,n)   (memmove(&(a)[i], &(a)[(i)+(n)], sizeof *(a) * (stbds_header(a)->length-(n)-(i))), stbds_header(a)->length -= (n))
 #define stbds_arrdelswap(a,i)  ((a)[i] = stbds_arrlast(a), stbds_header(a)->length -= 1)


### PR DESCRIPTION
- Added missing documentation for `arrlast` and `arrpush`
- Fixed two changes overwritten by the merge commit https://github.com/nothings/stb/commit/a32aeefd6bc270231b0000573699dabc05321c5a :
    - Readded call to custom free function in `stbds_arrfree`, from https://github.com/nothings/stb/pull/1144
    - Removed `stbds_arraddnoff`, which was rename to `stbds_arraddnindex` in https://github.com/nothings/stb/pull/1107 (since it isn't referenced anywhere else in the code and there's no short name `arraddnoff`, it doesn't seem necessary to keep it as a "synonym")