### PR TITLE
[stb_ds] Fixing direct call to STBDS_FREE from outside the STB_DS_IMPLEMENTATION block

### DIFF
--- a/stb_ds.h
+++ b/stb_ds.h
@@ -548,7 +548,7 @@ extern void * stbds_shmode_func(size_t elemsize, int mode);
 #define stbds_arraddnindex(a,n)(stbds_arrmaybegrow(a,n), (n) ? (stbds_header(a)->length += (n), stbds_header(a)->length-(n)) : stbds_arrlen(a))
 #define stbds_arraddnoff       stbds_arraddnindex
 #define stbds_arrlast(a)       ((a)[stbds_header(a)->length-1])
-#define stbds_arrfree(a)       ((void) ((a) ? STBDS_FREE(NULL,stbds_header(a)) : (void)0), (a)=NULL)
+#define stbds_arrfree(a)       ((void) ((a) ? stbds_arrfreef(a) : (void)0), (a)=NULL)
 #define stbds_arrdel(a,i)      stbds_arrdeln(a,i,1)
 #define stbds_arrdeln(a,i,n)   (memmove(&(a)[i], &(a)[(i)+(n)], sizeof *(a) * (stbds_header(a)->length-(n)-(i))), stbds_header(a)->length -= (n))
 #define stbds_arrdelswap(a,i)  ((a)[i] = stbds_arrlast(a), stbds_header(a)->length -= 1)

--- a/stb_ds.h
+++ b/stb_ds.h
@@ -382,6 +382,7 @@ CREDITS
     Macoy Madson
     Andreas Vennstrom
     Tobias Mansfield-Williams
+    Guilherme Espirito Santo
 */
 
 #ifdef STBDS_UNIT_TESTS


### PR DESCRIPTION
Issue is described here https://github.com/nothings/stb/issues/1632
This causes the library to use the default implementation for source files that don't define STB_DS_IMPLEMENTATION.