### PR TITLE
Add missing STBIRDEF to allow multiple stb_image_resize2.h implementations

### DIFF
--- a/stb_image_resize2.h
+++ b/stb_image_resize2.h
@@ -1451,8 +1451,8 @@ static stbir__inline stbir_uint8 stbir__linear_to_srgb_uchar(float in)
     #include <smmintrin.h>
     #define stbir__simdf_pack_to_8words(out,reg0,reg1) out = _mm_packus_epi32(_mm_cvttps_epi32(_mm_max_ps(_mm_min_ps(reg0,STBIR__CONSTF(STBIR_max_uint16_as_float)),_mm_setzero_ps())), _mm_cvttps_epi32(_mm_max_ps(_mm_min_ps(reg1,STBIR__CONSTF(STBIR_max_uint16_as_float)),_mm_setzero_ps())))
   #else
-    STBIR__SIMDI_CONST(stbir__s32_32768, 32768);
-    STBIR__SIMDI_CONST(stbir__s16_32768, ((32768<<16)|32768));
+    STBIRDEF STBIR__SIMDI_CONST(stbir__s32_32768, 32768);
+    STBIRDEF STBIR__SIMDI_CONST(stbir__s16_32768, ((32768<<16)|32768));
 
     #define stbir__simdf_pack_to_8words(out,reg0,reg1) \
       { \


### PR DESCRIPTION
The following code that includes the STB image resize implementation in multiple files will fail:

*a.cpp*:

```c++
#define STB_IMAGE_RESIZE_IMPLEMENTATION
#define STB_IMAGE_RESIZE_STATIC
#include "stb_image_resize2.h"

int a()
{
  return 3;
}
```

*b.cpp*:

```c++
#define STB_IMAGE_RESIZE_IMPLEMENTATION
#define STB_IMAGE_RESIZE_STATIC
#include "stb_image_resize2.h"

int b()
{
  return 2;
}
```

*main.cpp*:

```c++
int a();
int b();

int main()
{
  return a() + b();
}
```

Compile with

```
g++ -o main main.cpp a.cpp b.cpp
```

and you get

```
/usr/bin/ld: /tmp/cciFeflx.o:(.data+0x420): multiple definition of `stbir__s32_32768'; /tmp/cctlLRFu.o:(.data+0x420): first defined here
/usr/bin/ld: /tmp/cciFeflx.o:(.data+0x430): multiple definition of `stbir__s16_32768'; /tmp/cctlLRFu.o:(.data+0x430): first defined here
collect2: error: ld returned 1 exit status
```

The fix is easy: just a missing `STBIRDEF` in front of some simd constant variables, so that they are defined with `static` and can be included in multiple translation units if `STB_IMAGE_RESIZE_STATIC` is defined.  Once the fix in this PR is applied, the test program links happily.

Thanks so much for STB!  We use it inside of [mlpack](https://github.com/mlpack/mlpack) to provide image support for machine learning tasks.