### PR TITLE
Fix stbsp__uintptr on riscv64

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -230,7 +230,7 @@ STBSP__PUBLICDEC void STB_SPRINTF_DECORATE(set_separators)(char comma, char peri
 #define stbsp__uint16 unsigned short
 
 #ifndef stbsp__uintptr
-#if defined(__ppc64__) || defined(__powerpc64__) || defined(__aarch64__) || defined(_M_X64) || defined(__x86_64__) || defined(__x86_64) || defined(__s390x__)
+#if defined(__ppc64__) || defined(__powerpc64__) || defined(__aarch64__) || defined(_M_X64) || defined(__x86_64__) || defined(__x86_64) || defined(__s390x__) || defined(__riscv) && __riscv_xlen == 64
 #define stbsp__uintptr stbsp__uint64
 #else
 #define stbsp__uintptr stbsp__uint32


### PR DESCRIPTION
[Last pull request](https://github.com/nothings/stb/pull/1457) had done it wrong. This is an updated patch.