### PR TITLE
Fixed kerning advance in fonts with both GPOS and kern tables.

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -2609,14 +2609,15 @@ static stbtt_int32 stbtt__GetGlyphGPOSInfoAdvance(const stbtt_fontinfo *info, in
 
 STBTT_DEF int  stbtt_GetGlyphKernAdvance(const stbtt_fontinfo *info, int g1, int g2)
 {
-   int xAdvance = 0;
+   if (info->gpos) {
+      int xAdvance = stbtt__GetGlyphGPOSInfoAdvance(info, g1, g2);
+      if (xAdvance) return xAdvance;
+   }
 
-   if (info->gpos)
-      xAdvance += stbtt__GetGlyphGPOSInfoAdvance(info, g1, g2);
-   else if (info->kern)
-      xAdvance += stbtt__GetGlyphKernInfoAdvance(info, g1, g2);
+   if (info->kern)
+      return stbtt__GetGlyphKernInfoAdvance(info, g1, g2);
 
-   return xAdvance;
+   return 0;
 }
 
 STBTT_DEF int  stbtt_GetCodepointKernAdvance(const stbtt_fontinfo *info, int ch1, int ch2)


### PR DESCRIPTION
Notably, Segoe on Windows has kerning advances in the kern tables, but also has a GPOS table. The pair of characters aren't the same in each table.

Compare the string "STB TrueType Text Renderer" in the Windows window title and the STB render inside the window:

<img width="270" alt="before" src="https://github.com/user-attachments/assets/cb14fefe-20b1-4f21-837b-449a243396bf">

Compare to the STB render after the fix; notice the kerning advance between "T" and "r", and "T" and "e":

<img width="271" alt="after" src="https://github.com/user-attachments/assets/ef562c4a-da80-41c2-978a-fecdfe877bb8">

(the first STB line uses Subpixel advances, the second line doesn't)