### PR TITLE
Fixes null pointer dereference in https://github.com/nothings/stb/issues/1452

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -6527,7 +6527,7 @@ static void *stbi__pic_load(stbi__context *s,int *px,int *py,int *comp,int req_c
 
    if (!stbi__pic_load_core(s,x,y,comp, result)) {
       STBI_FREE(result);
-      result=0;
+      return 0;
    }
    *px = x;
    *py = y;


### PR DESCRIPTION
Hi stb maintainers!

I just saw issue #1452, and put together this pull request to fix it. When stbi__pic_load_core returns `NULL`, this code now frees the allocated image and returns 0 immediately, instead of passing a null pointer to `stbi__convert_format()`.

Thanks!