### PR TITLE
Support DIB with negative stride

### DIFF
--- a/stb_image_resize2.h
+++ b/stb_image_resize2.h
@@ -7968,10 +7968,10 @@ static int stbir__check_output_stuff( void ** ret_ptr, int * ret_pitch, void * o
   if ( output_stride_in_bytes == 0 )
     output_stride_in_bytes = pitch;
 
-  if ( output_stride_in_bytes < pitch )
+  if ( abs(output_stride_in_bytes) < pitch )
     return 0;
 
-  size = (size_t)output_stride_in_bytes * (size_t)output_h;
+  size = (size_t)abs(output_stride_in_bytes) * (size_t)output_h;
   if ( size == 0 )
     return 0;
 


### PR DESCRIPTION
Support DIB with negative stride, e.g. CImage/HBITMAP on windows/MFC.

Note: header file covers the topic, but the code does not (it assumes if the stride is smaller than pitch (size of scanline), something is wrong, but this will always be true for negative strides, which is the case for CImage).

      FLIPPED IMAGES
         Stride is just the delta from one scanline to the next. This means you can
         use a negative stride to handle inverted images (point to the final
         scanline and use a negative stride). You can invert the input or output,
         using negative strides.

Below code is now supported by this patched version of stb:

```
CImage src, dst;

            stbir_resize(static_cast<BYTE*>(src.GetBits()), src.GetWidth(), src.GetHeight(), src.GetPitch(), static_cast<BYTE*>(dst.GetBits()), dst.GetWidth(), dst.GetHeight(), dst.GetPitch(), STBIR_BGRA, STBIR_TYPE_UINT8, STBIR_EDGE_CLAMP, STBIR_FILTER_DEFAULT);

```
