### PR TITLE
Divisor is a double, no f postfix

### DIFF
--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -808,7 +808,7 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
          // do kilos
          if (fl & STBSP__METRIC_SUFFIX) {
             double divisor;
-            divisor = 1000.0f;
+            divisor = 1000.0;
             if (fl & STBSP__METRIC_1024)
                divisor = 1024.0;
             while (fl < 0x4000000) {


### PR DESCRIPTION
Just a little thing that my compiler with -Wdouble-promotion told me about.