### PR TITLE
stb_image: Improve error reporting if file operations fail within *_from_file functions.

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -1361,7 +1361,12 @@ STBIDEF stbi_uc *stbi_load_from_file(FILE *f, int *x, int *y, int *comp, int req
    result = stbi__load_and_postprocess_8bit(&s,x,y,comp,req_comp);
    if (result) {
       // need to 'unget' all the characters in the IO buffer
-      fseek(f, - (int) (s.img_buffer_end - s.img_buffer), SEEK_CUR);
+      if (fseek(f, -(int)(s.img_buffer_end - s.img_buffer), SEEK_CUR) != 0) {
+         // fseek() failed; we can no longer maintain the file cursor position
+         // guarantee of this function, so return null.
+         STBI_FREE(result);
+         return stbi__errpuc("bad file", "fseek() failed; seek position unreliable");
+      }
    }
    return result;
 }
@@ -1374,7 +1379,12 @@ STBIDEF stbi__uint16 *stbi_load_from_file_16(FILE *f, int *x, int *y, int *comp,
    result = stbi__load_and_postprocess_16bit(&s,x,y,comp,req_comp);
    if (result) {
       // need to 'unget' all the characters in the IO buffer
-      fseek(f, - (int) (s.img_buffer_end - s.img_buffer), SEEK_CUR);
+      if (fseek(f, -(int)(s.img_buffer_end - s.img_buffer), SEEK_CUR) != 0) {
+         // fseek() failed; we can no longer maintain the file cursor position
+         // guarantee of this function, so return null.
+         STBI_FREE(result);
+         return (stbi__uint16 *) stbi__errpuc("bad file", "fseek() failed; seek position unreliable");
+      }
    }
    return result;
 }
@@ -1522,12 +1532,13 @@ STBIDEF int      stbi_is_hdr          (char const *filename)
 STBIDEF int stbi_is_hdr_from_file(FILE *f)
 {
    #ifndef STBI_NO_HDR
-   long pos = ftell(f);
    int res;
+   long pos = ftell(f);
+   if (pos < 0) return stbi__err("bad file", "ftell() failed");
    stbi__context s;
    stbi__start_file(&s,f);
    res = stbi__hdr_test(&s);
-   fseek(f, pos, SEEK_SET);
+   if (fseek(f, pos, SEEK_SET) != 0) return stbi__err("bad file", "fseek() failed");
    return res;
    #else
    STBI_NOTUSED(f);
@@ -7612,9 +7623,10 @@ STBIDEF int stbi_info_from_file(FILE *f, int *x, int *y, int *comp)
    int r;
    stbi__context s;
    long pos = ftell(f);
+   if (pos < 0) return stbi__err("bad file", "ftell() failed");
    stbi__start_file(&s, f);
    r = stbi__info_main(&s,x,y,comp);
-   fseek(f,pos,SEEK_SET);
+   if (fseek(f, pos, SEEK_SET) != 0) return stbi__err("bad file", "fseek() failed");
    return r;
 }
 
@@ -7633,9 +7645,10 @@ STBIDEF int stbi_is_16_bit_from_file(FILE *f)
    int r;
    stbi__context s;
    long pos = ftell(f);
+   if (pos < 0) return stbi__err("bad file", "ftell() failed");
    stbi__start_file(&s, f);
    r = stbi__is_16_main(&s);
-   fseek(f,pos,SEEK_SET);
+   if (fseek(f, pos, SEEK_SET) != 0) return stbi__err("bad file", "fseek() failed");
    return r;
 }
 #endif // !STBI_NO_STDIO


### PR DESCRIPTION
Within the stb_image `*_from_file()` APIs, several of the calls to `ftell()` and `fseek()` responsible for resetting the file position don't check for returned error codes. This merge request adds error checks to these calls.

The main goal of this merge request for me is to fix a few warnings from our static analysis tool. It's difficult but possible to get these calls to fail even if the file's been successfully opened: for instance, imagine another process deletes the file or obtains an exclusive lock to the file - or say the file's on a flash drive that's unplugged at just the right time.

In `stbi_load_from_file()` and `stbi_load_from_file_16()`, the effect is that the function's guarantee that

```
// for stbi_load_from_file, file pointer is left pointing immediately after image
```

breaks; the file could still be readable, but not returning an error when the file position is unknown could lead to trouble if an application uses the `FILE` pointer afterwards.

In `stbi_is_hdr_from_file()`, `stbi_info_from_file()`, and `stbi_is_16_bit_from_file()`, the return value from `ftell()` — which is negative if `ftell()` produced an error — is passed to `fseek(..., SEEK_SET)`. The ensuing behavior of `fseek()` when called to set a negative seek position probably depends on the C library implementation; [Watcom's version of the specification, for instance, prohibits this](https://open-watcom.github.io/open-watcom-v2-wikidocs/clib.html#fseek).

(This does not adjust the credits to avoid merge conflicts with PR https://github.com/nothings/stb/pull/1223).

Thanks!