### PR TITLE
Fix possible double-free or memory leak in stbi__load_gif_main

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -6991,8 +6991,11 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
 
             if (out) {
                void *tmp = (stbi_uc*) STBI_REALLOC_SIZED( out, out_size, layers * stride );
-               if (!tmp)
-                  return stbi__load_gif_main_outofmem(&g, out, delays);
+               if (!tmp) {
+                  void *ret = stbi__load_gif_main_outofmem(&g, out, delays);
+		  if (delays && *delays) *delays = 0;
+		  return ret;
+	       }
                else {
                    out = (stbi_uc*) tmp;
                    out_size = layers * stride;
@@ -7007,8 +7010,11 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
                }
             } else {
                out = (stbi_uc*)stbi__malloc( layers * stride );
-               if (!out)
-                  return stbi__load_gif_main_outofmem(&g, out, delays);
+               if (!out) {
+                  void *ret = stbi__load_gif_main_outofmem(&g, out, delays);
+		  if (delays && *delays) *delays = 0;
+		  return ret;
+	       }
                out_size = layers * stride;
                if (delays) {
                   *delays = (int*) stbi__malloc( layers * sizeof(int) );


### PR DESCRIPTION
Fixes #1548

