### PR TITLE
 Optional PNG text chunks support for stb_image

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -5233,7 +5233,7 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
                stbi_uc *text = (stbi_uc*) STBI_MALLOC(text_len);
                if (!stbi__getn(s, text, text_len)) return stbi__err("outofdata","Corrupt PNG");
                int expanded_text_len = 0;
-               char *expanded_text = stbi_zlib_decode_malloc_guesssize(text, text_len, 1024, &expanded_text_len);
+               char *expanded_text = stbi_zlib_decode_malloc_guesssize((const char*) text, text_len, 1024, &expanded_text_len);
 			   STBI_FREE(text);
 			   text = (stbi_uc*) STBI_MALLOC(expanded_text_len + 1);
 			   memcpy(text, expanded_text, expanded_text_len);

--- a/stb_image.h
+++ b/stb_image.h
@@ -5205,13 +5205,13 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
                   key[key_len++] = chr;
                } while (chr);
                stbi__uint32 text_len = c.length - key_len;
-               stbi_uc *text = STBI_MALLOC(text_len + 1);
+               stbi_uc *text = (stbi_uc*) STBI_MALLOC(text_len + 1);
                if (!stbi__getn(s, text, text_len)) return stbi__err("outofdata","Corrupt PNG");
                text[text_len] = '\0';
-               stbi__png_text_chunk_handler(key, text, stbi__png_text_chunk_handler_user_data);
+               stbi__png_text_chunk_handler((const char*) key, (char*) text, stbi__png_text_chunk_handler_user_data);
             } else {
                stbi__skip(s, c.length);
-			}
+            }
             break;
          }
 	
@@ -5230,19 +5230,19 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
                } while (chr);
                if (stbi__get8(s) != 0) return stbi__err("zTXt invalid compress", "Corrupt PNG");
                stbi__uint32 text_len = c.length - key_len - 1;
-               stbi_uc *text = STBI_MALLOC(text_len);
+               stbi_uc *text = (stbi_uc*) STBI_MALLOC(text_len);
                if (!stbi__getn(s, text, text_len)) return stbi__err("outofdata","Corrupt PNG");
-               stbi__uint32 expanded_text_len = 0;
+               int expanded_text_len = 0;
                char *expanded_text = stbi_zlib_decode_malloc_guesssize(text, text_len, 1024, &expanded_text_len);
 			   STBI_FREE(text);
-			   text = STBI_MALLOC(expanded_text_len + 1);
+			   text = (stbi_uc*) STBI_MALLOC(expanded_text_len + 1);
 			   memcpy(text, expanded_text, expanded_text_len);
                text[expanded_text_len] = '\0';
                STBI_FREE(expanded_text);
-               stbi__png_text_chunk_handler(key, text, stbi__png_text_chunk_handler_user_data);
+               stbi__png_text_chunk_handler((const char*) key, (char*) text, stbi__png_text_chunk_handler_user_data);
             } else {
                stbi__skip(s, c.length);
-			}
+            }
             break;
 		 }
          


### PR DESCRIPTION
I am using stb_image for my small game engine project and thought that it would be great to embed a metadata (for example, char map for a bitmap font) in PNG files using some standard-conforming way. PNG specification (https://www.w3.org/TR/PNG-Chunks.html) allows compressed and uncompressed text chunks ("zTXt" and "tEXt" respectively) with keys (either standard like Title, Author etc or user defined) and some software and libraries (e. g. lodepng, libpng) support it. I've added this functional to stb_image, because it can be added just only by few lines of code.

Now you can set PNG text chunks handler (by default the option is completely disabled and shouldn't affect performance of the parser at all) and it would be called on each text chunk (both compressed and uncompressed chunks are supported). You can set some universal handler (also there is user_data pointer to be able to use the same handler multiple times with different behaivor or data structures) or change it before each decoding (and ever disable it again by passing NULL instead of the handler).

As I know there are similar features in some other formats (GIF comment extensions, JPEG APPn markers), so maybe it would be better to rename added functions in some format-agnostic way so it would be possible to add suport for other formats in future without introducing new APIs.

Thank you for your time!

P. S.: I am not sure how optimal I've implemented compressed text chunks handling - there are three allocations during the handling, but I am not enough familiar with stb_image source code :-(