### PR TITLE
Avoid address sanitizer on MSVC

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -158,12 +158,30 @@ PERFORMANCE vs MSVC 2008 32-/64-bit (GCC is even slower than MSVC):
  #if defined(__SANITIZE_ADDRESS__) && __SANITIZE_ADDRESS__
   #define STBSP__ASAN __attribute__((__no_sanitize_address__))
  #endif
+#elif defined(_MSC_VER)
+ #if defined(__SANITIZE_ADDRESS__) && __SANITIZE_ADDRESS__
+  #define STBSP__ASAN __declspec(no_sanitize_address)  
+ #endif
 #endif
 
 #ifndef STBSP__ASAN
 #define STBSP__ASAN
 #endif
 
+#if defined(_MSC_VER)
+#ifdef STB_SPRINTF_STATIC
+#define STBSP__PUBLICDEC static
+#define STBSP__PUBLICDEF STBSP__ASAN static
+#else
+#ifdef __cplusplus
+#define STBSP__PUBLICDEC extern "C"
+#define STBSP__PUBLICDEF STBSP__ASAN extern "C"
+#else
+#define STBSP__PUBLICDEC extern
+#define STBSP__PUBLICDEF STBSP__ASAN
+#endif
+#endif
+#else
 #ifdef STB_SPRINTF_STATIC
 #define STBSP__PUBLICDEC static
 #define STBSP__PUBLICDEF static STBSP__ASAN
@@ -174,6 +192,7 @@ PERFORMANCE vs MSVC 2008 32-/64-bit (GCC is even slower than MSVC):
 #else
 #define STBSP__PUBLICDEC extern
 #define STBSP__PUBLICDEF STBSP__ASAN
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Extending on #393
Since MSVC now supports address sanitizer, it appears to be throwing the same issues as other platforms

This PR adds compiler checks and appropriate declspecs for MSVC

Note that _declspec for MSVC must appear **before** the storage specifier, hence the additional set of STBSP__PUBLICDEF's
There's probably a cleaner way to structure that
