### PR TITLE
stb_image_resize2: Fix output callback parameter using the wrong buffer

### DIFF
--- a/stb_image_resize2.h
+++ b/stb_image_resize2.h
@@ -5958,7 +5958,7 @@ static void stbir__encode_scanline( stbir__info const * stbir_info, void *output
 
   // if we have an output callback, call it to send the data
   if ( stbir_info->out_pixels_cb )
-    stbir_info->out_pixels_cb( output_buffer_data, num_pixels, row, stbir_info->user_data );
+    stbir_info->out_pixels_cb( output_buffer, num_pixels, row, stbir_info->user_data );
 }
 
 

--- a/stb_image_resize2.h
+++ b/stb_image_resize2.h
@@ -326,6 +326,7 @@
       Jorge L Rodriguez: Original 1.0 implementation
       Aras Pranckevicius: bugfixes for 1.0
       Nathan Reed: warning fixes for 1.0
+      Julien Koenen: bug fix
 
    REVISIONS
       2.04 (2023-11-17) Fix for rare AVX bug, shadowed symbol (thanks Nikola Smiljanic).


### PR DESCRIPTION
Bug found by @motor3d, I'm just forwarding the fix