### PR TITLE
Fix STBIR__FREE_AND_CLEAR causing null reference member access

### DIFF
--- a/stb_image_resize2.h
+++ b/stb_image_resize2.h
@@ -6689,7 +6689,7 @@ static void stbir__get_split_info( stbir__per_split_info* split_info, int splits
 
 static void stbir__free_internal_mem( stbir__info *info )
 {
-  #define STBIR__FREE_AND_CLEAR( ptr ) { if ( ptr ) { void * p = (ptr); STBIR_FREE( p, info->user_data); (ptr) = 0; } }
+  #define STBIR__FREE_AND_CLEAR( ptr ) { if ( ptr ) { void * p = (ptr); (ptr) = 0; STBIR_FREE( p, info->user_data); } }
 
   if ( info )
   {
@@ -6731,7 +6731,7 @@ static void stbir__free_internal_mem( stbir__info *info )
     STBIR__FREE_AND_CLEAR( info->horizontal.coefficients );
     STBIR__FREE_AND_CLEAR( info->horizontal.contributors );
     STBIR__FREE_AND_CLEAR( info->alloced_mem );
-    STBIR__FREE_AND_CLEAR( info );
+    STBIR_FREE( info );
   #endif
   }
 

--- a/stb_image_resize2.h
+++ b/stb_image_resize2.h
@@ -6731,7 +6731,7 @@ static void stbir__free_internal_mem( stbir__info *info )
     STBIR__FREE_AND_CLEAR( info->horizontal.coefficients );
     STBIR__FREE_AND_CLEAR( info->horizontal.contributors );
     STBIR__FREE_AND_CLEAR( info->alloced_mem );
-    STBIR_FREE( info );
+    STBIR_FREE( info, info->user_data );
   #endif
   }
 

--- a/stb_image_resize2.h
+++ b/stb_image_resize2.h
@@ -6689,7 +6689,7 @@ static void stbir__get_split_info( stbir__per_split_info* split_info, int splits
 
 static void stbir__free_internal_mem( stbir__info *info )
 {
-  #define STBIR__FREE_AND_CLEAR( ptr ) { if ( ptr ) { void * p = (ptr); (ptr) = 0; STBIR_FREE( p, info->user_data); } }
+  #define STBIR__FREE_AND_CLEAR( ptr ) { if ( ptr ) { void * p = (ptr); STBIR_FREE( p, info->user_data); (ptr) = 0; } }
 
   if ( info )
   {


### PR DESCRIPTION
`stb_image_resize2.h:6734:5: runtime error: member access within null pointer of type 'stbir__info' (aka 'struct stbir__info')`
ASAN detects this (where Valgrind didn't).