### PR TITLE
stb_textedit: fixed cursor movement when pressing End (without Shift) after selecting multiple-lines

### DIFF
--- a/stb_textedit.h
+++ b/stb_textedit.h
@@ -1059,7 +1059,7 @@ retry:
       case STB_TEXTEDIT_K_LINEEND: {
          int n = STB_TEXTEDIT_STRINGLEN(str);
          stb_textedit_clamp(str, state);
-         stb_textedit_move_to_first(state);
+         stb_textedit_move_to_last(str, state);
          if (state->single_line)
              state->cursor = n;
          else while (state->cursor < n && STB_TEXTEDIT_GETCHAR(str, state->cursor) != STB_TEXTEDIT_NEWLINE)


### PR DESCRIPTION
Seems like a small bug that has been there from initial release.
(unless this was trying to mimick _some_ text editor but the behavior is rather odd so this seems unlikely to me)
All text editors I have tried behave like after the fix.

Repro:
- Perform a selection over multiple lines ~~(which does _not_ end up at end of the last selected line, otherwise issue is not noticeable)~~
- Press STB_TEXTEDIT_K_LINEEND key.
- Notice that cursor is moved to the end of the line corresponding to the beginning of selection.
- Desired: moved to the end of the line corresponding to the end of selection.

The code for Shift+STB_TEXTEDIT_K_LINEEND however works correctly and move the cursor at the right location, meaning there's a cursor moving difference between End and Shift+End, which arguably seems like a bug.

Calling `stb_textedit_move_to_last()` instead of `stb_textedit_move_to_first()` matches what STB_TEXTEDIT_K_RIGHT, STB_TEXTEDIT_K_WORDRIGHT paths are using.

The reason IMHO it hasn't been noticed is that when doing a multi-line selection you rarely want to press End without Shift.

Thank you!
