### PR TITLE
Fix Null pointer dereference in stbi__convert_format

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -6528,6 +6528,7 @@ static void *stbi__pic_load(stbi__context *s,int *px,int *py,int *comp,int req_c
    if (!stbi__pic_load_core(s,x,y,comp, result)) {
       STBI_FREE(result);
       result=0;
+      return result;
    }
    *px = x;
    *py = y;


### PR DESCRIPTION
Fixes #1546

