### PR TITLE
stb_image: add trailing semicolon in usage example

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -140,7 +140,7 @@ RECENT REVISION HISTORY:
 //    // ... x = width, y = height, n = # 8-bit components per pixel ...
 //    // ... replace '0' with '1'..'4' to force that many components per pixel
 //    // ... but 'n' will always be the number that it would have been if you said 0
-//    stbi_image_free(data)
+//    stbi_image_free(data);
 //
 // Standard parameters:
 //    int *x                 -- outputs image width in pixels


### PR DESCRIPTION
Tiny little one-char change to stop the basic usage example from throwing a missing-semicolon error. This one's bugged me for years, I always end up metaphorically stubbing my toe on it, each time I copy-paste the usage example into my own code.

Also wasn't sure whereabouts in the credits to put my name, or if such a tiny change even warrants it, let me know :)