### PR TITLE
Fix double-free in stbi__load_gif_main_outofmem

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -6990,6 +6990,10 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
             stride = g.w * g.h * 4;
 
             if (out) {
+               if (stride == 0) {
+                  void *ret = stbi__load_gif_main_outofmem(&g, out, delays);
+                  return ret;
+               }
                void *tmp = (stbi_uc*) STBI_REALLOC_SIZED( out, out_size, layers * stride );
                if (!tmp)
                   return stbi__load_gif_main_outofmem(&g, out, delays);


### PR DESCRIPTION
Fixes #1544

