### PR TITLE
stb_sprintf: set stbsp__uintptr to stbsp__uint64 on __wasm64__

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -230,7 +230,7 @@ STBSP__PUBLICDEC void STB_SPRINTF_DECORATE(set_separators)(char comma, char peri
 #define stbsp__uint16 unsigned short
 
 #ifndef stbsp__uintptr
-#if defined(__ppc64__) || defined(__powerpc64__) || defined(__aarch64__) || defined(_M_X64) || defined(__x86_64__) || defined(__x86_64) || defined(__s390x__)
+#if defined(__ppc64__) || defined(__powerpc64__) || defined(__aarch64__) || defined(_M_X64) || defined(__x86_64__) || defined(__x86_64) || defined(__s390x__) || defined(__wasm64__)
 #define stbsp__uintptr stbsp__uint64
 #else
 #define stbsp__uintptr stbsp__uint32


### PR DESCRIPTION
stb_sprintf detects size of stbsp__uintptr as 32 bits on wasm64 which is incorrect. Added a macro check to account for this platform.