### PR TITLE
Fix warning c6262 in stbi  load gif main

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -114,7 +114,7 @@ RECENT REVISION HISTORY:
     Josh Tobin              Neil Bickford      Matthew Gregan       github:poppolopoppo
     Julian Raschke          Gregory Mullen     Christian Floisand   github:darealshinji
     Baldur Karlsson         Kevin Schmidt      JR Smith             github:Michaelangel007
-                            Brad Weinberger    Matvey Cherevko      github:mosra
+    Denis Genestier         Brad Weinberger    Matvey Cherevko      github:mosra
     Luca Sas                Alexander Veselov  Zack Middleton       [reserved]
     Ryan C. Gordon          [reserved]                              [reserved]
                      DO NOT ADD YOUR NAME HERE


### PR DESCRIPTION
Visual Studio analyser is generating this warning:
`stb_image.h(6962): warning C6262: Function uses '35036' bytes of stack.  Consider moving some data to heap.`

So this pull request is moving the `stbi__gif` variable in the heap through an `alloc`/`free` call.