### PR TITLE
Minor optimization for interlaced pngs

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -4885,15 +4885,17 @@ static int stbi__create_png_image(stbi__png *a, stbi_uc *image_data, stbi__uint3
             STBI_FREE(final);
             return 0;
          }
+         stbi__uint32 img_x = a->s->img_x;
+         stbi_uc* a_out = a->out;
          for (j=0; j < y; ++j) {
             for (i=0; i < x; ++i) {
                int out_y = j*yspc[p]+yorig[p];
                int out_x = i*xspc[p]+xorig[p];
-               memcpy(final + out_y*a->s->img_x*out_bytes + out_x*out_bytes,
-                      a->out + (j*x+i)*out_bytes, out_bytes);
+               memcpy(final + out_y*img_x*out_bytes + out_x*out_bytes,
+                      a_out + (j*x+i)*out_bytes, out_bytes);
             }
          }
-         STBI_FREE(a->out);
+         STBI_FREE(a_out);
          image_data += img_len;
          image_data_len -= img_len;
       }


### PR DESCRIPTION
Description:
- Avoid pointer deref in inner loop 
- (With fno-strict-aliasing pointer lookups cannot assume to be loop invariants)

I am studying this particular common pitfall. If you are not interested in this kind of change, that's ok.

Testing:
- test_png_regress passes
- benchmark with interlaced png to how improvement (it's very small, but can be detected)