### PR TITLE
Fix 'declaration shadows a local variable' warning

### DIFF
--- a/stb_image_resize2.h
+++ b/stb_image_resize2.h
@@ -4652,10 +4652,10 @@ static void stbir__decode_scanline(stbir__info const * stbir_info, int n, float 
     stbir__simdf8_madd( tot0, tot0, c, d ); }               
 
 #define stbir__store_output()                     \
-    { stbir__simdf t,c;                           \
+    { stbir__simdf t,d;                           \
     stbir__simdf8_add4halves( t, stbir__if_simdf8_cast_to_simdf4(tot0), tot0 );    \
-    stbir__simdf_0123to2301( c, t );              \
-    stbir__simdf_add( t, t, c );                  \
+    stbir__simdf_0123to2301( d, t );              \
+    stbir__simdf_add( t, t, d );                  \
     stbir__simdf_store2( output, t );             \
     horizontal_coefficients += coefficient_width; \
     ++horizontal_contributors;                    \


### PR DESCRIPTION
When compiling for AVX and AVX2 code expands to 
`    
// stbir__4_coeff_start

	stbir__simdf8 tot0,c,cs;                      \
    STBIR_SIMD_NO_UNROLL(decode);                 \
    stbir__simdf8_load4b( cs, hc );               \
    stbir__simdf8_0123to00112233( c, cs );        \
    stbir__simdf8_mult_mem( tot0, c, decode );


// stbir__store_output

    { stbir__simdf t,c;                           \
    stbir__simdf8_add4halves( t, stbir__if_simdf8_cast_to_simdf4(tot0), tot0 );    \
    stbir__simdf_0123to2301( c, t );              \
    stbir__simdf_add( t, t, c );                  \
    stbir__simdf_store2( output, t );             \
    horizontal_coefficients += coefficient_width; \
    ++horizontal_contributors;                    \
    output += 2; }`

Declaration of `c` in the nested scope shadows previously declared variable coming from expansion of `stbir__4_coeff_start`. I'm not sure what the logic is behind variable names but I'm just using the next available letter.