### PR TITLE
Bug fix: parsing a character literal consumes extra input character

### DIFF
--- a/stb_c_lexer.h
+++ b/stb_c_lexer.h
@@ -671,7 +671,7 @@ int stb_c_lexer_get_token(stb_lexer *lexer)
                return stb__clex_token(lexer, CLEX_parse_error, start,start);
             if (p == lexer->eof || *p != '\'')
                return stb__clex_token(lexer, CLEX_parse_error, start,p);
-            return stb__clex_token(lexer, CLEX_charlit, start, p+1);
+            return stb__clex_token(lexer, CLEX_charlit, start, p);
          })
          goto single_char;
 


### PR DESCRIPTION
When lexing a character literal, the character immediately after the closing quote would be skipped over. This fixes that issue. 

Reproducing example: put the following in a file, and try lexing it. You won't get the ')' token.
```
'-')
```