### PR TITLE
stb_image: fix: loading of an invalid JPEG #1608

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -3436,7 +3436,7 @@ static int stbi__decode_jpeg_image(stbi__jpeg *j)
          if (NL != j->s->img_y) return stbi__err("bad DNL height", "Corrupt JPEG");
          m = stbi__get_marker(j);
       } else {
-         if (!stbi__process_marker(j, m)) return 1;
+         if (!stbi__process_marker(j, m)) return stbi__err("bad marker","Corrupt JPEG");
          m = stbi__get_marker(j);
       }
    }


### PR DESCRIPTION
Hi this PR tries to fix the issue #1608, as `stbi__process_marker` returns `0` when the image is corrupted (with bad markers), so I believe that we should also return `0` from here.