### PR TITLE
stb_truetype.h: Use STBTT_assert macro

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -3134,8 +3134,8 @@ static void stbtt__fill_active_edges_new(float *scanline, float *scanline_fill, 
                   dy = -dy;
                   t = x0, x0 = xb, xb = t;
                }
-               assert(dy >= 0);
-               assert(dx >= 0);
+               STBTT_assert(dy >= 0);
+               STBTT_assert(dx >= 0);
 
                x1 = (int) x_top;
                x2 = (int) x_bottom;


### PR DESCRIPTION
Replaced two direct calls to assert with STBTT_assert macro.