### PR TITLE
Fix: stb_sprintf - gcc defines __riscv

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -21,6 +21,7 @@
 //    Adam Allison
 //    Arvid Gerstmann
 //    Markus Kolb
+//    Xin Liu
 //
 // LICENSE:
 //
@@ -230,7 +231,7 @@ STBSP__PUBLICDEC void STB_SPRINTF_DECORATE(set_separators)(char comma, char peri
 #define stbsp__uint16 unsigned short
 
 #ifndef stbsp__uintptr
-#if defined(__ppc64__) || defined(__powerpc64__) || defined(__aarch64__) || defined(_M_X64) || defined(__x86_64__) || defined(__x86_64) || defined(__s390x__)
+#if defined(__ppc64__) || defined(__powerpc64__) || defined(__aarch64__) || defined(_M_X64) || defined(__x86_64__) || defined(__x86_64) || defined(__s390x__) || defined(__riscv)
 #define stbsp__uintptr stbsp__uint64
 #else
 #define stbsp__uintptr stbsp__uint32


### PR DESCRIPTION
This allow stb to build on RISC-V machine.