### PR TITLE
stb_image PNG reader: Adds checks for invalid DEFLATE codes, fixing an infinite loop found by ossfuzz.

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -4256,11 +4256,12 @@ static int stbi__parse_huffman_block(stbi__zbuf *a)
             a->zout = zout;
             return 1;
          }
+         if (z >= 286) return stbi__err("bad huffman code","Corrupt PNG"); // per DEFLATE, length codes 286 and 287 must not appear in compressed data
          z -= 257;
          len = stbi__zlength_base[z];
          if (stbi__zlength_extra[z]) len += stbi__zreceive(a, stbi__zlength_extra[z]);
          z = stbi__zhuffman_decode(a, &a->z_distance);
-         if (z < 0) return stbi__err("bad huffman code","Corrupt PNG");
+         if (z < 0 || z >= 30) return stbi__err("bad huffman code","Corrupt PNG"); // per DEFLATE, distance codes 30 and 31 must not appear in compressed data
          dist = stbi__zdist_base[z];
          if (stbi__zdist_extra[z]) dist += stbi__zreceive(a, stbi__zdist_extra[z]);
          if (zout - a->zout_start < dist) return stbi__err("bad dist","Corrupt PNG");


### PR DESCRIPTION
This pull request attempts to fix an issue where a specially formatted PNG file
could cause an infinite loop in `stbi__parse_huffman_block` (ossfuzz issue [24232](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24232&q=proj%3Dstb))

The file in ossfuzz issue 24232 appears to cause an infinite loop by making
literal 0 correspond to length 0, and then truncating the file early (resulting
in reading a stream of 0s). More specifically, the file contains a Huffman
length table in which literal 0 decodes to length code 287. It turns out that
length codes 286 and 287 are in fact invalid codes - they're illegal symbols,
but they're there because they're required for constructing the canonical
Huffman tree! stb_image handles these codes by setting `len`, the number of
bytes to output, to 0. However, the result is that the loops on lines [4274](https://github.com/nothings/stb/blob/master/stb_image.h#L4274) and
4276 do not advance the state. By doing some necessary setup (so that the range
checks on [lines 4265-4267](https://github.com/nothings/stb/blob/master/stb_image.h#L4265-L4267) pass) and then truncating the file early (so that
`stbi__zreceive` always returns 0, like in issue #1224), reading the ossfuzz
file results in an infinite loop.

Since length codes 286 and 287 are illegal, this pull request adds a branch to
reject them (which fixes the issue with this file).

This also adds a check to reject invalid distance codes 30 and 31 for completeness
(I think the only effect of setting `dist` to 0 by using a specially formatted
distance table would be that uninitialized data would be left in the output).

Another approach would be to check that len != 0 after line [4261](https://github.com/nothings/stb/blob/master/stb_image.h#L4261).
However, I think it's possible for 0 to appear as a valid literal value, 256,
in the fixed Huffman length table (RFC 1951 section 3.2.6 - or maybe
256 also represents "end of block" there?)

(This does not adjust the credits to avoid merge conflicts with PR #1223)

Some references used when checking that length codes 286 and 287 and distance
codes 30 and 31 are indeed invalid:

RFC 1951 (DEFLATE Compressed Data Format Specification) sections 3.2.5-3.2.7: https://datatracker.ietf.org/doc/html/rfc1951#page-11

* The tables in 3.2.5 present instructions for only length codes 0-285, and distance codes 0-29.

* Section 3.2.6 states

```
         Literal/length values 286-287 will never actually
         occur in the compressed data, but participate in the code
         construction.

         Distance codes 0-31 are represented by (fixed-length) 5-bit
         codes, with possible additional bits as shown in the table
         shown in Paragraph 3.2.5, above.  Note that distance codes 30-
         31 will never actually occur in the compressed data.
```

https://en.wikipedia.org/wiki/Deflate#Bit_reduction lists

```
286, 287: not used, reserved and illegal but still part of the tree.
```

and

```
30–31: not used, reserved and illegal but still part of the tree.
```

Thanks!