### PR TITLE
Provide type definitions for Symbian OS/EPOC, #1321

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -635,7 +635,7 @@ STBIDEF int   stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const ch
    #endif
 #endif
 
-#if defined (_MSC_VER) || defined __SYMBIAN32__
+#if defined (_MSC_VER) || defined (__SYMBIAN32__)
 typedef unsigned short stbi__uint16;
 typedef   signed short stbi__int16;
 typedef unsigned int   stbi__uint32;

--- a/stb_image.h
+++ b/stb_image.h
@@ -635,7 +635,7 @@ STBIDEF int   stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const ch
    #endif
 #endif
 
-#ifdef _MSC_VER
+#if defined (_MSC_VER) || defined __SYMBIAN32__
 typedef unsigned short stbi__uint16;
 typedef   signed short stbi__int16;
 typedef unsigned int   stbi__uint32;


### PR DESCRIPTION
The Symbian S60v1 SDK does not provide `stdint.h`.
This additional preprocessor definition ensures that the required types are provided so that `stb_image.h` also compiles on this legacy system.

This modification is intended for use with the [N-Gage SDK.](https://github.com/ngagesdk)-project.

No additional credit required.