### PR TITLE
Add fix for https://github.com/nothings/stb/issues/1860 by checking malloc multiplication before allocating

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -1035,7 +1035,7 @@ static int stbi__mad3sizes_valid(int a, int b, int c, int add)
 }
 
 // returns 1 if "a*b*c*d + add" has no negative terms/factors and doesn't overflow
-#if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR) || !defined(STBI_NO_PNM)
+#if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR) || !defined(STBI_NO_PNM) || !defined(STBI_NO_PNG) || !defined(STBI_NO_PSD)
 static int stbi__mad4sizes_valid(int a, int b, int c, int d, int add)
 {
    return stbi__mul2sizes_valid(a, b) && stbi__mul2sizes_valid(a*b, c) &&
@@ -1058,7 +1058,7 @@ static void *stbi__malloc_mad3(int a, int b, int c, int add)
    return stbi__malloc(a*b*c + add);
 }
 
-#if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR) || !defined(STBI_NO_PNM)
+#if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR) || !defined(STBI_NO_PNM) || !defined(STBI_NO_PNG) || !defined(STBI_NO_PSD)
 static void *stbi__malloc_mad4(int a, int b, int c, int d, int add)
 {
    if (!stbi__mad4sizes_valid(a, b, c, d, add)) return NULL;


### PR DESCRIPTION
This should fix https://github.com/nothings/stb/issues/1860 .

Previously, `stbi__convert_format16` didn't check if the multiplication `req_comp * x * y * 2` would overflow before calling `stbi__malloc`. Thankfully, the fix is a quick change to use `stbi__malloc_mad4` instead of a raw `stbi__malloc`. (`stbi__convert_format8` already checked this. The floating-point path checks this inside `stbi__hdr_load`.)

I also added a safety check to code in `stbi__convert_8_to_16` that looks like it could run into a similar issue. (We know that `req_comp * x * y` is valid here because we've been passed a valid buffer. That does imply that we could save a few operations by doing an `stbi__malloc_mad2` inside `stbi__convert_format16`, though.)

Thanks!