### PR TITLE
Fixes the first stbi_load_gif issue in #1838 by clearing `delays` on all outofmem paths

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -6956,7 +6956,10 @@ static void *stbi__load_gif_main_outofmem(stbi__gif *g, stbi_uc *out, int **dela
    STBI_FREE(g->background);
 
    if (out) STBI_FREE(out);
-   if (delays && *delays) STBI_FREE(*delays);
+   if (delays && *delays) {
+      STBI_FREE(*delays);
+      *delays = NULL;
+   }
    return stbi__errpuc("outofmem", "Out of memory");
 }
 
@@ -6991,19 +6994,15 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
             stride = g.w * g.h * 4;
 
             if (out) {
-               void *tmp = (stbi_uc*) STBI_REALLOC_SIZED( out, out_size, layers * stride );
-               if (!tmp)
+               out = (stbi_uc*) STBI_REALLOC_SIZED( out, out_size, layers * stride );
+               if (!out)
                   return stbi__load_gif_main_outofmem(&g, out, delays);
-               else {
-                   out = (stbi_uc*) tmp;
-                   out_size = layers * stride;
-               }
+               out_size = layers * stride;
 
                if (delays) {
-                  int *new_delays = (int*) STBI_REALLOC_SIZED( *delays, delays_size, sizeof(int) * layers );
-                  if (!new_delays)
+                  *delays = (int*) STBI_REALLOC_SIZED( *delays, delays_size, sizeof(int) * layers );
+                  if (!*delays)
                      return stbi__load_gif_main_outofmem(&g, out, delays);
-                  *delays = new_delays;
                   delays_size = layers * sizeof(int);
                }
             } else {


### PR DESCRIPTION
After calling `stbi_load_gif`, apps should free the `delays` pointer it passed in if `delays` is non-null. This means that after freeing `delays` in the `stbi__load_gif_main_outofmem` error path, stb_image_load should also set `delays` to `NULL`. Otherwise if we allocate `delays` once but we get to `stbi__load_gif_main_outofmem` on a later frame, then the app sees a non-null `delays` pointer and tries to free it again.

With this change, running `clang++ poc.c -fsanitize=address && ./a.out 490442704-000e388f-3edd-409b-9253-83046ac80317.gif` from #1838 now correctly reports "Failed to load GIF" instead of segfaulting.

Forks with JarLob's double-free fix in #1549 were also affected; it implemented this logic on some paths, but not all, and #1838 happens to reach one of the other paths. Moving the `delays = NULL` logic to `stbi__load_gif_main_outofmem` on those forks allows us to save a few lines of code.

In addition, since `realloc` first frees the input pointer ([C specification](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf) 7.22.3.5 item 1), we shouldn't pass the input to `stbi__load_gif_main_outofmem` after a realloc -- then we'd get a different double-free. If we remove the temporary pointer and do `p = realloc(p, ...)` then I think we get the right behavior and save a few lines of code.

Thanks!