### PR TITLE
Fix Clang Warning

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -773,7 +773,7 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
 #ifdef __STDC_LIB_EXT1__
       len = sprintf_s(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #else
-      len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
+      len = snprintf(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #endif
       s->func(s->context, buffer, len);
 


### PR DESCRIPTION
<img width="1282" alt="image" src="https://github.com/user-attachments/assets/404d8ba2-3210-4bf6-b745-33ae4dab543c">
Apple Clang suggests using the safer function snprintf instead of sprintf. And I tried to fix this warning.