### PR TITLE
fix: stbi_write_hdr_to_func undefined when STBI_WRITE_NO_STDIO defined

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -634,8 +634,6 @@ STBIWDEF int stbi_write_tga(char const *filename, int x, int y, int comp, const 
 
 #define stbiw__max(a, b)  ((a) > (b) ? (a) : (b))
 
-#ifndef STBI_WRITE_NO_STDIO
-
 static void stbiw__linear_to_rgbe(unsigned char *rgbe, float *linear)
 {
    int exponent;
@@ -791,6 +789,7 @@ STBIWDEF int stbi_write_hdr_to_func(stbi_write_func *func, void *context, int x,
    return stbi_write_hdr_core(&s, x, y, comp, (float *) data);
 }
 
+#ifndef STBI_WRITE_NO_STDIO
 STBIWDEF int stbi_write_hdr(char const *filename, int x, int y, int comp, const float *data)
 {
    stbi__write_context s = { 0 };


### PR DESCRIPTION
The implementation of `stbi_write_hdr_to_func` is not compiled when `STBI_WRITE_NO_STDIO` is defined, even though the function signature is still present in the header. This appears to be a typo/oversight, and I have changed the location of the #ifndef guard so it matches the other image formats. I have tested this code and the header now compiles with `STBI_WRITE_NO_STDIO` while using `stbi_write_hdr_to_func` where it did not before.