### PR TITLE
Avoid sign-compare warning in stb_sprintf with GCC 7.5.0

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -21,6 +21,7 @@
 //    Adam Allison
 //    Arvid Gerstmann
 //    Markus Kolb
+//    Robert Müller
 //
 // LICENSE:
 //
@@ -591,7 +592,7 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
             s = (char *)"null";
          // get the length, limited to desired precision
          // always limit to ~0u chars since our counts are 32b
-         l = stbsp__strlen_limited(s, (pr >= 0) ? pr : ~0u);
+         l = stbsp__strlen_limited(s, (pr >= 0) ? (stbsp__uint32)pr : ~0u);
          lead[0] = 0;
          tail[0] = 0;
          pr = 0;


### PR DESCRIPTION
This avoids the warning/error "signed and unsigned type in conditional expression [-Werror=sign-compare]" with GCC 7.5.0 on Ubuntu 18.04.