### PR TITLE
Fix root-cause of CVE-2021-45340 : dereference of NULL ptr.

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -100,7 +100,7 @@ RECENT REVISION HISTORY:
  Bug & warning fixes
     Marc LeBlanc            David Woo          Guillaume George     Martins Mozeiko
     Christpher Lloyd        Jerry Jansson      Joseph Thomson       Blazej Dariusz Roszkowski
-    Phil Jordan                                Dave Moore           Roy Eltham
+    Phil Jordan             Henner Zeller      Dave Moore           Roy Eltham
     Hayaki Saito            Nathan Reed        Won Chun
     Luke Graham             Johan Duparc       Nick Verigakis       the Horde3D community
     Thomas Ruf              Ronny Chevalier                         github:rlyeh
@@ -1757,6 +1757,7 @@ static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int r
    int i,j;
    unsigned char *good;
 
+   if (data == NULL) return data;
    if (req_comp == img_n) return data;
    STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
 


### PR DESCRIPTION
Originally reported in libsixel (https://github.com/libsixel/libsixel/issues/51 and https://github.com/libsixel/libsixel/issues/73) also as https://nvd.nist.gov/vuln/detail/CVE-2021-45340

Fixed there by locally patching stb https://github.com/libsixel/libsixel/commit/c8c7f1b1cab7bd556f54787a5e409d2ddf86ea9f

Hereby fixing upstream.