### PR TITLE
Fix "string_len" typo in stb_c_lexer.h

### DIFF
--- a/stb_c_lexer.h
+++ b/stb_c_lexer.h
@@ -562,7 +562,6 @@ int stb_c_lexer_get_token(stb_lexer *lexer)
          {
             int n = 0;
             lexer->string = lexer->string_storage;
-            lexer->string_len = n;
             do {
                if (n+1 >= lexer->string_storage_len)
                   return stb__clex_token(lexer, CLEX_parse_error, p, p+n);
@@ -575,6 +574,7 @@ int stb_c_lexer_get_token(stb_lexer *lexer)
                || p[n] == '_' || (unsigned char) p[n] >= 128
                 STB_C_LEX_DOLLAR_IDENTIFIER( || p[n] == '$' )
             );
+            lexer->string_len = n;
             lexer->string[n] = 0;
             return stb__clex_token(lexer, CLEX_id, p, p+n-1);
          }


### PR DESCRIPTION
Looks like a copy-paste mistake.