### PR TITLE
Add STBIR_MEMCPY_NOUNALIGNED macro to avoid unaligned accesses.

### DIFF
--- a/stb_image_resize2.h
+++ b/stb_image_resize2.h
@@ -2839,6 +2839,7 @@ static void stbir_overlapping_memcpy( void * dest, void const * src, size_t byte
   char STBIR_SIMD_STREAMOUT_PTR( * ) s_end = ((char*) src) + bytes;
   ptrdiff_t ofs_to_dest = (char*)dest - (char*)src;
 
+  #ifndef STBIR_MEMCPY_NOUNALIGNED // define this before inclusion to force STB to always use aligned accesses
   if ( ofs_to_dest >= 8 ) // is the overlap more than 8 away?
   {
     char STBIR_SIMD_STREAMOUT_PTR( * ) s_end8 = ((char*) src) + (bytes&~7);
@@ -2853,6 +2854,7 @@ static void stbir_overlapping_memcpy( void * dest, void const * src, size_t byte
     if ( sd == s_end )
       return;
   }
+  #endif
 
   STBIR_NO_UNROLL_LOOP_START
   do


### PR DESCRIPTION
This adds the `STBIR_MEMCPY_NOUNALIGNED` macro in the same way that `stb_sprintf.h` does.  By defining this macro, the compiled code will not use any unaligned accesses, which on some architectures causes problems.  This is a fix for #1857.

Totally open to any other approaches to do this or whatever, it had just sat for a while and I wanted to get a fix in.

Thanks!
