### PR TITLE
Do not rely on __STDC_LIB_EXT1__ for sprintf_s

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -770,7 +770,7 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
       char header[] = "#?RADIANCE\n# Written by stb_image_write.h\nFORMAT=32-bit_rle_rgbe\n";
       s->func(s->context, header, sizeof(header)-1);
 
-#ifdef __STDC_LIB_EXT1__
+#if defined(_WIN32) && defined(__STDC_WANT_SECURE_LIB__)
       len = sprintf_s(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #else
       len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);


### PR DESCRIPTION
It is not reliable at least on some versions of Clang (e.g.,  v14.1 on macOS 13.5.1), and anyway the safe `_s` functions are mostly a MSVC thing that they try and force to use through a warning but is barely standard.

Only `stb_image_write` was still using that, this PR aligns it to the behavior of e.g. [`stb_ds`](https://github.com/nothings/stb/blob/5736b15f7ea0ffb08dd38af21067c314d6a3aae9/stb_ds.h#L1643)

* Delete this list before clicking CREATE PULL REQUEST
* Make sure you're using a special branch just for this pull request. (Sometimes people unknowingly use a default branch, then later update that branch, which updates the pull request with the other changes if it hasn't been merged yet.)
* Do NOT update the version number in the file. (This just causes conflicts.)
* Do add your name to the list of contributors. (Don't worry about the formatting.) I'll try to remember to add it if you don't, but I sometimes forget as it's an extra step.

If you get something above wrong, don't fret it, it's not the end of the world.
