### PR TITLE
stb_image.h: add QOI support

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -7632,14 +7632,16 @@ static void *stbi__qoi_load(stbi__context *s, int *x, int *y, int *comp, int req
             break;
 
          if (s->img_n == 3) {
-            for (int i = 0; i < run; i++) {
+            int i;
+            for (i = 0; i < run; i++) {
                *dst++ = c >> 24;
                *dst++ = c >> 16;
                *dst++ = c >> 8;
             }
          }
          else {
-            for (int i = 0; i < run; i++) {
+            int i;
+            for (i = 0; i < run; i++) {
                *dst++ = c >> 24;
                *dst++ = c >> 16;
                *dst++ = c >> 8;


### PR DESCRIPTION
This commit adds support for loading QOI images with stb_image.h. Not sure if this is on the cards right now, given that QOI isn't too time-consuming to implement for one's own projects, and that several libraries already exist that support it. If not, feel free to ignore this PR - at the very least it was a fun exercise!