### PR TITLE
Fix integer overflow

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -1207,7 +1207,7 @@ static stbi__uint16 *stbi__convert_8_to_16(stbi_uc *orig, int w, int h, int chan
    int img_len = w * h * channels;
    stbi__uint16 *enlarged;
 
-   enlarged = (stbi__uint16 *) stbi__malloc(img_len*2);
+   enlarged = (stbi__uint16 *) stbi__malloc(((size_t)img_len)*2);
    if (enlarged == NULL) return (stbi__uint16 *) stbi__errpuc("outofmem", "Out of memory");
 
    for (i = 0; i < img_len; ++i)


### PR DESCRIPTION
Cast to `size_t` to avoid multiplication overflow. Fixes #1529

