### PR TITLE
Fix Null pointer dereference because of an uninitialized variable

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -1446,7 +1446,7 @@ STBIDEF stbi_uc *stbi_load_gif_from_memory(stbi_uc const *buffer, int len, int *
    stbi__start_mem(&s,buffer,len);
 
    result = (unsigned char*) stbi__load_gif_main(&s, delays, x, y, z, comp, req_comp);
-   if (stbi__vertically_flip_on_load) {
+   if (stbi__vertically_flip_on_load && result) {
       stbi__vertical_flip_slices( result, *x, *y, *z, *comp );
    }
 


### PR DESCRIPTION
Call `stbi__vertical_flip_slices` only if the previous function didn't fail. Fixes #1550

