### PR TITLE
stb_vorbis: undefined behaviour causes audio distortions when ubsan is enabled

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -34,6 +34,7 @@
 //    github:audinowho   Dougall Johnson     David Reid
 //    github:Clownacy    Pedro J. Estebanez  Remi Verschelde
 //    AnthoFoxo          github:morlat       Gabriel Ravier
+//    Seb de Graffenried
 //
 // Partial history:
 //    1.22    - 2021-07-11 - various small fixes

--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -2067,7 +2067,7 @@ static __forceinline void draw_line(float *output, int x0, int y0, int x1, int y
    ady -= abs(base) * adx;
    if (x1 > n) x1 = n;
    if (x < x1) {
-      LINE_OP(output[x], inverse_db_table[y&255]);
+      LINE_OP(output[x], inverse_db_table[(uint32)y&255]);
       for (++x; x < x1; ++x) {
          err += ady;
          if (err >= adx) {
@@ -2075,7 +2075,7 @@ static __forceinline void draw_line(float *output, int x0, int y0, int x1, int y
             y += sy;
          } else
             y += base;
-         LINE_OP(output[x], inverse_db_table[y&255]);
+         LINE_OP(output[x], inverse_db_table[(uint32)y&255]);
       }
    }
 }


### PR DESCRIPTION
Fixes distorted decompressed audio when UBSan was enabled.

I found an audio distortion issue while working on a game. This bug seems petty harmless since it shows up only when ubsan is enabled (for me at least). However – since I was not listening to audio at the time at enabled ubsan – it took me a little while to link the audio distortion bug to the fact that ubsan was enabled. Fixing this might save others the trouble!

Distorted audio (ubsan enabled): https://github.com/nothings/stb/assets/6556843/a92daa96-4ac0-4c3f-aa03-4e58d161dd78
Correct audio (ubsan disabled): https://github.com/nothings/stb/assets/6556843/a932be22-d25d-4158-8f16-e3effc583416

Minimal repro: [stb_vorbis_ubsan_bug_repro.zip](https://github.com/nothings/stb/files/13063268/stb_vorbis_ubsan_bug_repro.zip)

Running run_repro.sh on my arm mac results in this input showing that the decoded data with and without ubsan don't match:

```
> Compiling and running without ubsan
Decoded 3309167 samples.
> done

> Compiling and running with ubsan
stb_vorbis.c:2078:10: runtime error: index -128 out of bounds for type 'float[256]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior stb_vorbis.c:2078:10 in 
stb_vorbis.c:2070:7: runtime error: index -120 out of bounds for type 'float[256]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior stb_vorbis.c:2070:7 in 
Decoded 3309167 samples.
> done

> Comparing the two decoded files
decoded.data decoded_ubsan.data differ: char 57, line 1
> done

> Compiling and running the patched version without ubsan
Decoded 3309167 samples.
> done

> Compiling and running the patched version with ubsan
Decoded 3309167 samples.
> done

> Comparing the two decoded files
Files matched!
> done
```