### PR TITLE
Added missing fclose in stb_include.h

### DIFF
--- a/stb_include.h
+++ b/stb_include.h
@@ -33,6 +33,7 @@
 //
 // Fixes:
 //  Michal Klos
+//  Francesco Cozzuto
 
 #ifndef STB_INCLUDE_STB_INCLUDE_H
 #define STB_INCLUDE_STB_INCLUDE_H
@@ -66,7 +67,10 @@ static char *stb_include_load_file(char *filename, size_t *plen)
    len = (size_t) ftell(f);
    if (plen) *plen = len;
    text = (char *) malloc(len+1);
-   if (text == 0) return 0;
+   if (text == 0) {
+      fclose(f);
+      return 0;
+   }
    fseek(f, 0, SEEK_SET);
    fread(text, 1, len, f);
    fclose(f);


### PR DESCRIPTION
The "stb_include_load_file" function in "stb_include.h" leaks the file descriptor in case of malloc failure. I just added the missing fclose call before the early return statement