### PR TITLE
Support implicit r and rg channel loading, only convert to luma then explicitly done.

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -164,11 +164,13 @@ RECENT REVISION HISTORY:
 // An output image with N components has the following components interleaved
 // in this order in each pixel:
 //
-//     N=#comp     components
-//       1           grey
-//       2           grey, alpha
-//       3           red, green, blue
-//       4           red, green, blue, alpha
+//     N=#comp            components
+//       1                  red
+//       2                  red, green
+//       3                  red, green, blue
+//       4                  red, green, blue, alpha
+//       STBI_grey          grey
+//       STBI_grey_alpha    grey, alpha
 //
 // If image loading fails for any reason, the return value will be NULL,
 // and *x, *y, *channels_in_file will be unchanged. The function
@@ -374,10 +376,12 @@ enum
 {
    STBI_default = 0, // only used for desired_channels
 
-   STBI_grey       = 1,
-   STBI_grey_alpha = 2,
+   STBI_r          = 1,
+   STBI_rg         = 2
    STBI_rgb        = 3,
    STBI_rgb_alpha  = 4
+   STBI_grey       = 1 << 8,
+   STBI_grey_alpha = 2 << 8,
 };
 
 #include <stdlib.h>
@@ -1750,23 +1754,26 @@ static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int r
       unsigned char *src  = data + j * x * img_n   ;
       unsigned char *dest = good + j * x * req_comp;
 
