### PR TITLE
Add missing initializer braces in stb_easy_font.h

### DIFF
--- a/stb_easy_font.h
+++ b/stb_easy_font.h
@@ -202,7 +202,7 @@ static int stb_easy_font_print(float x, float y, char *text, unsigned char color
     float start_x = x;
     int offset = 0;
 
-    stb_easy_font_color c = { 255,255,255,255 }; // use structure copying to avoid needing depending on memcpy()
+    stb_easy_font_color c = { { 255,255,255,255 } }; // use structure copying to avoid needing depending on memcpy()
     if (color) { c.c[0] = color[0]; c.c[1] = color[1]; c.c[2] = color[2]; c.c[3] = color[3]; }
 
     while (*text && offset < vbuf_size) {


### PR DESCRIPTION
See the following compiler warning from gcc 11.2.1 with `-Wall`:

```
In file included from test_easyfont.c:1:
../stb_easy_font.h: In function 'stb_easy_font_print':
../stb_easy_font.h:205:29: warning: missing braces around initializer [-Wmissing-braces]
  205 |     stb_easy_font_color c = { 255,255,255,255 }; // use structure copying to avoid needing depending on memcpy()
      |                             ^
      |                               {               }
```

There should be one set of braces for the structure `stb_easy_font_color`, and then another to contain the elements of the array member `c`. This is a pedantic fix, as typical compilers will compile it correctly and will at most warn rather than erroring.

No contributors list entry is needed for this trivial contribution.