### PR TITLE
stb_sprintf: fix overflow in negating INT_MIN

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -1061,14 +1061,14 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
             stbsp__int64 i64 = va_arg(va, stbsp__int64);
             n64 = (stbsp__uint64)i64;
             if ((f[0] != 'u') && (i64 < 0)) {
-               n64 = (stbsp__uint64)-i64;
+               n64 = -(stbsp__uint64)i64;
                fl |= STBSP__NEGATIVE;
             }
          } else {
             stbsp__int32 i = va_arg(va, stbsp__int32);
             n64 = (stbsp__uint32)i;
             if ((f[0] != 'u') && (i < 0)) {
-               n64 = (stbsp__uint32)-i;
+               n64 = -(stbsp__uint32)i;
                fl |= STBSP__NEGATIVE;
             }
          }


### PR DESCRIPTION
`stbsp_sprintf` failed for INT_MIN with `%d`.  I found that there is a negative operation on signed integer may lead to overflow. 

According to C11.6.2.6.9, I fixed this bug by negating unsigned integer.

```
#include <assert.h>
#include <limits.h>

#define STB_SPRINTF_IMPLEMENTATION
#include "stb_sprintf.h"

int main()
{
    int n = 0;
    char buf[64];
    n = stbsp_sprintf(buf, "%d", INT_MIN + 1);
    assert(n == 11);
    n = stbsp_sprintf(buf, "%d", INT_MIN);
    assert(n == 11);
    return 0;
}
```

`gcc -std=c11 -O2 a.c && ./a.out`

> a.out: a.c:14: main: Assertion `n == 11' failed.
Aborted (core dumped)
