### PR TITLE
I updated stale code in STB_C_LEX_ISWHITE

### DIFF
--- a/stb_c_lexer.h
+++ b/stb_c_lexer.h
@@ -501,12 +501,12 @@ int stb_c_lexer_get_token(stb_lexer *lexer)
    // skip whitespace and comments
    for (;;) {
       #ifdef STB_C_LEX_ISWHITE
-      while (p != lexer->stream_end) {
+      while (p != lexer->eof) {
          int n;
          n = STB_C_LEX_ISWHITE(p);
          if (n == 0) break;
          if (lexer->eof && lexer->eof - lexer->parse_point < n)
-            return stb__clex_token(tok, CLEX_parse_error, p,lexer->eof-1);
+            return stb__clex_token(lexer, CLEX_parse_error, p,lexer->eof-1);
          p += n;
       }
       #else


### PR DESCRIPTION
It looks like some stale code was left in the ifdef for STB_C_LEX_ISWHITE.  The changes worked for me with this definition of isWhite in the file I'm using the library from:

```
#define STB_C_LEXER_IMPLEMENTATION
int myWhite(char *c){
    return (*c == ' ' || *c == '\t' || *c == '\f');
}
#define STB_C_LEX_ISWHITE(x) myWhite(x)
#include "stb_c_lexer.h"
```