### PR TITLE
FIX: image_writer: use snprintf instead of sprintf (retry PR 1619)

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -772,6 +772,8 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
 
 #ifdef __STDC_LIB_EXT1__
       len = sprintf_s(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+      len = snprintf(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #else
       len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #endif


### PR DESCRIPTION
This is a cherry-pick of the fix from #1619 by @ismagilli. I opened a new pull request since the fork from #1619 was deleted, and the comment in https://github.com/nothings/stb/pull/1619#issuecomment-3791376191 suggested that there was a possibility that this patch could eventually be merged.

Original PR description:

> Modern compilers warn that the `sprintf` function is deprecated. I have added a call to `snprintf` function.
> 
> Note. Function `snprintf` appeared only in C99, so I added a check that the program compiles to the C99 standard and above. The `gcc` and `clang` compilers define the constant `__STDC_VERSION__`. The `defined(__STDC_VERSION__)` check is necessary because the `__STDC_VERSION__ ` constant may not defined.
> 
> From `man snprintf`:
> 
> ```
> the snprintf() and vsnprintf() functions conform to ISO/IEC 9899:1999 (“ISO C99”)
> ```

