### PR TITLE
This prevents few warnings that appear when compiling with clang

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -206,7 +206,9 @@ STBIWDEF void stbi_flip_vertically_on_write(int flip_boolean);
    #define _CRT_NONSTDC_NO_DEPRECATE
    #endif
 #elif defined(__clang__)
+   #pragma clang diagnostic push
    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+   #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
 #ifndef STBI_WRITE_NO_STDIO
@@ -1625,6 +1627,10 @@ STBIWDEF int stbi_write_jpg(char const *filename, int x, int y, int comp, const 
    } else
       return 0;
 }
+#endif
+
+#if defined(__clang__)
+   #pragma clang diagnostic pop
 #endif
 
 #endif // STB_IMAGE_WRITE_IMPLEMENTATION

--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -205,6 +205,8 @@ STBIWDEF void stbi_flip_vertically_on_write(int flip_boolean);
    #ifndef _CRT_NONSTDC_NO_DEPRECATE
    #define _CRT_NONSTDC_NO_DEPRECATE
    #endif
+#elif defined(__clang__)
+   #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
 #ifndef STBI_WRITE_NO_STDIO


### PR DESCRIPTION
Examples of these warnings:

```
stb_image_write.h:776:13: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only. Due to security
      concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
      len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
```

```
./thirdparty/stb/stb_image_write.h:518:32: error: missing field 'context' initializer [-Werror,-Wmissing-field-initializers]
   stbi__write_context s = { 0 };
                               ^
```