### PR TITLE
Prevent warning due to type-limits on `arrsetlen(arr, 0)`

### DIFF
--- a/stb_ds.h
+++ b/stb_ds.h
@@ -536,7 +536,7 @@ extern void * stbds_shmode_func(size_t elemsize, int mode);
 #define stbds_temp_key(t) (*(char **) stbds_header(t)->hash_table)
 
 #define stbds_arrsetcap(a,n)   (stbds_arrgrow(a,0,n))
-#define stbds_arrsetlen(a,n)   ((stbds_arrcap(a) < (size_t) (n) ? stbds_arrsetcap((a),(size_t)(n)),0 : 0), (a) ? stbds_header(a)->length = (size_t) (n) : 0)
+#define stbds_arrsetlen(a,n)   (((ptrdiff_t) stbds_arrcap(a) < (ptrdiff_t) (n) ? stbds_arrsetcap((a),(size_t)(n)),0 : 0), (a) ? stbds_header(a)->length = (size_t) (n) : 0)
 #define stbds_arrcap(a)        ((a) ? stbds_header(a)->capacity : 0)
 #define stbds_arrlen(a)        ((a) ? (ptrdiff_t) stbds_header(a)->length : 0)
 #define stbds_arrlenu(a)       ((a) ?             stbds_header(a)->length : 0)


### PR DESCRIPTION
Related to #1731.

As suggested by @nothings, cast array capacity and new capacity to `ptrdiff_t` in order to avoid 'always-false´ complaints that arise from `-Wextra`.

# Why?
I tend to work on projects with pretty restrictive flags (-Wall -Wextra etc.), and I've introduced a dependency on `stb_ds`, as it is an excellent library that I use a lot. Unfortunately, `arrsetlen(arr, 0)` + `-Wextra` always produces an extraneous warning because the array capacity is unsigned, and thus the array-growth part of setlen is `always-false`. 

Since the workaround is pretty trivial, I don't think it is a problem to satisfy stricter compilation options in this case. 

# Why not? 
Theoretically this runs the risk of being a bad cast, since PTRDIFF_MAX < SIZE_MAX. Is there a realistic case where this would be a problem? I'm mostly referring to funky platforms I may not be aware of.

---
Thanks a lot, folks, it's a great library.