### PR TITLE
- stb_ds.h: remove missing-field-initializers warning in c++

### DIFF
--- a/stb_ds.h
+++ b/stb_ds.h
@@ -761,7 +761,11 @@ size_t stbds_rehash_items;
 
 void *stbds_arrgrowf(void *a, size_t elemsize, size_t addlen, size_t min_cap)
 {
-  stbds_array_header temp={0}; // force debugging
+  stbds_array_header temp={
+#ifndef __cplusplus
+    0
+#endif
+  }; // force debugging
   void *b;
   size_t min_len = stbds_arrlen(a) + addlen;
   (void) sizeof(temp);


### PR DESCRIPTION
Use `{}` instead of `{0}` struct initializer in c++ to compile without warnings when using the `-Wextra` flag.
Tested with `g++ -std=c++0x -Wextra main.c`.