### PR TITLE
remove potential UB in `stbiw__jpg_writeBits`

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -141,6 +141,7 @@ CREDITS:
       github:ignotion
       Adam Schackart
       Andrew Kensler
+      David Rubin
 
 LICENSE
 
@@ -1251,7 +1252,7 @@ static const unsigned char stbiw__jpg_ZigZag[] = { 0,1,5,6,14,15,27,28,2,4,7,13,
       24,31,40,44,53,10,19,23,32,39,45,52,54,20,22,33,38,46,51,55,60,21,34,37,47,50,56,59,61,35,36,48,49,57,58,62,63 };
 
 static void stbiw__jpg_writeBits(stbi__write_context *s, int *bitBufP, int *bitCntP, const unsigned short *bs) {
-   int bitBuf = *bitBufP, bitCnt = *bitCntP;
+   unsigned int bitBuf = *bitBufP, bitCnt = *bitCntP;
    bitCnt += bs[1];
    bitBuf |= bs[0] << (24 - bitCnt);
    while(bitCnt >= 8) {


### PR DESCRIPTION
The line:

https://github.com/nothings/stb/blob/ae721c50eaf761660b4f90cc590453cdb0c2acd0/stb_image_write.h#L1263

creates potential UB because `int` isn't guaranteed to be large enough. I *think* the solution is `unsigned int` but if you know something better please suggest. 

You can see this easily yourself by just compiling a program like:
```c
#define STB_IMAGE_IMPLEMENTATION
#include "stb_image.h"

#define STB_IMAGE_WRITE_IMPLEMENTATION
#include "stb_image_write.h"

int main(int argc, char const *argv[])
{
    char *filename = argv[1];
    int width, height, channels;
    unsigned char *img = stbi_load(filename, &width, &height, &channels, 0);

    stbi_write_jpg("temp.jpg", width, height, channels, img, 100);

    return 0;
}
```
Compile with:
```
clang -fsanitize=undefined test.c
```
running it:
```
stb_image_write.h:1264:14: runtime error: left shift of 12165120 by 8 places cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior stb_image_write.h:1264:14 in
```
