### PR TITLE
Add Laczos 3 filter to stb_image_resize

### DIFF
--- a/stb_image_resize.h
+++ b/stb_image_resize.h
@@ -157,6 +157,7 @@
       Sean Barrett: API design, optimizations
       Aras Pranckevicius: bugfix
       Nathan Reed: warning fixes
+      Ryhor Spivak: Lanczos 3 filter
 
    REVISIONS
       0.97 (2020-02-02) fixed warning


### PR DESCRIPTION
This adds Lanczos 3 filter. It may be useful for downscaling as it produce a bit sharper results than any other filter.