### PR TITLE
stb_ds: Support environments without realloc

### DIFF
--- a/stb_ds.h
+++ b/stb_ds.h
@@ -41,8 +41,8 @@ COMPILE-TIME OPTIONS
      hash table insertion about 20% slower on 4- and 8-byte keys, 5% slower on
      64-byte keys, and 10% slower on 256-byte keys on my test computer.
 
-  #define STBDS_REALLOC(context,ptr,size) better_realloc
-  #define STBDS_FREE(context,ptr)         better_free
+  #define STBDS_REALLOC(context,ptr,new_size,size_in_use) better_realloc
+  #define STBDS_FREE(context,ptr)                         better_free
 
      These defines only need to be set in the file containing #define STB_DS_IMPLEMENTATION.
 
@@ -371,6 +371,7 @@ CREDITS
   Per Vognsen  -- idea for hash table API/implementation
   Rafael Sachetto -- arrpop()
   github:HeroicKatora -- arraddn() reworking
+  Noah Greenberg -- support environments without realloc
 
   Bugfixes:
     Andy Durdin
@@ -457,8 +458,8 @@ CREDITS
 #endif
 #if !defined(STBDS_REALLOC) && !defined(STBDS_FREE)
 #include <stdlib.h>
-#define STBDS_REALLOC(c,p,s) realloc(p,s)
-#define STBDS_FREE(c,p)      free(p)
+#define STBDS_REALLOC(context,ptr,new_size,size_in_use) realloc(ptr,new_size)
+#define STBDS_FREE(context,ptr)                         free(ptr)
 #endif
 
 #ifdef _MSC_VER
@@ -782,7 +783,9 @@ void *stbds_arrgrowf(void *a, size_t elemsize, size_t addlen, size_t min_cap)
   //if (num_prev < 65536) if (a) prev_allocs[num_prev++] = (int *) ((char *) a+1);
   //if (num_prev == 2201)
   //  num_prev = num_prev;
-  b = STBDS_REALLOC(NULL, (a) ? stbds_header(a) : 0, elemsize * min_cap + sizeof(stbds_array_header));
+  const size_t new_size = elemsize * min_cap + sizeof(stbds_array_header);
+  const size_t size_in_use = (a) ? (elemsize * stbds_arrlen(a) + sizeof(stbds_array_header)) : 0;
+  b = STBDS_REALLOC(NULL, (a) ? stbds_header(a) : NULL, new_size, size_in_use);
   //if (num_prev < 65536) prev_allocs[num_prev++] = (int *) (char *) b;
   b = (char *) b + sizeof(stbds_array_header);
   if (a == NULL) {
@@ -884,7 +887,7 @@ static size_t stbds_log2(size_t slot_count)
 static stbds_hash_index *stbds_make_hash_index(size_t slot_count, stbds_hash_index *ot)
 {
   stbds_hash_index *t;
-  t = (stbds_hash_index *) STBDS_REALLOC(NULL,0,(slot_count >> STBDS_BUCKET_SHIFT) * sizeof(stbds_hash_bucket) + sizeof(stbds_hash_index) + STBDS_CACHE_LINE_SIZE-1);
+  t = (stbds_hash_index *) STBDS_REALLOC(NULL,0,(slot_count >> STBDS_BUCKET_SHIFT) * sizeof(stbds_hash_bucket) + sizeof(stbds_hash_index) + STBDS_CACHE_LINE_SIZE-1, 0);
   t->storage = (stbds_hash_bucket *) STBDS_ALIGN_FWD((size_t) (t+1), STBDS_CACHE_LINE_SIZE);
   t->slot_count = slot_count;
   t->slot_count_log2 = stbds_log2(slot_count);
@@ -1542,7 +1545,7 @@ static char *stbds_strdup(char *str)
   // to keep replaceable allocator simple, we don't want to use strdup.
   // rolling our own also avoids problem of strdup vs _strdup
   size_t len = strlen(str)+1;
-  char *p = (char*) STBDS_REALLOC(NULL, 0, len);
+  char *p = (char*) STBDS_REALLOC(NULL, 0, len, 0);
   memmove(p, str, len);
   return p;
 }
@@ -1575,7 +1578,7 @@ char *stbds_stralloc(stbds_string_arena *a, char *str)
       // note that we still advance string_block so block size will continue
       // increasing, so e.g. if somebody only calls this with 1000-long strings,
       // eventually the arena will start doubling and handling those as well
-      stbds_string_block *sb = (stbds_string_block *) STBDS_REALLOC(NULL, 0, sizeof(*sb)-8 + len);
+      stbds_string_block *sb = (stbds_string_block *) STBDS_REALLOC(NULL, 0, sizeof(*sb)-8 + len, 0);
       memmove(sb->storage, str, len);
       if (a->storage) {
         // insert it after the first element, so that we don't waste the space there
@@ -1588,7 +1591,7 @@ char *stbds_stralloc(stbds_string_arena *a, char *str)
       }
       return sb->storage;
     } else {
-      stbds_string_block *sb = (stbds_string_block *) STBDS_REALLOC(NULL, 0, sizeof(*sb)-8 + blocksize);
+      stbds_string_block *sb = (stbds_string_block *) STBDS_REALLOC(NULL, 0, sizeof(*sb)-8 + blocksize, 0);
       sb->next = a->storage;
       a->storage = sb;
       a->remaining = blocksize;


### PR DESCRIPTION
For environments that have `malloc` and `free` but not `realloc`.  `STBDS_REALLOC` can be implemented with something like this thanks to the addition of `size_in_use`:
```
void * realloc(void * old_ptr, size_t new_size, size_t size_in_use) {
    void * new_ptr = malloc(new_size);
    memcpy(new_ptr, old_ptr, size_in_use);
    return new_ptr;
}
```

Also made the arguments for STBDS_REALLOC/FREE match in the definition and documentation.