### PR TITLE
Fix crash - Avoid nullptr free in vorbis_deinit

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -34,6 +34,7 @@
 //    github:audinowho   Dougall Johnson     David Reid
 //    github:Clownacy    Pedro J. Estebanez  Remi Verschelde
 //    AnthoFoxo          github:morlat       Gabriel Ravier
+//    Daniel Collier
 //
 // Partial history:
 //    1.22    - 2021-07-11 - various small fixes
@@ -4210,10 +4211,13 @@ static void vorbis_deinit(stb_vorbis *p)
    int i,j;
 
    setup_free(p, p->vendor);
-   for (i=0; i < p->comment_list_length; ++i) {
-      setup_free(p, p->comment_list[i]);
+
+   if (p->comment_list) {
+      for (i=0; i < p->comment_list_length; ++i) {
+         if (p->comment_list[i]) setup_free(p, p->comment_list[i]);
+      }
+      setup_free(p, p->comment_list);
    }
-   setup_free(p, p->comment_list);
 
    if (p->residue_config) {
       for (i=0; i < p->residue_count; ++i) {


### PR DESCRIPTION
A corrupt .ogg file can cause a setup_malloc failure inside start_decoder. Specifically in this code:

```
if (f->comment_list_length > 0)
{
   f->comment_list = (char**) setup_malloc(f, sizeof(char*) * (f->comment_list_length));
   if (f->comment_list == NULL)                  return error(f, VORBIS_outofmem); // <<--------comment_list is NULL if setup_malloc fails.
}
```

Since setup_malloc can fail, we need to guard against NULL in vorbis_deinit. The subarrays can also be NULL if their allocations fail, so additional checks have been added for those as well.

----

**Repro steps if needed/wanted**

1. Download end extract the repo.zip somewhere. It contains a corrupted .ogg file and a minimal main.c which hits the crash: 
[repro.zip](https://github.com/user-attachments/files/22080003/repro.zip)
1. Grab a copy of stb_vorbis.c from master and put it in the same folder.
1. Compile (obviously need to run vcvarsall.bat or whatever) : ```cl /Zi /Od main.c```
1. Run ```main.exe``` and see that it crashes. "After stb_vorbis_open_filename..." does not get printed. The output will look as follows:
```
C:\dev\stb_vorbis_crash_fix>main.exe
Before stb_vorbis_open_filename...
```
5. Of course, do the same again but with my changes to stb_vorbis.c and see that there are no crashes. The output will be as follows:
```
C:\dev\stb_vorbis_crash_fix>main
Before stb_vorbis_open_filename...
After stb_vorbis_open_filename...
Failed to open file (error 3)
```
Note: the "Failed to open file" is expected because start_decoder() fails which causes vorbis_deinit() to get called. so stb_vorbis_open_filename() returns NULL.
6. Profit!

I tried to make the formatting and style follow the surrounding code, but let me know if it needs changing.

PS: Thanks so much for the stb libraries!

