### PR TITLE
stb_ds: Make STBDS_OFFSETOF() return size_t

### DIFF
--- a/stb_ds.h
+++ b/stb_ds.h
@@ -529,7 +529,7 @@ extern void * stbds_shmode_func(size_t elemsize, int mode);
 #define STBDS_ADDRESSOF(typevar, value)     &(value)
 #endif
 
-#define STBDS_OFFSETOF(var,field)           ((char *) &(var)->field - (char *) (var))
+#define STBDS_OFFSETOF(var,field)           ((size_t)((char *) &(var)->field - (char *) (var)))
 
 #define stbds_header(t)  ((stbds_array_header *) (t) - 1)
 #define stbds_temp(t)    stbds_header(t)->temp


### PR DESCRIPTION
Current implementation of STBDS_OFFSETOF() produces a warning when using shdel().

	:error: implicit conversion changes signedness: 'long' to 'size_t' (aka 'unsigned long') [-Werror,-Wsign-conversion]
		if (!shdel(console->index_entries, entry->key))

This is observed on Apple clang version 15.0.0 (clang-1500.3.9.4).

This happens because the difference between pointers is ptrdiff_t not size_t. A cast to size_t fixes the problem.
