### PR TITLE
Fix RGB->BGR channel flipping. First 4 pixels were being skipped.

### DIFF
--- a/stb_image_resize2.h
+++ b/stb_image_resize2.h
@@ -326,6 +326,7 @@
       Jorge L Rodriguez: Original 1.0 implementation
       Aras Pranckevicius: bugfixes
       Nathan Reed: warning fixes for 1.0
+      Ryan Salsbury: bugfixes
 
    REVISIONS
       2.07 (2024-05-24) fix for slow final split during threaded conversions of very 
@@ -4371,7 +4372,7 @@ static void stbir__simple_flip_3ch( float * decode_buffer, int width_times_chann
   float STBIR_STREAMOUT_PTR(*) decode = decode_buffer;
   float const * end_decode = decode_buffer + width_times_channels;
 
-  decode += 12;
+  end_decode -= 12;
   while( decode <= end_decode )
   {
     float t0,t1,t2,t3;
@@ -4381,7 +4382,7 @@ static void stbir__simple_flip_3ch( float * decode_buffer, int width_times_chann
     decode[2] = t0; decode[5] = t1; decode[8] = t2; decode[11] = t3;
     decode += 12;
   }
-  decode -= 12;
+  end_decode += 12;
 
   while( decode < end_decode )
   {


### PR DESCRIPTION
Caused first 4 pixels of every line to have bad colors. Not noticable unless the image has bright colors along the left edge.