### PR TITLE
Fix wild address read in stbi__gif_load_next

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -7019,7 +7019,7 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
             }
             memcpy( out + ((layers - 1) * stride), u, stride );
             if (layers >= 2) {
-               two_back = out - 2 * stride;
+               two_back = out + (layers - 2) * stride;
             }
 
             if (delays) {


### PR DESCRIPTION
It seems `layers` were forgotten to include in equation. Fixes #1538
