### PR TITLE
Fix signature of dummy realloc() for STB_VORBIS_NO_CRT

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -594,8 +594,8 @@ enum STBVorbisError
 #else // STB_VORBIS_NO_CRT
    #define NULL 0
    #define malloc(s)   0
-   #define free(s)     ((void) 0)
-   #define realloc(s)  0
+   #define free(p)     ((void) 0)
+   #define realloc(p, s)  0
 #endif // STB_VORBIS_NO_CRT
 
 #include <limits.h>


### PR DESCRIPTION
Fixes errors like `error: macro "realloc" passed 2 arguments, but takes just 1` from `stb_vorbis.c` when `STB_VORBIS_NO_CRT` is set.

Additionally, the parameter to the dummy `malloc` is renamed from `s` to `p` to establish a consistent `s`=size, `p`=pointer convention in the dummy macros.

This is a trivial fix, and I don’t feel it requires a contributor acknowledgement.