### PR TITLE
Fix char literal parsing

### DIFF
--- a/stb_c_lexer.h
+++ b/stb_c_lexer.h
@@ -38,6 +38,7 @@
 // Contributors:
 //   Arpad Goretity (bugfix)
 //   Alan Hickman (hex floats)
+//   Wonshtrum (bugfix)
 //
 // LICENSE
 //
@@ -671,7 +672,7 @@ int stb_c_lexer_get_token(stb_lexer *lexer)
                return stb__clex_token(lexer, CLEX_parse_error, start,start);
             if (p == lexer->eof || *p != '\'')
                return stb__clex_token(lexer, CLEX_parse_error, start,p);
-            return stb__clex_token(lexer, CLEX_charlit, start, p+1);
+            return stb__clex_token(lexer, CLEX_charlit, start, p);
          })
          goto single_char;
 


### PR DESCRIPTION
When creating a char literal token, its end pointed one character after its actual end.
See #1652.