### PR TITLE
Include ZLib Encoder In `stb_image_write`'s Header

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -194,6 +194,8 @@ STBIWDEF int stbi_write_jpg_to_func(stbi_write_func *func, void *context, int x,
 
 STBIWDEF void stbi_flip_vertically_on_write(int flip_boolean);
 
+STBIWDEF unsigned char *stbi_zlib_compress(unsigned char *data, int data_len, int *out_len, int quality);
+
 #endif//INCLUDE_STB_IMAGE_WRITE_H
 
 #ifdef STB_IMAGE_WRITE_IMPLEMENTATION


### PR DESCRIPTION
As part of the PNG encoder, `stb_image_write` includes a basic ZLib encoder (`stbi_zlib_compress`). This is defined with external-linkage, but is not included in the header without `STB_IMAGE_WRITE_IMPLEMENTATION`. This PR adds the function's prototype to the header-section so the encoder can be easily used.

This matches [the behavior](https://github.com/nothings/stb/blob/f58f558c120e9b32c217290b80bad1a0729fbb2c/stb_image.h#L527-L535) of the corresponding ZLib decoder in `stb_image`.