### PR TITLE
stb_image.h: compute correct palette entry count for 12 byte BMP headers

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -5555,7 +5555,7 @@ static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req
 
    if (info.hsz == 12) {
       if (info.bpp < 24)
-         psize = (info.offset - info.extra_read - 24) / 3;
+         psize = (info.offset - info.extra_read - info.hsz) / 3;
    } else {
       if (info.bpp < 16)
          psize = (info.offset - info.extra_read - info.hsz) >> 2;


### PR DESCRIPTION
When the old format 12-byte BMP header is used, palette entries are 3 bytes each rather than 4 bytes each.

When computing the number of entries, the size of the header must be subtracted before dividing by 3.

The size of the header in this case is 12 which may also be found in the info.hsz field.

Replace the incorrect hard-coded value of 24 with info.hsz (which will be 12 in this case) otherwise the last 12 bytes of the palette ends up being ignored (12 / 3 => the last 4 palette entries) and any references to them read garbage.