### PR TITLE
Fixes issue #1861 by zero-initializing `palette`.

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -5077,9 +5077,9 @@ static void stbi__de_iphone(stbi__png *z)
 
 static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
 {
-   stbi_uc palette[1024], pal_img_n=0;
+   stbi_uc palette[1024]={0}, pal_img_n=0;
    stbi_uc has_trans=0, tc[3]={0};
-   stbi__uint16 tc16[3];
+   stbi__uint16 tc16[3]={0};
    stbi__uint32 ioff=0, idata_limit=0, i, pal_len=0;
    int first=1,k,interlace=0, color=0, is_iphone=0;
    stbi__context *s = z->s;


### PR DESCRIPTION
In Issue #1861 , out-of-bounds palette indices that are greater than or equal to `pal_len` read from uninitialized elements of `palette` in `stbi__expand_png_palette`. This is an issue since data that was written to the stack previously could include sensitive info.

As one approach to fixing this, this merge request zero-initializes `palette` (and `tc16` as well, since I think it might be possible for something similar to happen in `stbi__compute_transparency16` if `img_out_n` isn't equal to `img_n`), so that these reads return 0 instead of uninitialized data. (We know that we can't read past the end of `palette` in `stbi__expand_png_palette` since `palette` has length 1024, but `*palette` has type `stbi_uc`, so the maximum element we can read is `(1 << 8) * 4 + 3 == 1023`.)

A different approach would be to add a check that each element of the palette is less than `pal_len` and exit early if so. However, my guess is the cost of a 1024-element memset is probably less on average than checking the palette index of every pixel, even if the branches in the latter fix were always predicted correctly, because it prevents vectorization inside `stbi__expand_png_palette`.

Thank you!