### PR TITLE
Extend Mapping submap_floor and submap_residue arrays.

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -752,11 +752,11 @@ typedef struct
 
 typedef struct
 {
-   uint16 coupling_steps;
    MappingChannel *chan;
+   uint16 coupling_steps;
    uint8  submaps;
-   uint8  submap_floor[15]; // varies
-   uint8  submap_residue[15]; // varies
+   uint8  submap_floor[16]; // varies
+   uint8  submap_residue[16]; // varies
 } Mapping;
 
 typedef struct


### PR DESCRIPTION
The submap arrays in `Mapping` are size 15, but should be size 16. The number of submap entries is [in the range [1,16]](https://github.com/nothings/stb/blob/af1a5bc352164740c1cc1354942b1c6b72eacb8a/stb_vorbis.c#L4075) and the mux values that these arrays are indexed by are [in the range [0,15]](https://github.com/nothings/stb/blob/af1a5bc352164740c1cc1354942b1c6b72eacb8a/stb_vorbis.c#L4098), as long as they are less than the submap count. [Per the Vorbis spec](https://xiph.org/vorbis/doc/Vorbis_I_spec.html#x1-650004.2.4), these ranges are correct, and nothing indicates that submap 15 should be considered invalid.

Also moves `Mapping::chan` to the front of `Mapping` to reduce the padding overhead of this struct to what it was before expanding the submap arrays.

Found with clang's UndefinedBehaviorSanitizer. Load any of these fuzz files in an stb_vorbis build with UndefinedBehaviorSanitizer enabled, and errors similar to the following should be generated:
```
stb_vorbis.c:4128:10: runtime error: index 15 out of bounds for type 'uint8 [15]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior stb_vorbis.c:4128:10 in 
stb_vorbis.c:4129:10: runtime error: index 15 out of bounds for type 'uint8 [15]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior stb_vorbis.c:4129:10 in 
stb_vorbis.c:4130:14: runtime error: index 15 out of bounds for type 'uint8 [15]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior stb_vorbis.c:4130:14 in 
stb_vorbis.c:4131:14: runtime error: index 15 out of bounds for type 'uint8 [15]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior stb_vorbis.c:4131:14 in 
```
[OGG_submap_15.tar.gz](https://github.com/nothings/stb/files/8258656/OGG_submap_15.tar.gz)