### PR TITLE
Fix reading bmp V3 info headers with `BI_BITFIELDS` compression

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -5478,13 +5478,8 @@ static void *stbi__bmp_parse_header(stbi__context *s, stbi__bmp_data *info)
       stbi__get32le(s); // discard vres
       stbi__get32le(s); // discard colorsused
       stbi__get32le(s); // discard max important
-      if (hsz == 40 || hsz == 56) {
-         if (hsz == 56) {
-            stbi__get32le(s);
-            stbi__get32le(s);
-            stbi__get32le(s);
-            stbi__get32le(s);
-         }
+      if (hsz == 40) {
+         // INFO header
          if (info->bpp == 16 || info->bpp == 32) {
             if (compress == 0) {
                stbi__bmp_set_mask_defaults(info, compress);
@@ -5501,6 +5496,14 @@ static void *stbi__bmp_parse_header(stbi__context *s, stbi__bmp_data *info)
             } else
                return stbi__errpuc("bad BMP", "bad BMP");
          }
+      } else if (hsz == 56) {
+         // V3 header
+         info->mr = stbi__get32le(s);
+         info->mg = stbi__get32le(s);
+         info->mb = stbi__get32le(s);
+         stbi__get32le(s); // discard alpha mask, matching the behavior in major web browsers
+         if (compress != 3)
+            stbi__bmp_set_mask_defaults(info, compress);
       } else {
          // V4/V5 header
          int i;


### PR DESCRIPTION
Previously these bitmaps would unconditionally discard all 4 bitmasks, then erroneously overread another 12 bytes if the compression was `BI_BITFIELDS`.

See attached BMP with `BITMAPV3INFOHEADER` and `BI_BITFIELDS` compression.
It should be loaded properly by paint, and cause a "bad BMP" error in stb_image.
[v3_info_header_with_bitfields.zip](https://github.com/nothings/stb/files/10698337/v3_info_header_with_bitfields.zip)

