### PR TITLE
stb_truetype: Add missing `return` keyword

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -54,7 +54,7 @@
 //       Hou Qiming                 Derek Vinyard
 //       Rob Loach                  Cort Stratton
 //       Kenney Phillis Jr.         Brian Costabile
-//       Ken Voskuil (kaesve)
+//       Ken Voskuil (kaesve)       Neil Bickford
 //
 // VERSION HISTORY
 //
@@ -2003,7 +2003,7 @@ static stbtt__buf stbtt__cid_get_glyph_subrs(const stbtt_fontinfo *info, int gly
          start = end;
       }
    }
-   if (fdselector == -1) stbtt__new_buf(NULL, 0);
+   if (fdselector == -1) return stbtt__new_buf(NULL, 0);
    return stbtt__get_subrs(info->cff, stbtt__cff_index_get(info->fontdicts, fdselector));
 }
 


### PR DESCRIPTION
Hi stb maintainers! Here's one more pull request: in stb_truetype.h, `stbtt__cid_get_glyph_subrs()` creates a null `stbtt__buf` on an invalid format or glyph as if to return an error, but discards the result. This pull request adds the keyword to return it.

Thanks!