### PR TITLE
stb_ds: fix undeclared identifier stbds_BB

### DIFF
--- a/stb_ds.h
+++ b/stb_ds.h
@@ -941,7 +941,7 @@ static stbds_hash_index *stbds_make_hash_index(size_t slot_count, stbds_hash_ind
   } else {
     size_t a,b,temp;
     memset(&t->string, 0, sizeof(t->string));
-    t->seed = stbds_BB;
+    t->seed = stbds_hash_seed;
     // LCG
     // in 32-bit, a =          2147001325   b =  715136305
     // in 64-bit, a = 2862933555777941757   b = 3037000493


### PR DESCRIPTION
Just stumbled upon the error

```
In file included from main.c:3:
./stb_ds.h:944:15: error: use of undeclared identifier 'stbds_BB'
  944 |     t->seed = stbds_BB;
      |               ^
1 error generated.
```
Looks like it's a typo that was introduced by accident in recent commit 758b6365aea39b45fc807175c7a444e427690722