### PR TITLE
Fix null pointer arithmetic in stb_image_resize2.h

### DIFF
--- a/stb_image_resize2.h
+++ b/stb_image_resize2.h
@@ -7057,7 +7057,7 @@ static stbir__info * stbir__alloc_internal_mem_and_build_samplers( stbir__sample
 #ifdef STBIR__SEPARATE_ALLOCATIONS
     #define STBIR__NEXT_PTR( ptr, size, ntype ) if ( alloced ) { void * p = STBIR_MALLOC( size, user_data); if ( p == 0 ) { stbir__free_internal_mem( info ); return 0; } (ptr) = (ntype*)p; }
 #else
-    #define STBIR__NEXT_PTR( ptr, size, ntype ) advance_mem = (void*) ( ( ((size_t)advance_mem) + 15 ) & ~15 ); if ( alloced ) ptr = (ntype*)advance_mem; advance_mem = ((char*)advance_mem) + (size);
+    #define STBIR__NEXT_PTR( ptr, size, ntype ) advance_mem = (void*) ( ( ((size_t)advance_mem) + 15 ) & ~15 ); if ( alloced ) ptr = (ntype*)advance_mem; advance_mem = (char*)(((size_t)advance_mem) + (size));
 #endif
 
     STBIR__NEXT_PTR( info, sizeof( stbir__info ), stbir__info );


### PR DESCRIPTION
A minimal reproduction for the undefined behavior is as follows:

```c
#define STB_IMAGE_RESIZE_IMPLEMENTATION
#include <stb_image_resize2.h>

int main() {
  unsigned char data[100]   = {0};
  unsigned char output[100] = {0};
  stbir_resize_uint8_linear(data, 10, 10, 0, output, 5, 5, 0, (stbir_pixel_layout)4);
  return 0;
}
```
```bash
clang example.c -fsanitize=undefined
./a.out
src/external/stb_image_resize2.h:7063:5: runtime error: applying non-zero offset 512 to null pointer
```

This PR fixes the undefined behavior by doing the same `size_t` cast we're doing in the first statement of the `STBIR__NEXT_PTR` macro.