### PR TITLE
Edit for MSVC

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -770,7 +770,7 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
       char header[] = "#?RADIANCE\n# Written by stb_image_write.h\nFORMAT=32-bit_rle_rgbe\n";
       s->func(s->context, header, sizeof(header)-1);
 
-#ifdef __STDC_LIB_EXT1__
+#if defined(__STDC_LIB_EXT1__) || _MSC_VER >= 1400 
       len = sprintf_s(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #else
       len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);


### PR DESCRIPTION
Suppress _CRT_SECURE_NO_WARNINGS warning for MSVC.