### PR TITLE
stb_vorbis: Fix Clang -Wtautological-compare warning and related Undefined Behaviour.

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -1401,7 +1401,7 @@ static int set_file_offset(stb_vorbis *f, unsigned int loc)
    #endif
    f->eof = 0;
    if (USE_MEMORY(f)) {
-      if (f->stream_start + loc >= f->stream_end || f->stream_start + loc < f->stream_start) {
+      if (loc >= f->stream_len) {
          f->stream = f->stream_end;
          f->eof = 1;
          return 0;


### PR DESCRIPTION

Fixes <https://github.com/nothings/stb/issues/1745>.
