### PR TITLE
stb_image: Fix gif two_back memory address

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -113,7 +113,7 @@ RECENT REVISION HISTORY:
     Baldur Karlsson         Kevin Schmidt      JR Smith             github:Michaelangel007
                             Brad Weinberger    Matvey Cherevko      github:mosra
     Luca Sas                Alexander Veselov  Zack Middleton       [reserved]
-    Ryan C. Gordon          [reserved]                              [reserved]
+    Ryan C. Gordon          Cocoa Xu                                [reserved]
                      DO NOT ADD YOUR NAME HERE
 
                      Jacko Dirks

--- a/stb_image.h
+++ b/stb_image.h
@@ -6942,7 +6942,7 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
             }
             memcpy( out + ((layers - 1) * stride), u, stride );
             if (layers >= 2) {
-               two_back = out - 2 * stride;
+               two_back = out + ((layers - 2) * stride);
             }
 
             if (delays) {


### PR DESCRIPTION
Hi, this should be a simple fix: since `out` is always the starting address, `two_back` should be calculated as follows,

```c
if (layers >= 2) {
    two_back = out + ((layers - 2) * stride);
}
```

otherwise, it would cause a segmentation fault.

Testing image [test_alpha.gif.zip](https://github.com/nothings/stb/files/9945209/test_alpha.gif.zip)