### PR TITLE
stb_ds.h: fix Thomas Wang 64-to-32 bit mix function

### DIFF
--- a/stb_ds.h
+++ b/stb_ds.h
@@ -1022,11 +1022,11 @@ size_t stbds_hash_string(char *str, size_t seed)
   // Thomas Wang 64-to-32 bit mix function, hopefully also works in 32 bits
   hash ^= seed;
   hash = (~hash) + (hash << 18);
-  hash ^= hash ^ STBDS_ROTATE_RIGHT(hash,31);
+  hash = hash ^ STBDS_ROTATE_RIGHT(hash,31);
   hash = hash * 21;
-  hash ^= hash ^ STBDS_ROTATE_RIGHT(hash,11);
-  hash += (hash << 6);
-  hash ^= STBDS_ROTATE_RIGHT(hash,22);
+  hash = hash ^ STBDS_ROTATE_RIGHT(hash,11);
+  hash = hash + (hash << 6);
+  hash = hash ^ STBDS_ROTATE_RIGHT(hash,22);
   return hash+seed;
 }
 


### PR DESCRIPTION
The operations `hash ^= hash ^ STBDS_ROTATE_RIGHT(hash, N);` are obviously wrong because `hash^hash` zeroes out and only result of rotate is left. The original only as assignments without xor.
https://web.archive.org/web/20071223173210/http://www.concentric.net/~Ttwang/tech/inthash.htm