### PR TITLE
stb_image: new define to allow compilation for wasm32 target

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -380,7 +380,9 @@ enum
    STBI_rgb_alpha  = 4
 };
 
+#ifndef STBI_WASM
 #include <stdlib.h>
+#endif
 typedef unsigned char stbi_uc;
 typedef unsigned short stbi_us;
 
@@ -583,8 +585,10 @@ STBIDEF int   stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const ch
 
 #include <stdarg.h>
 #include <stddef.h> // ptrdiff_t on osx
+#ifndef STBI_WASM
 #include <stdlib.h>
 #include <string.h>
+#endif
 #include <limits.h>
 
 #if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR)


### PR DESCRIPTION
This lets us use std image when we target wasm32 without emscripten, therefore without libc