### PR TITLE
Make fallthroughs explicit in stb_image.h

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -372,7 +372,14 @@ RECENT REVISION HISTORY:
 
 #define STBI_VERSION 1
 
-#define STBI_FALLTHROUGH __attribute__((fallthrough))
+#if defined(__has_attribute)
+#  if __has_attribute(fallthrough)
+#    define STBI_FALLTHROUGH __attribute__((fallthrough));
+#  endif
+#endif
+#if !defined(STBI_FALLTHROUGH)
+#  define STBI_FALLTHROUGH
+#endif
 
 enum
 {


### PR DESCRIPTION
The `-Wimplicit-fallthrough` flag can be used to check for implicit fallthroughs, which are a common source of errors.

I've added and used `STBI_FALLTHROUGH` which maps to `__attribute__((fallthrough))`, which the compiler uses to determine whether a fallthrough is explicit or not.
