### PR TITLE
stb_image: fix function name

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -4955,7 +4955,7 @@ STBIDEF void stbi_convert_iphone_png_to_rgb(int flag_true_if_should_convert)
 static STBI_THREAD_LOCAL int stbi__unpremultiply_on_load_local, stbi__unpremultiply_on_load_set;
 static STBI_THREAD_LOCAL int stbi__de_iphone_flag_local, stbi__de_iphone_flag_set;
 
-STBIDEF void stbi__unpremultiply_on_load_thread(int flag_true_if_should_unpremultiply)
+STBIDEF void stbi_set_unpremultiply_on_load_thread(int flag_true_if_should_unpremultiply)
 {
    stbi__unpremultiply_on_load_local = flag_true_if_should_unpremultiply;
    stbi__unpremultiply_on_load_set = 1;


### PR DESCRIPTION
i'm assuming it was a typo. fixes the following warning:

```
stb_image.h:4958:14: warning: no previous prototype for 'stbi__unpremultiply_on_load_thread' [-Wmissing-prototypes]
 4958 | STBIDEF void stbi__unpremultiply_on_load_thread(int flag_true_if_should_unpremultiply)
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```