-      #define STBI__COMBO(a,b)  ((a)*8+(b))
+      #define STBI__COMBO(a,b)  (((a)<<16)&(b))
       #define STBI__CASE(a,b)   case STBI__COMBO(a,b): for(i=x-1; i >= 0; --i, src += a, dest += b)
       // convert source image with img_n components to one with req_comp components;
       // avoid switch per pixel, so use switch per scanline and massive macros
       switch (STBI__COMBO(img_n, req_comp)) {
-         STBI__CASE(1,2) { dest[0]=src[0]; dest[1]=255;                                     } break;
-         STBI__CASE(1,3) { dest[0]=dest[1]=dest[2]=src[0];                                  } break;
-         STBI__CASE(1,4) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=255;                     } break;
-         STBI__CASE(2,1) { dest[0]=src[0];                                                  } break;
-         STBI__CASE(2,3) { dest[0]=dest[1]=dest[2]=src[0];                                  } break;
-         STBI__CASE(2,4) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=src[1];                  } break;
-         STBI__CASE(3,4) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];dest[3]=255;        } break;
-         STBI__CASE(3,1) { dest[0]=stbi__compute_y(src[0],src[1],src[2]);                   } break;
-         STBI__CASE(3,2) { dest[0]=stbi__compute_y(src[0],src[1],src[2]); dest[1] = 255;    } break;
-         STBI__CASE(4,1) { dest[0]=stbi__compute_y(src[0],src[1],src[2]);                   } break;
-         STBI__CASE(4,2) { dest[0]=stbi__compute_y(src[0],src[1],src[2]); dest[1] = src[3]; } break;
-         STBI__CASE(4,3) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];                    } break;
+         STBI__CASE(1,2                 ) { dest[0]=src[0]; dest[1]=255;                                     } break;
+         STBI__CASE(1,3                 ) { dest[0]=dest[1]=dest[2]=src[0];                                  } break;
+         STBI__CASE(1,4                 ) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=255;                     } break;
+         STBI__CASE(2,1                 ) { dest[0]=src[0];                                                  } break;
+         STBI__CASE(2,3                 ) { dest[0]=dest[1]=dest[2]=src[0];                                  } break;
+         STBI__CASE(2,4                 ) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=src[1];                  } break;
+         STBI__CASE(3,1                 ) { dest[0]=src[0];                                                  } break;
+         STBI__CASE(3,2                 ) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];dest[3]=255;        } break;
+         STBI__CASE(4,1                 ) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];dest[3]=255;        } break;
+         STBI__CASE(4,2                 ) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];dest[3]=255;        } break;
+         STBI__CASE(4,3                 ) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];                    } break;
+         STBI__CASE(3,STBI_grey         ) { dest[0]=stbi__compute_y(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(3,STBI_grey_alpha   ) { dest[0]=stbi__compute_y(src[0],src[1],src[2]); dest[1] = 255;    } break;
+         STBI__CASE(4,STBI_grey         ) { dest[0]=stbi__compute_y(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(4,STBI_grey_alpha   ) { dest[0]=stbi__compute_y(src[0],src[1],src[2]); dest[1] = src[3]; } break;
          default: STBI_ASSERT(0); STBI_FREE(data); STBI_FREE(good); return stbi__errpuc("unsupported", "Unsupported format conversion");
       }
       #undef STBI__CASE

--- a/stb_image.h
+++ b/stb_image.h
@@ -108,7 +108,7 @@ RECENT REVISION HISTORY:
     Cass Everitt            Ryamond Barbiero                        github:grim210
     Paul Du Bois            Engin Manap        Aldo Culquicondor    github:sammyhw
     Philipp Wiesemann       Dale Weiler        Oriol Ferrer Mesia   github:phprus
-    Josh Tobin                                 Matthew Gregan       github:poppolopoppo
+    Josh Tobin              Timothy Lochner    Matthew Gregan       github:poppolopoppo
     Julian Raschke          Gregory Mullen     Christian Floisand   github:darealshinji
     Baldur Karlsson         Kevin Schmidt      JR Smith             github:Michaelangel007
                             Brad Weinberger    Matvey Cherevko      github:mosra
@@ -377,11 +377,13 @@ enum
    STBI_default = 0, // only used for desired_channels
 
    STBI_r          = 1,
-   STBI_rg         = 2
+   STBI_rg         = 2,
    STBI_rgb        = 3,
-   STBI_rgb_alpha  = 4
-   STBI_grey       = 1 << 8,
-   STBI_grey_alpha = 2 << 8,
+   STBI_rgb_alpha  = 4,
+   STBI_grey       = STBI_luma_bit | 1,
+   STBI_grey_alpha = STBI_luma_bit | 2,
+
+   STBI_luma_bit = 1 << 8, // 
 };
 
 #include <stdlib.h>
@@ -1766,9 +1768,9 @@ static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int r
          STBI__CASE(2,3                 ) { dest[0]=dest[1]=dest[2]=src[0];                                  } break;
          STBI__CASE(2,4                 ) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=src[1];                  } break;
          STBI__CASE(3,1                 ) { dest[0]=src[0];                                                  } break;
-         STBI__CASE(3,2                 ) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];dest[3]=255;        } break;
-         STBI__CASE(4,1                 ) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];dest[3]=255;        } break;
-         STBI__CASE(4,2                 ) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];dest[3]=255;        } break;
+         STBI__CASE(3,2                 ) { dest[0]=src[0];dest[1]=src[1];                                   } break;
+         STBI__CASE(4,1                 ) { dest[0]=src[0];                                                  } break;
+         STBI__CASE(4,2                 ) { dest[0]=src[0];dest[1]=src[1];                                   } break;
          STBI__CASE(4,3                 ) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];                    } break;
          STBI__CASE(3,STBI_grey         ) { dest[0]=stbi__compute_y(src[0],src[1],src[2]);                   } break;
          STBI__CASE(3,STBI_grey_alpha   ) { dest[0]=stbi__compute_y(src[0],src[1],src[2]); dest[1] = 255;    } break;
