### PR TITLE
stb_textedit: fix out-of-bounds selection when performing undo/redo while text is selected

### DIFF
--- a/stb_textedit.h
+++ b/stb_textedit.h
@@ -1265,6 +1265,7 @@ static void stb_text_undo(STB_TEXTEDIT_STRING *str, STB_TexteditState *state)
    }
 
    state->cursor = u.where + u.insert_length;
+   state->select_start = state->select_end = state->cursor;
 
    s->undo_point--;
    s->redo_point--;
@@ -1316,6 +1317,7 @@ static void stb_text_redo(STB_TEXTEDIT_STRING *str, STB_TexteditState *state)
    }
 
    state->cursor = r.where + r.insert_length;
+   state->select_start = state->select_end = state->cursor;
 
    s->undo_point++;
    s->redo_point++;


### PR DESCRIPTION
Fixes #1103. Reproduce the bug by selecting all text, then performing an undo/redo operation that deletes some part of it. That will result in a value of state->select_end beyond STB_TEXTEDIT_STRINGLEN(), leading to crashes in code that use the library.