### PR TITLE
Resolve compilation errors and warnings

### DIFF
--- a/stb_dxt.h
+++ b/stb_dxt.h
@@ -83,6 +83,7 @@ STBDDEF void stb_compress_bc5_block(unsigned char *dest, const unsigned char *sr
 // #define STB_DXT_USE_ROUNDING_BIAS
 
 #include <stdlib.h>
+#include <string.h> // memcpy
 
 #if !defined(STBD_FABS)
 #include <math.h>

--- a/stb_herringbone_wang_tile.h
+++ b/stb_herringbone_wang_tile.h
@@ -366,10 +366,12 @@ STBHW_EXTERN const char *stbhw_get_last_error(void)
 //  need to try to do more sophisticated parsing of edge color
 //  markup or something.
 
+typedef struct stbhw__process stbhw__process;
+
 typedef void stbhw__process_rect(struct stbhw__process *p, int xpos, int ypos,
                                  int a, int b, int c, int d, int e, int f);
 
-typedef struct stbhw__process
+struct stbhw__process
 {
    stbhw_tileset *ts;
    stbhw_config *c;
@@ -377,7 +379,7 @@ typedef struct stbhw__process
    stbhw__process_rect *process_v_rect;
    unsigned char *data;
    int stride,w,h;
-} stbhw__process;
+};
 
 static void stbhw__process_h_row(stbhw__process *p,
                            int xpos, int ypos,


### PR DESCRIPTION
 - stb_dxt.h error: <string.h> required for 'memcpy'
 - stb_herringbone_wang_tile.h warnings: Use separate declaration and definition of struct to suppress warnings
