### PR TITLE
Fix data races in stbir_resize_extended_split by moving the call to s…

### DIFF
--- a/stb_image_resize2.h
+++ b/stb_image_resize2.h
@@ -7636,7 +7636,12 @@ STBIRDEF int stbir_build_samplers_with_splits( STBIR_RESIZE * resize, int splits
       stbir_free_samplers( resize );
 
     resize->called_alloc = 1;
-    return stbir__perform_build( resize, splits );
+    splits = stbir__perform_build( resize, splits );
+
+    // update anything that can be changed without recalcing samplers
+    stbir__update_info_from_resize( resize->samplers, resize );
+
+    return splits;
   }
 
   STBIR_PROFILE_BUILD_CLEAR( resize->samplers );
@@ -7711,9 +7716,6 @@ STBIRDEF int stbir_resize_extended_split( STBIR_RESIZE * resize, int split_start
     
   if ( ( split_start >= resize->splits ) || ( split_start < 0 ) || ( ( split_start + split_count ) > resize->splits ) || ( split_count <= 0 ) )
     return 0;
-  
-  // update anything that can be changed without recalcing samplers
-  stbir__update_info_from_resize( resize->samplers, resize );
  
   // do resize
   return stbir__perform_resize( resize->samplers, split_start, split_count );


### PR DESCRIPTION
Thread sanitizer reports numerous data races, mostly when assigning the `info` struct inside `stbir__update_info_from_resize`. I'm also seeing visual corruption when running resizing on multiple threads. My guess would be torn reads and writes. 

It looks like `stbir__update_info_from_resize` is not touching any of the per-slice data members which suggests it can be called only once instead of being called once per split. I've moved the call into `stbir_build_samplers_with_splits` as we need to call that function when setting up the multi-threaded slice resizing. The code can potentially be simpler if `stbir__update_info_from_resize` can be called before the call to `stbir__perform_build`. I don't understand the code enough to make this call.