### PR TITLE
Fix error caused by use of sprintf on MSVC

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -313,14 +313,16 @@ static FILE *stbiw__fopen(char const *filename, char const *mode)
    if (0 == MultiByteToWideChar(65001 /* UTF8 */, 0, mode, -1, wMode, sizeof(wMode)/sizeof(*wMode)))
       return 0;
 
-#if defined(_MSC_VER) && _MSC_VER >= 1400
+#if (defined(__STDC_WANT_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ && defined(__STDC_LIB_EXT1__)) \
+      || (defined(_MSC_VER) && _MSC_VER >= 1400)
    if (0 != _wfopen_s(&f, wFilename, wMode))
       f = 0;
 #else
    f = _wfopen(wFilename, wMode);
 #endif
 
-#elif (defined(_MSC_VER) && _MSC_VER >= 1400)
+#elif (defined(__STDC_WANT_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ && defined(__STDC_LIB_EXT1__)) \
+      || (defined(_MSC_VER) && _MSC_VER >= 1400)
    if (0 != fopen_s(&f, filename, mode))
       f = 0;
 #else
@@ -770,7 +772,8 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
       char header[] = "#?RADIANCE\n# Written by stb_image_write.h\nFORMAT=32-bit_rle_rgbe\n";
       s->func(s->context, header, sizeof(header)-1);
 
-#if defined(_MSC_VER) && _MSC_VER >= 1400
+#if (defined(__STDC_WANT_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ && defined(__STDC_LIB_EXT1__)) \
+      || (defined(_MSC_VER) && _MSC_VER >= 1400)
       len = sprintf_s(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199001L
       len = snprintf(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);

--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -770,7 +770,7 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
       char header[] = "#?RADIANCE\n# Written by stb_image_write.h\nFORMAT=32-bit_rle_rgbe\n";
       s->func(s->context, header, sizeof(header)-1);
 
-#ifdef __STDC_LIB_EXT1__
+#if defined(_MSC_VER) && _MSC_VER >= 1400
       len = sprintf_s(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #else
       len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);

--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -320,9 +320,9 @@ static FILE *stbiw__fopen(char const *filename, char const *mode)
    f = _wfopen(wFilename, wMode);
 #endif
 
-#elif defined(_MSC_VER) && _MSC_VER >= 1400
+#elif (defined(_MSC_VER) && _MSC_VER >= 1400)
    if (0 != fopen_s(&f, filename, mode))
-      f=0;
+      f = 0;
 #else
    f = fopen(filename, mode);
 #endif
@@ -772,6 +772,8 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
 
 #if defined(_MSC_VER) && _MSC_VER >= 1400
       len = sprintf_s(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199001L
+      len = snprintf(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #else
       len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #endif


### PR DESCRIPTION
`__STDC_LIB_EXT1__` is not defined on MSVC, causing line 766 to raise the following error:

> 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.

I initially replaced the condition with `defined(_MSC_VER) && _MSC_VER >= 1400` for the sake of consistency with the other two occurrences of `_s` functions in this file, but I later (in the third commit) replaced the conditions with `(defined(__STDC_WANT_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ && defined(__STDC_LIB_EXT1__)) || (defined(_MSC_VER) && _MSC_VER >= 1400)` for all three locations where `_s` functions were called so that `_s` functions would be used over regular functions where supported; if the latter is unwanted, please feel free to remove it. A call to `snprintf` was also added for non-MSVC implementations supporting C99 but not `_s` functions.