### PR TITLE
Add new fuzzers to add coverage in oss-fuzz

### DIFF
--- a/tests/ossfuzz.sh
+++ b/tests/ossfuzz.sh
@@ -10,6 +10,30 @@ $CXX $CXXFLAGS -std=c++11 -I. \
     $SRC/stb/tests/stbi_read_fuzzer.c \
     -o $OUT/stbi_read_fuzzer $LIB_FUZZING_ENGINE
 
+$CXX $CXXFLAGS -std=c++11 -I. -DSTB_IMAGE_IMPLEMENTATION  \
+    $SRC/stb/tests/stbi_gif_read_fuzzer.c \
+    -o $OUT/stb_gif_read_fuzzer $LIB_FUZZING_ENGINE
+
+$CXX $CXXFLAGS -std=c++11 -I. -DSTB_IMAGE_IMPLEMENTATION  \
+    $SRC/stb/tests/stbi_bmp_read_fuzzer.c \
+    -o $OUT/stb_bmp_read_fuzzer $LIB_FUZZING_ENGINE
+
+$CXX $CXXFLAGS -std=c++11 -I. -DSTB_IMAGE_IMPLEMENTATION  \
+    $SRC/stb/tests/stbi_jpeg_read_fuzzer.c \
+    -o $OUT/stb_jpeg_read_fuzzer $LIB_FUZZING_ENGINE
+
+$CXX $CXXFLAGS -std=c++11 -I. -DSTB_IMAGE_IMPLEMENTATION  \
+    $SRC/stb/tests/stbi_pic_read_fuzzer.c \
+    -o $OUT/stb_pic_read_fuzzer $LIB_FUZZING_ENGINE
+
+$CXX $CXXFLAGS -std=c++11 -I. -DSTB_IMAGE_IMPLEMENTATION  \
+    $SRC/stb/tests/stbi_psd_read_fuzzer.c \
+    -o $OUT/stb_psd_read_fuzzer $LIB_FUZZING_ENGINE
+
+$CXX $CXXFLAGS -std=c++11 -I. -DSTB_IMAGE_IMPLEMENTATION  \
+    $SRC/stb/tests/stbi_extended_read_fuzzer.c \
+    -o $OUT/stb_extended_read_fuzzer $LIB_FUZZING_ENGINE
+
 find $SRC/stb/tests/pngsuite -name "*.png" | \
      xargs zip $OUT/stb_png_read_fuzzer_seed_corpus.zip
 

--- a/tests/stbi_bmp_read_fuzzer.c
+++ b/tests/stbi_bmp_read_fuzzer.c
@@ -1,0 +1,33 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define STBI_NO_JPEG
+#define STBI_NO_PNG
+#define STBI_NO_GIF
+#define STBI_NO_PSD
+#define STBI_NO_TGA
+#define STBI_NO_PIC
+#define STBI_NO_PNM
+#define STBI_NO_HDR
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "../stb_image.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    stbi__context s;
+    stbi__start_mem(&s, data, size);
+
+    int x, y, comp;
+    void *result = stbi__bmp_load(&s, &x, &y, &comp, 0, NULL);
+    if (result) {
+        free(result);
+    }
+
+    return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/stbi_extended_read_fuzzer.c
+++ b/tests/stbi_extended_read_fuzzer.c
@@ -1,0 +1,30 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "../stb_image.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    int x, y, comp;
+
+    stbi__uint16 *result_16 = stbi_load_16_from_memory(data, size, &x, &y, &comp, 0);
+    if (result_16) {
+        free(result_16);
+    }
+
+    float *result_f = stbi_loadf_from_memory(data, size, &x, &y, &comp, 0);
+    if (result_f) {
+        free(result_f);
+    }
+
+    int is_16_bit = stbi_is_16_bit_from_memory(data, size);
+
+    stbi_info_from_memory(data, size, &x, &y, &comp);
+
+    return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/stbi_gif_read_fuzzer.c
+++ b/tests/stbi_gif_read_fuzzer.c
@@ -1,0 +1,30 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "../stb_image.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    int x, y, comp, z;
+    int *delays = NULL; 
+
+    if (size > INT_MAX) {
+        return 0; 
+    }
+
+    stbi_uc *image = stbi_load_gif_from_memory(data, (int)size, &delays, &x, &y, &z, &comp, 0);
+
+    if (image) {
+        stbi_image_free(image);
+        if (delays) {
+            STBI_FREE(delays); 
+        }
+    }
+
+    return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/stbi_jpeg_read_fuzzer.c
+++ b/tests/stbi_jpeg_read_fuzzer.c
@@ -1,0 +1,35 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define STBI_NO_PNG
+#define STBI_NO_BMP
+#define STBI_NO_GIF
+#define STBI_NO_PSD
+#define STBI_NO_TGA
+#define STBI_NO_PIC
+#define STBI_NO_PNM
+#define STBI_NO_HDR
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "../stb_image.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    stbi__context s;
+    stbi__start_mem(&s, data, size);
+
+    int x, y, comp;
+    stbi__result_info ri;
+    ri.bits_per_channel = 8;
+
+    void *result = stbi__jpeg_load(&s, &x, &y, &comp, 0, &ri);
+    if (result) {
+        free(result);
+    }
+
+    return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/stbi_pic_read_fuzzer.c
+++ b/tests/stbi_pic_read_fuzzer.c
@@ -1,0 +1,34 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define STBI_NO_JPEG
+#define STBI_NO_PNG
+#define STBI_NO_BMP
+#define STBI_NO_GIF
+#define STBI_NO_PSD
+#define STBI_NO_TGA
+#define STBI_NO_PNM
+#define STBI_NO_HDR
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "../stb_image.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    stbi__context s;
+    stbi__start_mem(&s, data, size);
+
+    int x, y, comp;
+    stbi__result_info ri;
+
+    void *result = stbi__pic_load(&s, &x, &y, &comp, 0, &ri);
+    if (result) {
+        free(result);
+    }
+
+    return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/stbi_psd_read_fuzzer.c
+++ b/tests/stbi_psd_read_fuzzer.c
@@ -1,0 +1,35 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define STBI_NO_JPEG
+#define STBI_NO_PNG
+#define STBI_NO_BMP
+#define STBI_NO_GIF
+#define STBI_NO_TGA
+#define STBI_NO_PIC
+#define STBI_NO_PNM
+#define STBI_NO_HDR
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "../stb_image.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    stbi__context s;
+    stbi__start_mem(&s, data, size);
+
+    int x, y, comp;
+    stbi__result_info ri;
+    int bpc = 8; // Bits per channel
+
+    void *result = stbi__psd_load(&s, &x, &y, &comp, 0, &ri, bpc);
+    if (result) {
+        free(result);
+    }
+
+    return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This pull request introduces additional fuzzers to enhance the fuzzing coverage of the stb_image.h library in oss-fuzz, specifically targeting the testing of various image format loader functions.
