### PR TITLE
Forward declare stbhw__process struct to fix warnings

### DIFF
--- a/stb_herringbone_wang_tile.h
+++ b/stb_herringbone_wang_tile.h
@@ -366,6 +366,8 @@ STBHW_EXTERN const char *stbhw_get_last_error(void)
 //  need to try to do more sophisticated parsing of edge color
 //  markup or something.
 
+struct stbhw__process;
+
 typedef void stbhw__process_rect(struct stbhw__process *p, int xpos, int ypos,
                                  int a, int b, int c, int d, int e, int f);
 


### PR DESCRIPTION
`stb_herringbone_wang_tile.h` is currently producing warnings on `clang` and `gcc` relating to the `stbhw__process_rect` typedef. This includes when compiling the `herringbone_map.c` and `herringbone_generator.c` files in the `tests` directory.

This PR forward declares the struct which fixes those warnings.

Output of `clang -o herringbone_map herringbone_map.c -lm`:

```
In file included from herringbone_map.c:7:
./../stb_herringbone_wang_tile.h:369:41: warning: declaration of 'struct stbhw__process' will not be visible outside of this function [-Wvisibility]
typedef void stbhw__process_rect(struct stbhw__process *p, int xpos, int ypos,
                                        ^
./../stb_herringbone_wang_tile.h:401:43: warning: incompatible pointer types passing 'stbhw__process *' (aka 'struct stbhw__process *') to parameter of type 'struct stbhw__process *' [-Wincompatible-pointer-types]
                        p->process_h_rect(p, xpos, ypos, a,b,c,d,e,f);
                                          ^
./../stb_herringbone_wang_tile.h:425:43: warning: incompatible pointer types passing 'stbhw__process *' (aka 'struct stbhw__process *') to parameter of type 'struct stbhw__process *' [-Wincompatible-pointer-types]
                        p->process_v_rect(p, xpos, ypos, a,b,c,d,e,f);
                                          ^
./../stb_herringbone_wang_tile.h:929:21: warning: incompatible pointer types assigning to 'stbhw__process_rect *' (aka 'void (*)(struct stbhw__process *, int, int, int, int, int, int, int, int)') from 'void (stbhw__process *, int, int, int, int, int, int, int, int)' (aka 'void (struct stbhw__process *, int, int, int, int, int, int, int, int)') [-Wincompatible-pointer-types]
   p.process_h_rect = stbhw__parse_h_rect;
                    ^ ~~~~~~~~~~~~~~~~~~~
./../stb_herringbone_wang_tile.h:930:21: warning: incompatible pointer types assigning to 'stbhw__process_rect *' (aka 'void (*)(struct stbhw__process *, int, int, int, int, int, int, int, int)') from 'void (stbhw__process *, int, int, int, int, int, int, int, int)' (aka 'void (struct stbhw__process *, int, int, int, int, int, int, int, int)') [-Wincompatible-pointer-types]
   p.process_v_rect = stbhw__parse_v_rect;
                    ^ ~~~~~~~~~~~~~~~~~~~
./../stb_herringbone_wang_tile.h:1186:24: warning: incompatible pointer types assigning to 'stbhw__process_rect *' (aka 'void (*)(struct stbhw__process *, int, int, int, int, int, int, int, int)') from 'void (stbhw__process *, int, int, int, int, int, int, int, int)' (aka 'void (struct stbhw__process *, int, int, int, int, int, int, int, int)') [-Wincompatible-pointer-types]
      p.process_h_rect = stbhw__corner_process_h_rect;
                       ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./../stb_herringbone_wang_tile.h:1187:24: warning: incompatible pointer types assigning to 'stbhw__process_rect *' (aka 'void (*)(struct stbhw__process *, int, int, int, int, int, int, int, int)') from 'void (stbhw__process *, int, int, int, int, int, int, int, int)' (aka 'void (struct stbhw__process *, int, int, int, int, int, int, int, int)') [-Wincompatible-pointer-types]
      p.process_v_rect = stbhw__corner_process_v_rect;
                       ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./../stb_herringbone_wang_tile.h:1189:24: warning: incompatible pointer types assigning to 'stbhw__process_rect *' (aka 'void (*)(struct stbhw__process *, int, int, int, int, int, int, int, int)') from 'void (stbhw__process *, int, int, int, int, int, int, int, int)' (aka 'void (struct stbhw__process *, int, int, int, int, int, int, int, int)') [-Wincompatible-pointer-types]
      p.process_h_rect = stbhw__edge_process_h_rect;
                       ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~
./../stb_herringbone_wang_tile.h:1190:24: warning: incompatible pointer types assigning to 'stbhw__process_rect *' (aka 'void (*)(struct stbhw__process *, int, int, int, int, int, int, int, int)') from 'void (stbhw__process *, int, int, int, int, int, int, int, int)' (aka 'void (struct stbhw__process *, int, int, int, int, int, int, int, int)') [-Wincompatible-pointer-types]
      p.process_v_rect = stbhw__edge_process_v_rect;
                       ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~
9 warnings generated.
```

Output of `clang --version`:
```
clang version 10.0.0-4ubuntu1
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```

`gcc` outputs a similar set of warnings but `gcc` appears not to have a flag to silence the first warning.