### PR TITLE
stb_truetype: allow user defined STBTT_DEF

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -499,10 +499,12 @@ int main(int arg, char **argv)
 #ifndef __STB_INCLUDE_STB_TRUETYPE_H__
 #define __STB_INCLUDE_STB_TRUETYPE_H__
 
+#ifndef STBTT_DEF
 #ifdef STBTT_STATIC
 #define STBTT_DEF static
 #else
 #define STBTT_DEF extern
+#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Allow users to define their own STBTT_DEF.
Other headers such as stb_image.h and stb_image_write.h have a similar
mechanism. I ran into a "STBTT_DEF redefined" compiler warning and
figured that stb_truetype.h does not check if STBTT_DEF is defined.
