### PR TITLE
Clarify behavior of `arrput` on values that depend on the array.

### DIFF
--- a/stb_ds.h
+++ b/stb_ds.h
@@ -97,6 +97,8 @@ DOCUMENTATION
       arrput:
         T arrput(T* a, T b);
           Appends the item b to the end of array a. Returns b.
+          The array may change prior to evaluation of b: items that depend 
+          on its observables may need to be passed through a temporary.
 
       arrins:
         T arrins(T* a, int p, T b);


### PR DESCRIPTION
Closes #1766 (?)

Added a remark to the documentation of `arrput` to make it clear that items depending on certain properties of the array should be stored in a temporary variable before being appended. Is this alright or does anyone think adding the same sort of remark to `{sh,hm}put` is warranted? 

From my tests, and inspecting the implementation, the key itself depending on the map seems to be permissible. Although the same issues arise when you try to `shput` a value that depends on the size of the map, for instance.