### PR TITLE
Fix AVX and AVX2 corruption due to undefined upper 128 bits after cal…

### DIFF
--- a/stb_image_resize2.h
+++ b/stb_image_resize2.h
@@ -1554,7 +1554,7 @@ static stbir__inline stbir_uint8 stbir__linear_to_srgb_uchar(float in)
 
     static __m256i stbir_00112233 = { STBIR__CONST_4d_32i( 0, 0, 1, 1 ), STBIR__CONST_4d_32i( 2, 2, 3, 3 ) };
     #define stbir__simdf8_0123to00112233( out, in ) (out) = _mm256_permutevar_ps ( in, stbir_00112233 )
-    #define stbir__simdf8_add4( out, a8, b ) (out) = _mm256_add_ps( a8,  _mm256_castps128_ps256( b ) )
+    #define stbir__simdf8_add4( out, a8, b ) (out) = _mm256_add_ps( a8, _mm256_blend_ps( _mm256_castps128_ps256( b ), _mm256_setzero_ps )
 
     static __m256i stbir_load6 = { STBIR__CONST_4_32i( 0x80000000 ), STBIR__CONST_4d_32i(  0x80000000,  0x80000000, 0, 0 ) };
     #define stbir__simdf8_load6z( out, ptr ) (out) = _mm256_maskload_ps( ptr, stbir_load6 )
@@ -1582,11 +1582,11 @@ static stbir__inline stbir_uint8 stbir__linear_to_srgb_uchar(float in)
     #ifdef STBIR_USE_FMA           // not on by default to maintain bit identical simd to non-simd
     #define stbir__simdf8_madd( out, add, mul1, mul2 ) (out) = _mm256_fmadd_ps( mul1, mul2, add )
     #define stbir__simdf8_madd_mem( out, add, mul, ptr ) (out) = _mm256_fmadd_ps( mul, _mm256_loadu_ps( (float const*)(ptr) ), add )
-    #define stbir__simdf8_madd_mem4( out, add, mul, ptr ) (out) = _mm256_fmadd_ps( _mm256_castps128_ps256( mul ), _mm256_castps128_ps256( _mm_loadu_ps( (float const*)(ptr) ) ), add )
+    #define stbir__simdf8_madd_mem4( out, add, mul, ptr ) (out) = _mm256_fmadd_ps( _mm256_blend_ps( _mm256_castps128_ps256( mul ), _mm256_setzero_ps(), 0xf0 ), _mm256_blend_ps( _mm256_castps128_ps256( _mm_loadu_ps( (float const*)(ptr) ) ), _mm256_setzero_ps(), 0xf0 ), add )
     #else
     #define stbir__simdf8_madd( out, add, mul1, mul2 ) (out) = _mm256_add_ps( add, _mm256_mul_ps( mul1, mul2 ) )
     #define stbir__simdf8_madd_mem( out, add, mul, ptr ) (out) = _mm256_add_ps( add, _mm256_mul_ps( mul, _mm256_loadu_ps( (float const*)(ptr) ) ) )
-    #define stbir__simdf8_madd_mem4( out, add, mul, ptr ) (out) = _mm256_add_ps( add, _mm256_castps128_ps256( _mm_mul_ps( mul, _mm_loadu_ps( (float const*)(ptr) ) ) ) )
+    #define stbir__simdf8_madd_mem4( out, add, mul, ptr ) (out) = _mm256_add_ps( add, _mm256_blend_ps( _mm256_castps128_ps256( _mm_mul_ps( mul, _mm_loadu_ps( (float const*)(ptr) ) ) ), _mm256_setzero_ps(), 0xf0 ) )
     #endif
     #define stbir__if_simdf8_cast_to_simdf4( val ) _mm256_castps256_ps128( val )
 


### PR DESCRIPTION
When `stbir__1_coeff_remnant` and `stbir__store_output` are expanded the following happens:

`stbir__simdf8_madd_mem4( tot0, tot0, t,  );` will corrupt upper 128 bits of `tot0` because of `_mm256_castps128_ps256` 
`stbir__simdf8_add4halves( t, t, tot0 );` will use those bits via `_mm256_extractf128_ps( tot0, 1 )`

I was observing image corruption when scaling by 1/9 factor but it's very difficult to reproduce, I'm guessing this is because the compiler inserts VZEROUPPER at various places so upper 128 bits get set to zero most of the time but in some situations I get random values in the upper half of the register.

I haven't seen the bug when enabling FMA but I've applied the fix as the code suffers from the same issue.
This goes for `stbir__simdf8_add4` too, no problem was observed but that's the only other place where `_mm256_castps128_ps256` is used.