### PR TITLE
Fix compile error with MSVC

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -141,6 +141,7 @@ CREDITS:
       github:ignotion
       Adam Schackart
       Andrew Kensler
+      duckdoom5
 
 LICENSE
 


### PR DESCRIPTION
MSVC seems to define `sprintf_s` under `__STDC_WANT_SECURE_LIB__`. 
<img width="1528" height="297" alt="image" src="https://github.com/user-attachments/assets/2a444ed7-590d-4e92-ba45-b8e1402c1aaa" />
_C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\ucrt\stdio.h_

`__STDC_LIB_EXT1__` is undefined, causing the compiler to spit out this error:

```stb_image_write.h(763,15): error C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.```
