### PR TITLE
stb_image: Fix "unused invalid_chunk" with STBI_FAILURE_USERMSG

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -5178,7 +5178,7 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
             // if critical, fail
             if (first) return stbi__err("first not IHDR", "Corrupt PNG");
             if ((c.type & (1 << 29)) == 0) {
-               #ifndef STBI_NO_FAILURE_STRINGS
+               #if !defined(STBI_NO_FAILURE_STRINGS) && !defined(STBI_FAILURE_USERMSG)
                // not threadsafe
                static char invalid_chunk[] = "XXXX PNG chunk not known";
                invalid_chunk[0] = STBI__BYTECAST(c.type >> 24);


### PR DESCRIPTION
If `STBI_FAILURE_USERMSG` is set, GCC warns:

```
stb_image.h:5183:28: warning: variable ‘invalid_chunk’ set but not used [-Wunused-but-set-variable]
    static char invalid_chunk[] = "XXXX PNG chunk not known";
```

Add STBI_FAILURE_USERMSG to the ifndef condition that disables the section (along with STBI_NO_FAILURE_STRINGS).

---

Note: I don't need (and weakly don't want) to be added to the contributor's list. I don't care about attribution.