### PR TITLE
Fixed typo in readme.header.md

### DIFF
--- a/tools/README.header.md
+++ b/tools/README.header.md
@@ -18,5 +18,5 @@ by Jorge L. "VinoBS" Rodriguez, and stb_image_resize2 and stb_sprintf by Jeff Ro
 
 <a name="stb_libs"></a>
 
-library    | lastest version | category | LoC | description
+library    | latest version | category | LoC | description
 --------------------- | ---- | -------- | --- | --------------------------------


### PR DESCRIPTION
Fixed a typo in the header file of README. Changed "lastest" to "latest".

Contributor name : CodeAlpha07 (Devu Gupta)
