### PR TITLE
stb_sprintf.h - add declspec for no-sanitize-address on msvc >= 2015

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -158,6 +158,8 @@ PERFORMANCE vs MSVC 2008 32-/64-bit (GCC is even slower than MSVC):
  #if defined(__SANITIZE_ADDRESS__) && __SANITIZE_ADDRESS__
   #define STBSP__ASAN __attribute__((__no_sanitize_address__))
  #endif
+#elif defined(_MSC_VER) && (_MSC_VER >= 1900)
+ #define STBSP__ASAN __declspec(no_sanitize_address)
 #endif
 
 #ifndef STBSP__ASAN


### PR DESCRIPTION
I was using ASAN: https://learn.microsoft.com/en-us/cpp/sanitizers/asan-building?view=msvc-170#__declspecno_sanitize_address
with msvc recently, and I got a bunch of complaints from it pointing fingers at `stb_sprintf`. There is some code in there that's intentionally reading past a buffer by 3 bytes.

There existed some `#define`'s for other compilers to ignore this overrun when they are in address-sanitizer-enabled-mode, but it was missing for msvc. I can find documentation for `__declspec(no_sanitize_address)` at least as far back as VS 2015, so that's what I've checked here, but it maybe could be more lax than that, I didn't dig super deeply. 