### PR TITLE
stb_ds: add arrclear

### DIFF
--- a/stb_ds.h
+++ b/stb_ds.h
@@ -136,6 +136,11 @@ DOCUMENTATION
           Changes the length of the array to n. Allocates uninitialized
           slots at the end if necessary.
 
+      arrclear:
+        void arrclear(T* a);
+          Changes the length of the array to 0. Doesn't destroy the allocated
+          elements if any are present. Equivalent to arrsetlen(a, 0).
+
       arrsetcap:
         size_t arrsetcap(T* a, int n);
           Sets the length of allocated storage to at least n. It will not
@@ -405,6 +410,7 @@ CREDITS
 #define arraddnptr  stbds_arraddnptr
 #define arraddnindex stbds_arraddnindex
 #define arrsetlen   stbds_arrsetlen
+#define arrclear    stbds_arrclear
 #define arrlast     stbds_arrlast
 #define arrins      stbds_arrins
 #define arrinsn     stbds_arrinsn
@@ -537,6 +543,7 @@ extern void * stbds_shmode_func(size_t elemsize, int mode);
 
 #define stbds_arrsetcap(a,n)   (stbds_arrgrow(a,0,n))
 #define stbds_arrsetlen(a,n)   ((stbds_arrcap(a) < (size_t) (n) ? stbds_arrsetcap((a),(size_t)(n)),0 : 0), (a) ? stbds_header(a)->length = (size_t) (n) : 0)
+#define stbds_arrclear(a)      ((a) ? stbds_header(a)->length = 0 : 0)
 #define stbds_arrcap(a)        ((a) ? stbds_header(a)->capacity : 0)
 #define stbds_arrlen(a)        ((a) ? (ptrdiff_t) stbds_header(a)->length : 0)
 #define stbds_arrlenu(a)       ((a) ?             stbds_header(a)->length : 0)


### PR DESCRIPTION
I build my projects with compiler warnings enabled by default, so when I use `arrsetlen(a,n)` with `n=0`, I get this:

```c
stb_ds.h:539:50: warning: comparison of unsigned expression in ‘< 0’ is always false [-Wtype-limits]
  539 | #define stbds_arrsetlen(a,n)   ((stbds_arrcap(a) < (size_t) (n) ? stbds_arrsetcap((a),(si...
      |                                                  ^
stb_ds.h:407:21: note: in expansion of macro ‘stbds_arrsetlen’
  407 | #define arrsetlen   stbds_arrsetlen
      |                     ^~~~~~~~~~~~~~~
test.c:7:9: note: in expansion of macro ‘arrsetlen’
    7 |         arrsetlen(numbers, 0);
      |         ^~~~~~~~~
```

I understand that this warning is only relevant for the `n=0` case (warning description makes it pretty clear) and it's not dangerous at all, but it's a disturbing warning output which comes up on every clean build nevertheless.

I'd really want to avoid having to make exceptions for such warnings with pragmas, compiler arguments and what not.

So I've come up with `arrclear` macro. It does what it says, just like in STL's `vector`; and it doesn't raise the warning.

If you feel me on this one, consider having this macro in the `stb_ds.h`, otherwise never mind :^)

Best regards, Grigory