### PR TITLE
Remove sz cast to int in stb_leakcheck_malloc.

### DIFF
--- a/stb_leakcheck.h
+++ b/stb_leakcheck.h
@@ -44,7 +44,7 @@ void *stb_leakcheck_malloc(size_t sz, const char *file, int line)
    if (mi_head)
       mi->next->prev = mi;
    mi->prev = NULL;
-   mi->size = (int) sz;
+   mi->size = sz;
    mi_head = mi;
    return mi+1;
 }


### PR DESCRIPTION
Casting sz to an int before storing it in mi->size is flagged as a warning with -Wconversion.
Very new to the STB libraries, so forgive me if I'm missing something.