@@ -1814,23 +1816,26 @@ static stbi__uint16 *stbi__convert_format16(stbi__uint16 *data, int img_n, int r
       stbi__uint16 *src  = data + j * x * img_n   ;
       stbi__uint16 *dest = good + j * x * req_comp;
 
-      #define STBI__COMBO(a,b)  ((a)*8+(b))
+      #define STBI__COMBO(a,b)  (((a)<<16)&(b))
       #define STBI__CASE(a,b)   case STBI__COMBO(a,b): for(i=x-1; i >= 0; --i, src += a, dest += b)
       // convert source image with img_n components to one with req_comp components;
       // avoid switch per pixel, so use switch per scanline and massive macros
       switch (STBI__COMBO(img_n, req_comp)) {
-         STBI__CASE(1,2) { dest[0]=src[0]; dest[1]=0xffff;                                     } break;
-         STBI__CASE(1,3) { dest[0]=dest[1]=dest[2]=src[0];                                     } break;
-         STBI__CASE(1,4) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=0xffff;                     } break;
-         STBI__CASE(2,1) { dest[0]=src[0];                                                     } break;
-         STBI__CASE(2,3) { dest[0]=dest[1]=dest[2]=src[0];                                     } break;
-         STBI__CASE(2,4) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=src[1];                     } break;
-         STBI__CASE(3,4) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];dest[3]=0xffff;        } break;
-         STBI__CASE(3,1) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]);                   } break;
-         STBI__CASE(3,2) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]); dest[1] = 0xffff; } break;
-         STBI__CASE(4,1) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]);                   } break;
-         STBI__CASE(4,2) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]); dest[1] = src[3]; } break;
-         STBI__CASE(4,3) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];                       } break;
+         STBI__CASE(1,2                 ) { dest[0]=src[0]; dest[1]=255;                                     } break;
+         STBI__CASE(1,3                 ) { dest[0]=dest[1]=dest[2]=src[0];                                  } break;
+         STBI__CASE(1,4                 ) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=255;                     } break;
+         STBI__CASE(2,1                 ) { dest[0]=src[0];                                                  } break;
+         STBI__CASE(2,3                 ) { dest[0]=dest[1]=dest[2]=src[0];                                  } break;
+         STBI__CASE(2,4                 ) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=src[1];                  } break;
+         STBI__CASE(3,1                 ) { dest[0]=src[0];                                                  } break;
+         STBI__CASE(3,2                 ) { dest[0]=src[0];dest[1]=src[1];                                   } break;
+         STBI__CASE(4,1                 ) { dest[0]=src[0];                                                  } break;
+         STBI__CASE(4,2                 ) { dest[0]=src[0];dest[1]=src[1];                                   } break;
+         STBI__CASE(4,3                 ) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];                    } break;
+         STBI__CASE(3,STBI_grey         ) { dest[0]=stbi__compute_y(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(3,STBI_grey_alpha   ) { dest[0]=stbi__compute_y(src[0],src[1],src[2]); dest[1] = 255;    } break;
+         STBI__CASE(4,STBI_grey         ) { dest[0]=stbi__compute_y(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(4,STBI_grey_alpha   ) { dest[0]=stbi__compute_y(src[0],src[1],src[2]); dest[1] = src[3]; } break;
          default: STBI_ASSERT(0); STBI_FREE(data); STBI_FREE(good); return (stbi__uint16*) stbi__errpuc("unsupported", "Unsupported format conversion");
       }
       #undef STBI__CASE
@@ -5670,8 +5675,8 @@ static int stbi__tga_get_comp(int bits_per_pixel, int is_grey, int* is_rgb16)
    // only RGB or RGBA (incl. 16bit) or grey allowed
    if (is_rgb16) *is_rgb16 = 0;
    switch(bits_per_pixel) {
-      case 8:  return STBI_grey;
-      case 16: if(is_grey) return STBI_grey_alpha;
+      case 8:  return STBI_r;
+      case 16: if(is_grey) return STBI_rg;
                // fallthrough
       case 15: if(is_rgb16) *is_rgb16 = 1;
                return STBI_rgb;


### PR DESCRIPTION
In the age of PBR, the common case is not to load images with luma conversion. This PR makes it so that when supplying numerical integers 1...4 to the `desired_channels` argument, no additional operations are done. `STBI_grey` and `STBI_grey_alpha` have been moved to new identifiers where a special bit is set to identify them, while `STBI_r` and `STBI_rg` have taken their place. In this way, `STBI_grey` and `STBI_grey_alpha` now hints to the `desired_channels` argument that the user would like a luma conversion done.

Rational:
1.  Textures related to PBR assets often come with occlusion, roughness, and metallic packed into the r, g, and b channels. When you want to only grab the r and g channels (as asset authors often put all 1 or all 0 in the b channel if it is effectively unused), stb_image confusingly will do a luma conversion.
2. Performing a luma conversion in the case of 1 or 2 required channels goes against the law of least surprise.
3. Performing a luma calculation is additional work, and strictly speaking unrelated to the isolated goal of loading images. It's common to make such conversion operations at other times in asset creation.
4. OpenGL deprecated GL_LUMINANCE and co. in 2008 with OpenGL 3.0, then dropped them entirely a year later. The recommendation from OpenGL is to use R8, RG8, R16, or RG16 instead. This change follows that guideline.