### PR TITLE
Eliminate usage of "just" and "very"

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,8 +19,8 @@ address things. Many issues have been around for a long time.
 
 # Pull requests
 
-* Make sure you're using a special branch just for this pull request. (Sometimes people unknowingly use a default branch, then later update that branch, which updates the pull request with the other changes if it hasn't been merged yet.)
-* Do NOT update the version number in the file. (This just causes conflicts.)
+* Make sure you're using a special branch for this pull request. (Sometimes people unknowingly use a default branch, then later update that branch, which updates the pull request with the other changes if it hasn't been merged yet.)
+* Do NOT update the version number in the file. (This causes conflicts.)
 * Do add your name to the list of contributors. (Don't worry about the formatting.) I'll try to remember to add it if you don't, but I sometimes forget as it's an extra step.
 * Your change needs to compile as both C and C++. Pre-C99 compilers should be supported (e.g. declare at start of block)
 

--- a/.github/ISSUE_TEMPLATE/2-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/2-bug_report.md
@@ -27,4 +27,4 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **AI BUG REPORTS**  
-Using AI like LLMs just adds unnecessary additional verbiage that maintainers have to read and determine whether there is valuable and useful information. An AI by definition *cannot* add useful detail that was not in the original information you gathered. 
+Using AI like LLMs adds unnecessary additional verbiage that maintainers have to read and determine whether there is valuable and useful information. An AI by definition *cannot* add useful detail that was not in the original information you gathered.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 * Delete this list before clicking CREATE PULL REQUEST
-* Make sure you're using a special branch just for this pull request. (Sometimes people unknowingly use a default branch, then later update that branch, which updates the pull request with the other changes if it hasn't been merged yet.)
-* Do NOT update the version number in the file. (This just causes conflicts.)
+* Make sure you're using a special branch for this pull request. (Sometimes people unknowingly use a default branch, then later update that branch, which updates the pull request with the other changes if it hasn't been merged yet.)
+* Do NOT update the version number in the file. (This causes conflicts.)
 * Do add your name to the list of contributors. (Don't worry about the formatting.) I'll try to remember to add it if you don't, but I sometimes forget as it's an extra step.
 
 If you get something above wrong, don't fret it, it's not the end of the world.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ You can use [this URL](https://github.com/nothings/stb#stb_libs) to link directl
 
 #### Why do you list "lines of code"? It's a terrible metric.
 
-Just to give you some idea of the internal complexity of the library,
+To give you some idea of the internal complexity of the library,
 to help you manage your expectations, or to let you know what you're
 getting into. While not all the libraries are written in the same
 style, they're certainly similar styles, and so comparisons between
@@ -137,12 +137,12 @@ realize. (It also makes library dependencies a lot worse in Windows.)
 There's also a common problem in Windows where a library was built
 against a different version of the runtime library, which causes
 link conflicts and confusion. Shipping the libs as headers means
-you normally just compile them straight into your project without
+you normally compile them straight into your project without
 making libraries, thus sidestepping that problem.
 
-Making them a single file makes it very easy to just
-drop them into a project that needs them. (Of course you can
-still put them in a proper shared library tree if you want.)
+Making them a single file makes it easy to drop them into a project
+that needs them. (Of course you can still put them in a proper shared
+library tree if you want.)
 
 Why not two files, one a header and one an implementation?
 The difference between 10 files and 9 files is not a big deal,
@@ -152,7 +152,7 @@ remember to attach *two* files, etc.
 
 #### Why "stb"? Is this something to do with Set-Top Boxes?
 
-No, they are just the initials for my name, Sean T. Barrett.
+No, they are the initials for my name, Sean T. Barrett.
 This was not chosen out of egomania, but as a moderately sane
 way of namespacing the filenames and source function names.
 

--- a/docs/stb_howto.txt
+++ b/docs/stb_howto.txt
@@ -149,7 +149,7 @@ at it so why would you care whether your credit appeared
 there?
 
 Permissive licenses like zlib and BSD license are
-perfectly reasonable, but they are very wordy and
+perfectly reasonable, but they are wordy and
 have only two benefits over public domain: legally-mandated
 attribution and liability-control. I do not believe these
 are worth the excessive verbosity and user-unfriendliness
@@ -170,7 +170,7 @@ I recommend a declaration along these lines:
 // publish, and distribute this file as you see fit.
 
 I typically place this declaration at the end of the initial
-comment block of the file and just say 'public domain'
+comment block of the file and say 'public domain'
 at the top.
 
 I have had people say they couldn't use one of my

--- a/docs/stb_voxel_render_interview.md
+++ b/docs/stb_voxel_render_interview.md
@@ -25,7 +25,7 @@ For one thing, it's a terrible idea for the
 developer. Remember before Minecraft was on the Xbox 360,
 there were a ton of "indie" clones (some maybe making
 decent money even), but then the real Minecraft came out
-and just crushed them (as far as I know). It's just not
+and crushed them (as far as I know). It's not
 something you really want to compete with.
 
 The reason I made this library is because I'd like
@@ -35,7 +35,7 @@ necessary its *gameplay*.
 I can understand the urge to clone the gameplay. When
 you have a world made of voxels/blocks, there are a
 few things that become incredibly easy to do that would
-otherwise be very hard (at least for an indie) to do in 3D.
+otherwise be hard (at least for an indie) to do in 3D.
 One thing is that procedural generation becomes much easier.
 Another is that destructible environments are easy. Another
 is that you have a world where your average user can build
@@ -71,22 +71,22 @@ technology that could be used multiple ways.
 One thing I did intentionally was try to make it possible to
 make nicer looking ground terrain, using the half-height
 slopes and "weird slopes". There are Minecraft mods with
-drivable cars and they just go up these blocky slopes and,
+drivable cars and they go up these blocky slopes and,
 like, what? So I wanted you to be able to make smoother
-terrain, either just for the look, or for vehicles etc.
+terrain, either for the look, or for vehicles etc.
 Also, you can spatially cross-fade between two ground textures for
 that classic bad dirt/grass transition that has shipped
 in plenty of professional games. Of course, you could
-just use a separate non-voxel ground renderer for all of
+use a separate non-voxel ground renderer for all of
 this. But this way, you can seamlessly integrate everything
 else with it. E.g. in your authoring tool (or procedural
 generation) you can make smooth ground and then cut a
 sharp-edged hole in it for a building's basement or whatever.
 
-Another thing you can do is work at a very different scale.
-In Minecraft, a person is just under 2 blocks tall. In
-Ace of Spades, a person is just under 3 blocks tall. Why
-not 4 or 6? Well, partly because you just need a lot more
+Another thing you can do is work at a different scale.
+In Minecraft, a person is under 2 blocks tall. In
+Ace of Spades, a person is under 3 blocks tall. Why
+not 4 or 6? Well, partly because you need a lot more
 voxels; if a meter is 2 voxels in Mineraft and 4 voxels in
 your game, and you draw the same number of voxels due to
 hardware limits, then your game has half the view distance
@@ -144,7 +144,7 @@ first Minecraft map in stb_voxel_render release trailer). I'd
 made a bunch of procedural level generators for the game, and
 I started trying to make a city generator inspired by Broville.
 
-But I realized it would be a lot of work, and of very little
+But I realized it would be a lot of work, and of little
 value (most of my maps didn't get much play because people
 preferred to play on maps where they could charge straight
 at the enemies and shoot them as fast as possible). So I

--- a/docs/why_public_domain.md
+++ b/docs/why_public_domain.md
@@ -9,7 +9,7 @@ in the public domain:
   development of it, and then because it doesn't develop as well it's
   not as good, and then because it's not as good, in the long run
   maybe fewer people will use it. I have total respect for that
-  opinion, but I just don't believe it myself for most software.
+  opinion, but I don't believe it myself for most software.
 
 2. Public domain vs. attribution-required licenses
 
@@ -28,7 +28,7 @@ in the public domain:
 3. Other aspects of BSD-style licenses besides attribution
 
   Permissive licenses like zlib and BSD license are perfectly reasonable
-  in their requirements, but they are very wordy and
+  in their requirements, but they are wordy and
   have only two benefits over public domain: legally-mandated
   attribution and liability-control. I do not believe these
   are worth the excessive verbosity and user-unfriendliness
@@ -80,7 +80,7 @@ at it so why would you care whether your credit
 appeared there?
 
 Permissive licenses like zlib and BSD license are
-perfectly reasonable, but they are very wordy and
+perfectly reasonable, but they are wordy and
 have only two benefits over public domain: legally-mandated
 attribution and liability-control. I do not believe these
 are worth the excessive verbosity and user-unfriendliness
@@ -101,7 +101,7 @@ I recommend a declaration along these lines:
 // publish, and distribute this file as you see fit.
 
 I typically place this declaration at the end of the initial
-comment block of the file and just say 'public domain'
+comment block of the file and say 'public domain'
 at the top.
 
 I have had people say they couldn't use one of my

--- a/stb_c_lexer.h
+++ b/stb_c_lexer.h
@@ -33,7 +33,7 @@
 //     - haven't implemented multiline strings
 //     - haven't implemented octal/hex character constants
 //     - haven't implemented support for unicode CLEX_char
-//     - need to expand error reporting so you don't just get "CLEX_parse_error"
+//     - need to expand error reporting so you don't get "CLEX_parse_error"
 //
 // Contributors:
 //   Arpad Goretity (bugfix)

--- a/stb_connected_components.h
+++ b/stb_connected_components.h
@@ -16,7 +16,7 @@
 //
 // The above creates an implementation that can run on maps up to 1024x1024.
 // Map sizes must be a multiple of (1<<(LOG2/2)) on each axis (e.g. 32 if LOG2=10,
-// 16 if LOG2=8, etc.) (You can just pad your map with untraversable space.)
+// 16 if LOG2=8, etc.) (You can pad your map with untraversable space.)
 //
 // MEMORY USAGE
 //
@@ -49,7 +49,7 @@
 //    - more comments
 //    - try re-integrating naive algorithm & compare performance
 //    - more optimized batching (current approach still recomputes local clumps many times)
-//    - function for setting a grid of squares at once (just use batching)
+//    - function for setting a grid of squares at once (use batching)
 //
 // LICENSE
 //
@@ -96,7 +96,7 @@ extern "C" {
 //  initialization
 //
 
-// you allocate the grid data structure to this size (note that it will be very big!!!)
+// you allocate the grid data structure to this size (note that it will be big)
 extern size_t stbcc_grid_sizeof(void);
 
 // initialize the grid, value of map[] is 0 = traversable, non-0 is solid
@@ -130,7 +130,7 @@ extern void stbcc_update_batch_end(stbcc_grid *g);
 extern int stbcc_query_grid_open(stbcc_grid *g, int x, int y);
 
 // get a unique id for the connected component this is in; it's not necessarily
-// small, you'll need a hash table or something to remap it (or just use
+// small, you'll need a hash table or something to remap it (or use
 extern unsigned int stbcc_get_unique_id(stbcc_grid *g, int x, int y);
 #define STBCC_NULL_UNIQUE_ID 0xffffffff // returned for closed map squares
 
@@ -408,7 +408,7 @@ static void stbcc__build_all_connections_for_cluster(stbcc_grid *g, int cx, int 
 {
    // in this particular case, we are fully non-incremental. that means we
    // can discover the correct sizes for the arrays, but requires we build
-   // the data into temporary data structures, or just count the sizes, so
+   // the data into temporary data structures, or count the sizes, so
    // for simplicity we do the latter
    stbcc__cluster *cluster = &g->cluster[cy][cx];
    unsigned char connected[STBCC__MAX_EDGE_CLUMPS_PER_CLUSTER][STBCC__MAX_EDGE_CLUMPS_PER_CLUSTER/8]; // 64 x 8 => 1KB

--- a/stb_divide.h
+++ b/stb_divide.h
@@ -19,7 +19,7 @@
 //    // #define C_INTEGER_DIVISION_FLOORS     // see Note 2
 //    #include "stb_divide.h"
 //
-// Other source files should just include stb_divide.h
+// Other source files should include stb_divide.h
 //
 // Note 1: On platforms/compilers that you know signed C division
 // truncates, you can #define C_INTEGER_DIVISION_TRUNCATES.
@@ -168,14 +168,14 @@ int stb_div_floor(int v1, int v2)
    #else
    if (v1 >= 0 && v2 < 0) {
       if (v2 + 1 >= INT_MIN + v1) // check if increasing v1's magnitude overflows
-         return -stb__div((v2+1)-v1,v2); // nope, so just compute it
+         return -stb__div((v2+1)-v1,v2); // nope, so compute it
       else
          return -stb__div(-v1,v2) + ((-v1)%v2 ? -1 : 0);
    }
    if (v1 < 0 && v2 >= 0) {
       if (v1 != INT_MIN) {
          if (v1 + 1 >= INT_MIN + v2) // check if increasing v1's magnitude overflows
-            return -stb__div((v1+1)-v2,-v2); // nope, so just compute it
+            return -stb__div((v1+1)-v2,-v2); // nope, so compute it
          else
             return -stb__div(-v1,v2) + (stb__mod(v1,-v2) ? -1 : 0);
       } else // it must be possible to compute -(v1+v2) without overflowing

--- a/stb_ds.h
+++ b/stb_ds.h
@@ -340,7 +340,7 @@ NOTES - HASH MAP
     in GCC or clang, or if you're using C++ in GCC. But note that this can make your
     code less portable.
 
-  * To test for presence of a key in a hashmap, just do 'hmgeti(foo,key) >= 0'.
+  * To test for presence of a key in a hashmap, do 'hmgeti(foo,key) >= 0'.
 
   * The iteration order of your data in the hashmap is determined solely by the
     order of insertions and deletions. In particular, if you never delete, new
@@ -355,7 +355,7 @@ NOTES - HASH MAP
     @TODO: make an arena variant that garbage collects the strings with a trivial
     copy collector into a new arena whenever the table shrinks / rebuilds. Since
     current arena recommendation is to only use arena if it never deletes, then
-    this can just replace current arena implementation.
+    this can replace current arena implementation.
 
   * If adversarial input is a serious concern and you're on a 64-bit platform,
     enable STBDS_SIPHASH_2_4 (see the 'Compile-time options' section), and pass
@@ -836,7 +836,7 @@ typedef struct
   size_t seed;
   size_t slot_count_log2;
   stbds_string_arena string;
-  stbds_hash_bucket *storage; // not a separate allocation, just 64-byte aligned storage after this struct
+  stbds_hash_bucket *storage; // not a separate allocation, 64-byte aligned storage after this struct
 } stbds_hash_index;
 
 #define STBDS_INDEX_EMPTY    -1
@@ -1056,7 +1056,7 @@ static size_t stbds_siphash_bytes(void *p, size_t len, size_t seed)
 
   // hash that works on 32- or 64-bit registers without knowing which we have
   // (computes different results on 32-bit and 64-bit platform)
-  // derived from siphash, but on 32-bit platforms very different as it uses 4 32-bit state not 4 64-bit
+  // derived from siphash, but on 32-bit platforms different as it uses 4 32-bit state not 4 64-bit
   v0 = ((((size_t) 0x736f6d65 << 16) << 16) + 0x70736575) ^  seed;
   v1 = ((((size_t) 0x646f7261 << 16) << 16) + 0x6e646f6d) ^ ~seed;
   v2 = ((((size_t) 0x6c796765 << 16) << 16) + 0x6e657261) ^  seed;
@@ -1571,7 +1571,7 @@ char *stbds_stralloc(stbds_string_arena *a, char *str)
       ++a->block;
 
     if (len > blocksize) {
-      // if string is larger than blocksize, then just allocate the full size.
+      // if string is larger than blocksize, then allocate the full size.
       // note that we still advance string_block so block size will continue
       // increasing, so e.g. if somebody only calls this with 1000-long strings,
       // eventually the arena will start doubling and handling those as well

--- a/stb_dxt.h
+++ b/stb_dxt.h
@@ -68,7 +68,7 @@ STBDDEF void stb_compress_bc5_block(unsigned char *dest, const unsigned char *sr
 
 #ifdef STB_DXT_IMPLEMENTATION
 
-// configuration options for DXT encoder. set them in the project/makefile or just define
+// configuration options for DXT encoder. set them in the project/makefile or define
 // them at the top.
 
 // STB_DXT_USE_ROUNDING_BIAS
@@ -239,7 +239,7 @@ static unsigned int stb__MatchColorsBlock(unsigned char *block, unsigned char *c
    // half"/"best in bottom half" and then the same inside that subinterval.
    //
    // relying on this 1d approximation isn't always optimal in terms of euclidean distance,
-   // but it's very close and a lot faster.
+   // but it's close, and a lot faster.
    // http://cbloomrants.blogspot.com/2008/12/12-08-08-dxtc-summary.html
 
    c0Point   = (stops[1] + stops[3]);

--- a/stb_easy_font.h
+++ b/stb_easy_font.h
@@ -8,7 +8,7 @@
 //    ASCII-only,
 //    bitmap font for use in 3D APIs.
 //
-// Intended for when you just want to get some text displaying
+// Intended for when you want to get some text displaying
 // in a 3D app as quickly as possible.
 //
 // Doesn't use any textures, instead builds characters out of quads.

--- a/stb_herringbone_wang_tile.h
+++ b/stb_herringbone_wang_tile.h
@@ -340,7 +340,7 @@ STBHW_EXTERN int stbhw_make_template(stbhw_config *c, unsigned char *data, int w
 #endif
 
 // global variables for color assignments
-// @MEMORY change these to just store last two/three rows
+// @MEMORY change these to store last two/three rows
 //         and keep them on the stack
 static signed char c_color[STB_HBWANG_MAX_Y+6][STB_HBWANG_MAX_X+6];
 static signed char v_color[STB_HBWANG_MAX_Y+6][STB_HBWANG_MAX_X+5];
@@ -979,7 +979,7 @@ static unsigned char stbhw__black[3] = { 0,0,0 };
 
 // each edge set gets its own unique color variants
 // used http://phrogz.net/css/distinct-colors.html to generate this set,
-// but it's not very good and needs to be revised
+// but it's not good and needs to be revised
 
 static unsigned char stbhw__color[7][8][3] =
 {

--- a/stb_hexwave.h
+++ b/stb_hexwave.h
@@ -154,7 +154,7 @@
 //      AlternatingSaw               AlternatingSaw   0       0..1     0..any   0
 //
 //   The last entry is noteworthy because the morph from the halfway point to either
-//   endpoint sounds very different. For example, an LFO sweeping back and forth over
+//   endpoint sounds different. For example, an LFO sweeping back and forth over
 //   the whole range will morph between the middle timbre and the AlternatingSaw
 //   timbre in two different ways, alternating.
 //
@@ -162,7 +162,7 @@
 //   any value you want as the endpoint for half_height.
 //
 //   You can always morph between any two waveforms with the same value of 'reflect'
-//   by just sweeping the parameters simultaneously. There will never be artifacts
+//   by sweeping the parameters simultaneously. There will never be artifacts
 //   and the result will always be useful, if not necessarily what you want.
 //
 //   You can vary the sound of two-parameter morphs by ramping them differently,
@@ -385,7 +385,7 @@ static void hexwave_generate_linesegs(hexvert vert[9], HexWave *hex, float dt)
           // why does this happen if the math is right? i believe if done perfectly,
           // the two BLAMPs on either side of the slope would cancel out, but our
           // BLAMPs have only limited sub-sample precision and limited integration
-          // accuracy. or maybe it's just the math blowing up w/ floating point precision
+          // accuracy. or maybe it's the math blowing up w/ floating point precision
           // limits as we try to make x * (1/x) cancel out
           //
           // min_len verified artifact-free even near nyquist with only oversample=4

--- a/stb_image.h
+++ b/stb_image.h
@@ -50,7 +50,7 @@ RECENT REVISION HISTORY:
 
       2.30  (2024-05-31) avoid erroneous gcc warning
       2.29  (2023-05-xx) optimizations
-      2.28  (2023-01-29) many error fixes, security errors, just tons of stuff
+      2.28  (2023-01-29) many error fixes, security errors, tons of stuff
       2.27  (2021-07-11) document stbi_info better, 16-bit PNM support, bug fixes
       2.26  (2020-07-13) many minor fixes
       2.25  (2020-02-02) fix warnings
@@ -194,7 +194,7 @@ RECENT REVISION HISTORY:
 // including sizes of memory buffers. This is now part of the API and thus
 // hard to change without causing breakage. As a result, the various image
 // loaders all have certain limits on image size; these differ somewhat
-// by format but generally boil down to either just under 2GB or just under
+// by format but generally boil down to either under 2GB or under
 // 1GB. When the decoded image would be larger than this, stb_image decoding
 // will fail.
 //
@@ -365,7 +365,7 @@ RECENT REVISION HISTORY:
 //    valid image of gigantic dimensions and force stb_image to allocate a
 //    huge block of memory and spend disproportionate time decoding it. By
 //    default this is set to (1 << 24), which is 16777216, but that's still
-//    very big.
+//    big.
 
 #ifndef STBI_NO_STDIO
 #include <stdio.h>
@@ -483,11 +483,11 @@ STBIDEF int      stbi_is_hdr_from_file(FILE *f);
 #endif // STBI_NO_STDIO
 
 
-// get a VERY brief reason for failure
+// get a brief reason for failure
 // on most compilers (and ALL modern mainstream compilers) this is threadsafe
 STBIDEF const char *stbi_failure_reason  (void);
 
-// free the loaded image -- this is just free()
+// free the loaded image -- this is free()
 STBIDEF void     stbi_image_free      (void *retval_from_stbi_load);
 
 // get image dimensions & components without fully decoding
@@ -506,12 +506,12 @@ STBIDEF int      stbi_is_16_bit_from_file(FILE *f);
 
 
 // for image formats that explicitly notate that they have premultiplied alpha,
-// we just return the colors as stored in the file. set this flag to force
+// we return the colors as stored in the file. set this flag to force
 // unpremultiplication. results are undefined if the unpremultiply overflow.
 STBIDEF void stbi_set_unpremultiply_on_load(int flag_true_if_should_unpremultiply);
 
 // indicate whether we should process iphone images back to canonical format,
-// or just pass them through "as-is"
+// or pass them through "as-is"
 STBIDEF void stbi_convert_iphone_png_to_rgb(int flag_true_if_should_convert);
 
 // flip the image vertically, so the first pixel in the output array is the bottom left
@@ -886,7 +886,7 @@ static void stbi__start_file(stbi__context *s, FILE *f)
 static void stbi__rewind(stbi__context *s)
 {
    // conceptually rewind SHOULD rewind to the beginning of the stream,
-   // but we just rewind to the beginning of the initial buffer, because
+   // but we rewind to the beginning of the initial buffer, because
    // we only use it after doing 'test', which only ever looks at at most 92 bytes
    s->img_buffer = s->img_buffer_original;
    s->img_buffer_end = s->img_buffer_original_end;
@@ -1141,7 +1141,7 @@ static void *stbi__load_main(stbi__context *s, int *x, int *y, int *comp, int re
    ri->channel_order = STBI_ORDER_RGB; // all current input & output are this, but this is here so we can add BGR order
    ri->num_channels = 0;
 
-   // test the formats with a very explicit header first (at least a FOURCC
+   // test the formats with a explicit header first (at least a FOURCC
    // or distinctive magic number first)
    #ifndef STBI_NO_PNG
    if (stbi__png_test(s))  return stbi__png_load(s,x,y,comp,req_comp, ri);
@@ -1161,7 +1161,7 @@ static void *stbi__load_main(stbi__context *s, int *x, int *y, int *comp, int re
    if (stbi__pic_test(s))  return stbi__pic_load(s,x,y,comp,req_comp, ri);
    #endif
 
-   // then the formats that can end up attempting to load with just 1 or 2
+   // then the formats that can end up attempting to load with 1 or 2
    // bytes matching expectations; these are prone to false positives, so
    // try them later
    #ifndef STBI_NO_JPEG
@@ -1737,7 +1737,7 @@ static stbi__uint32 stbi__get32le(stbi__context *s)
 //  generic converter from built-in img_n to req_comp
 //    individual types do this automatically as much as possible (e.g. jpeg
 //    does all cases internally since it needs to colorspace convert anyway,
-//    and it never has alpha, so very few cases ). png can automatically
+//    and it never has alpha, so few cases ). png can automatically
 //    interleave an alpha=255 channel, but falls back to this for other cases
 //
 //  assume data buffer is malloced, so malloc a new one and free that one
@@ -2374,7 +2374,7 @@ static int stbi__jpeg_decode_block_prog_ac(stbi__jpeg *j, short data[64], stbi__
                      j->eob_run += stbi__jpeg_get_bits(j, r);
                   r = 64; // force end of block
                } else {
-                  // r=15 s=0 should write 16 0s, so we just do
+                  // r=15 s=0 should write 16 0s, so we do
                   // a run of 15 0s and then write s (which is 0),
                   // so we don't have to do anything special here
                }
@@ -2954,9 +2954,9 @@ static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
          int i,j;
          STBI_SIMD_ALIGN(short, data[64]);
          int n = z->order[0];
-         // non-interleaved data, we just need to process one block at a time,
+         // non-interleaved data, we need to process one block at a time,
          // in trivial scanline order
-         // number of blocks to do just depends on how many actual "pixels" this
+         // number of blocks to do depends on how many actual "pixels" this
          // component has, independent of interleaved MCU blocking and such
          int w = (z->img_comp[n].x+7) >> 3;
          int h = (z->img_comp[n].y+7) >> 3;
@@ -2968,7 +2968,7 @@ static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
                // every data block is an MCU, so countdown the restart interval
                if (--z->todo <= 0) {
                   if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
-                  // if it's NOT a restart, then just bail, so we get corrupt data
+                  // if it's NOT a restart, then bail, so we get corrupt data
                   // rather than no data
                   if (!STBI__RESTART(z->marker)) return 1;
                   stbi__jpeg_reset(z);
@@ -2984,7 +2984,7 @@ static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
                // scan an interleaved mcu... process scan_n components in order
                for (k=0; k < z->scan_n; ++k) {
                   int n = z->order[k];
-                  // scan out an mcu's worth of this component; that's just determined
+                  // scan out an mcu's worth of this component; that's determined
                   // by the basic H and V specified for the component
                   for (y=0; y < z->img_comp[n].v; ++y) {
                      for (x=0; x < z->img_comp[n].h; ++x) {
@@ -3011,9 +3011,9 @@ static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
       if (z->scan_n == 1) {
          int i,j;
          int n = z->order[0];
-         // non-interleaved data, we just need to process one block at a time,
+         // non-interleaved data, we need to process one block at a time,
          // in trivial scanline order
-         // number of blocks to do just depends on how many actual "pixels" this
+         // number of blocks to do depends on how many actual "pixels" this
          // component has, independent of interleaved MCU blocking and such
          int w = (z->img_comp[n].x+7) >> 3;
          int h = (z->img_comp[n].y+7) >> 3;
@@ -3044,7 +3044,7 @@ static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
                // scan an interleaved mcu... process scan_n components in order
                for (k=0; k < z->scan_n; ++k) {
                   int n = z->order[k];
-                  // scan out an mcu's worth of this component; that's just determined
+                  // scan out an mcu's worth of this component; that's determined
                   // by the basic H and V specified for the component
                   for (y=0; y < z->img_comp[n].v; ++y) {
                      for (x=0; x < z->img_comp[n].h; ++x) {
@@ -3269,8 +3269,8 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
    p  = stbi__get8(s);            if (p != 8) return stbi__err("only 8-bit","JPEG format not supported: 8-bit only"); // JPEG baseline
    s->img_y = stbi__get16be(s);   if (s->img_y == 0) return stbi__err("no header height", "JPEG format not supported: delayed height"); // Legal, but we don't handle it--but neither does IJG
    s->img_x = stbi__get16be(s);   if (s->img_x == 0) return stbi__err("0 width","Corrupt JPEG"); // JPEG requires
-   if (s->img_y > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
-   if (s->img_x > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
+   if (s->img_y > STBI_MAX_DIMENSIONS) return stbi__err("too large","Large image (corrupt?)");
+   if (s->img_x > STBI_MAX_DIMENSIONS) return stbi__err("too large","Large image (corrupt?)");
    c = stbi__get8(s);
    if (c != 3 && c != 1 && c != 4) return stbi__err("bad component count","Corrupt JPEG");
    s->img_n = c;
@@ -3690,7 +3690,7 @@ static void stbi__YCbCr_to_RGB_simd(stbi_uc *out, stbi_uc const *y, stbi_uc cons
 #ifdef STBI_SSE2
    // step == 3 is pretty ugly on the final interleave, and i'm not convinced
    // it's useful in practice (you wouldn't use it for textures, for example).
-   // so just accelerate step == 4 case.
+   // so accelerate step == 4 case.
    if (step == 4) {
       // this is a fairly straightforward implementation and not super-optimized.
       __m128i signflip  = _mm_set1_epi8(-0x80);
@@ -4325,7 +4325,7 @@ static int stbi__parse_huffman_block(stbi__zbuf *a)
             a->zout = zout;
             if (a->hit_zeof_once && a->num_bits < 16) {
                // The first time we hit zeof, we inserted 16 extra zero bits into our bit
-               // buffer so the decoder can just do its speculative decoding. But if we
+               // buffer so the decoder can do its speculative decoding. But if we
                // actually consumed any of those bits (which is the case when num_bits < 16),
                // the stream actually read past the end so it is malformed.
                return stbi__err("unexpected end","Corrupt PNG");
@@ -4656,7 +4656,7 @@ static stbi_uc first_row_filter[5] =
 
 static int stbi__paeth(int a, int b, int c)
 {
-   // This formulation looks very different from the reference in the PNG spec, but is
+   // This formulation looks different from the reference in the PNG spec, but is
    // actually equivalent and has favorable data dependencies and admits straightforward
    // generation of branch-free code, which helps performance significantly.
    int thresh = c*3 - (a + b);
@@ -4721,7 +4721,7 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
 
    // we used to check for exact match between raw_len and img_len on non-interlaced PNGs,
    // but issue #276 reported a PNG in the wild that had extra data at the end (all zeros),
-   // so just check for raw_len < img_len always.
+   // so check for raw_len < img_len always.
    if (raw_len < img_len) return stbi__err("not enough pixels","Corrupt PNG");
 
    // Allocate two scan lines worth of filter workspace buffer.
@@ -5106,8 +5106,8 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
             if (c.length != 13) return stbi__err("bad IHDR len","Corrupt PNG");
             s->img_x = stbi__get32be(s);
             s->img_y = stbi__get32be(s);
-            if (s->img_y > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
-            if (s->img_x > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
+            if (s->img_y > STBI_MAX_DIMENSIONS) return stbi__err("too large","Large image (corrupt?)");
+            if (s->img_x > STBI_MAX_DIMENSIONS) return stbi__err("too large","Large image (corrupt?)");
             z->depth = stbi__get8(s);  if (z->depth != 1 && z->depth != 2 && z->depth != 4 && z->depth != 8 && z->depth != 16)  return stbi__err("1/2/4/8/16-bit only","PNG not supported: 1/2/4/8/16-bit only");
             color = stbi__get8(s);  if (color > 6)         return stbi__err("bad ctype","Corrupt PNG");
             if (color == 3 && z->depth == 16)                  return stbi__err("bad ctype","Corrupt PNG");
@@ -5545,8 +5545,8 @@ static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req
    flip_vertically = ((int) s->img_y) > 0;
    s->img_y = abs((int) s->img_y);
 
-   if (s->img_y > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
-   if (s->img_x > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+   if (s->img_y > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Large image (corrupt?)");
+   if (s->img_x > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Large image (corrupt?)");
 
    mr = info.mr;
    mg = info.mg;
@@ -5898,8 +5898,8 @@ static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req
    STBI_NOTUSED(tga_x_origin); // @TODO
    STBI_NOTUSED(tga_y_origin); // @TODO
 
-   if (tga_height > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
-   if (tga_width > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+   if (tga_height > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Large image (corrupt?)");
+   if (tga_width > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Large image (corrupt?)");
 
    //   do a tiny bit of precessing
    if ( tga_image_type >= 8 )
@@ -6153,8 +6153,8 @@ static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req
    h = stbi__get32be(s);
    w = stbi__get32be(s);
 
-   if (h > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
-   if (w > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+   if (h > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Large image (corrupt?)");
+   if (w > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Large image (corrupt?)");
 
    // Make sure the depth is 8 bits.
    bitdepth = stbi__get16be(s);
@@ -6220,7 +6220,7 @@ static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req
       // Endloop
 
       // The RLE-compressed data is preceded by a 2-byte data count for each row in the data,
-      // which we're going to just skip.
+      // which we're going to skip.
       stbi__skip(s, h * channelCount * 2 );
 
       // Read the RLE data by channel.
@@ -6511,8 +6511,8 @@ static void *stbi__pic_load(stbi__context *s,int *px,int *py,int *comp,int req_c
    x = stbi__get16be(s);
    y = stbi__get16be(s);
 
-   if (y > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
-   if (x > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+   if (y > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Large image (corrupt?)");
+   if (x > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Large image (corrupt?)");
 
    if (stbi__at_eof(s))  return stbi__errpuc("bad file","file too short (pic header)");
    if (!stbi__mad3sizes_valid(x, y, 4, 0)) return stbi__errpuc("too large", "PIC image too large to decode");
@@ -6623,8 +6623,8 @@ static int stbi__gif_header(stbi__context *s, stbi__gif *g, int *comp, int is_in
    g->ratio = stbi__get8(s);
    g->transparent = -1;
 
-   if (g->w > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
-   if (g->h > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
+   if (g->w > STBI_MAX_DIMENSIONS) return stbi__err("too large","Large image (corrupt?)");
+   if (g->h > STBI_MAX_DIMENSIONS) return stbi__err("too large","Large image (corrupt?)");
 
    if (comp != 0) *comp = 4;  // can't actually tell whether it's 3 or 4 until we parse the comments
 
@@ -6774,7 +6774,7 @@ static stbi_uc *stbi__process_gif_raster(stbi__context *s, stbi__gif *g)
 }
 
 // this function is designed to support animated gifs, although stb_image doesn't support it
-// two back is the image from two frames ago, used for a very specific disposal format
+// two back is the image from two frames ago, used for a specific disposal format
 static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, int req_comp, stbi_uc *two_back)
 {
    int dispose;
@@ -6896,7 +6896,7 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
                // if first frame, any pixel not drawn to gets the background color
                for (pi = 0; pi < pcount; ++pi) {
                   if (g->history[pi] == 0) {
-                     g->pal[g->bgindex][3] = 255; // just in case it was made transparent, undo that; It will be reset next frame if need be;
+                     g->pal[g->bgindex][3] = 255; // in case it was made transparent, undo that; It will be reset next frame if need be;
                      memcpy( &g->out[pi * 4], &g->pal[g->bgindex], 4 );
                   }
                }
@@ -7194,8 +7194,8 @@ static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int re
    token += 3;
    width = (int) strtol(token, NULL, 10);
 
-   if (height > STBI_MAX_DIMENSIONS) return stbi__errpf("too large","Very large image (corrupt?)");
-   if (width > STBI_MAX_DIMENSIONS) return stbi__errpf("too large","Very large image (corrupt?)");
+   if (height > STBI_MAX_DIMENSIONS) return stbi__errpf("too large","Large image (corrupt?)");
+   if (width > STBI_MAX_DIMENSIONS) return stbi__errpf("too large","Large image (corrupt?)");
 
    *x = width;
    *y = height;
@@ -7512,8 +7512,8 @@ static void *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req
    if (ri->bits_per_channel == 0)
       return 0;
 
-   if (s->img_y > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
-   if (s->img_x > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+   if (s->img_y > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Large image (corrupt?)");
+   if (s->img_x > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Large image (corrupt?)");
 
    *x = s->img_x;
    *y = s->img_y;

--- a/stb_image_resize2.h
+++ b/stb_image_resize2.h
@@ -161,7 +161,7 @@
 
          The difference between the generic 4 or 2 channel layouts, and the
          specialized _PM versions is with the _PM versions you are telling us that
-         the data *is* alpha, just don't premultiply it. That's important when
+         the data *is* alpha, don't premultiply it. That's important when
          using SRGB pixel formats, we need to know where the alpha is, because
          it is converted linearly (rather than with the SRGB converters).
 
@@ -234,7 +234,7 @@
          buffers).
 
       FLIPPED IMAGES
-         Stride is just the delta from one scanline to the next. This means you can
+         Stride is the delta from one scanline to the next. This means you can
          use a negative stride to handle inverted images (point to the final
          scanline and use a negative stride). You can invert the input or output,
          using negative strides.
@@ -255,13 +255,13 @@
 
       PROGRESS
          For interactive use with slow resize operations, you can use the 
-         scanline callbacks in the extended API. It would have to be a *very* large
-         image resample to need progress though - we're very fast.
+         scanline callbacks in the extended API. It would have to be a large
+         image resample to need progress though - we're fast.
 
       CEIL and FLOOR
          In scalar mode, the only functions we use from math.h are ceilf and floorf,
          but if you have your own versions, you can define the STBIR_CEILF(v) and
-         STBIR_FLOORF(v) macros and we'll use them instead. In SIMD, we just use
+         STBIR_FLOORF(v) macros and we'll use them instead. In SIMD, we use
          our own versions.
 
       ASSERT
@@ -288,7 +288,7 @@
 
           stbir_resize_uint8_srgb_edgemode()
             - switch to the "medium complexity" API
-            - stbir_resize(), very similar API but a few more parameters:
+            - stbir_resize(), similar API but a few more parameters:
               - pixel_layout: cast channel count to `stbir_pixel_layout`
               - data_type:    STBIR_TYPE_UINT8_SRGB
               - edge:         unchanged (STBIR_EDGE_WRAP, etc.)
@@ -296,13 +296,13 @@
             - which channel is alpha is specified in stbir_pixel_layout, see enum for details
 
       FUTURE TODOS
-        *  For polyphase integral filters, we just memcpy the coeffs to dupe
+        *  For polyphase integral filters, we memcpy the coeffs to dupe
            them, but we should indirect and use the same coeff memory.
         *  Add pixel layout conversions for sensible different channel counts
            (maybe, 1->3/4, 3->4, 4->1, 3->1).
          * For SIMD encode and decode scanline routines, do any pre-aligning
            for bad input/output buffer alignments and pitch?
-         * For very wide scanlines, we should we do vertical strips to stay within
+         * For wide scanlines, we should we do vertical strips to stay within
            L2 cache. Maybe do chunks of 1K pixels at a time. There would be
            some pixel reconversion, but probably dwarfed by things falling out
            of cache. Probably also something possible with alternating between
@@ -342,7 +342,7 @@
       2.13 (2025-02-27) fixed a bug when using input callbacks, turned off simd for 
                           tiny-c, fixed some variables that should have been static,
                           fixes a bug when calculating temp memory with resizes that
-                          exceed 2GB of temp memory (very large resizes).
+                          exceed 2GB of temp memory (large resizes).
       2.12 (2024-10-18) fix incorrect use of user_data with STBIR_FREE
       2.11 (2024-09-08) fix harmless asan warnings in 2-channel and 3-channel mode
                           with AVX-2, fix some weird scaling edge conditions with
@@ -354,7 +354,7 @@
       2.08 (2024-06-10) fix for RGB->BGR three channel flips and add SIMD (thanks
                           to Ryan Salsbury), fix for sub-rect resizes, use the
                           pragmas to control unrolling when they are available.
-      2.07 (2024-05-24) fix for slow final split during threaded conversions of very 
+      2.07 (2024-05-24) fix for slow final split during threaded conversions of
                           wide scanlines when downsampling (caused by extra input 
                           converting), fix for wide scanline resamples with many 
                           splits (int overflow), fix GCC warning.
@@ -366,7 +366,7 @@
       2.03 (2023-11-01) ASAN and TSAN warnings fixed, minor tweaks.
       2.00 (2023-10-10) mostly new source: new api, optimizations, simd, vertical-first, etc
                           2x-5x faster without simd, 4x-12x faster with simd,
-                          in some cases, 20x to 40x faster esp resizing large to very small.
+                          in some cases, 20x to 40x faster esp resizing large to small.
       0.96 (2019-03-04) fixed warnings
       0.95 (2017-07-23) fixed warnings
       0.94 (2017-03-18) fixed warnings
@@ -451,8 +451,8 @@ typedef enum
   STBIR_AR_PM   = 16,
 
   STBIR_RGBA_NO_AW = 11,            // alpha formats, where NO alpha weighting is applied at all!
-  STBIR_BGRA_NO_AW = 12,            //   these are just synonyms for the _PM flags (which also do
-  STBIR_ARGB_NO_AW = 13,            //   no alpha weighting). These names just make it more clear
+  STBIR_BGRA_NO_AW = 12,            //   these are synonyms for the _PM flags (which also do
+  STBIR_ARGB_NO_AW = 13,            //   no alpha weighting). These names make it more clear
   STBIR_ABGR_NO_AW = 14,            //   for some folks).
   STBIR_RA_NO_AW   = 15,
   STBIR_AR_NO_AW   = 16,
@@ -512,7 +512,7 @@ typedef enum
 {
   STBIR_TYPE_UINT8            = 0,
   STBIR_TYPE_UINT8_SRGB       = 1,
-  STBIR_TYPE_UINT8_SRGB_ALPHA = 2,  // alpha channel, when present, should also be SRGB (this is very unusual)
+  STBIR_TYPE_UINT8_SRGB_ALPHA = 2,  // alpha channel, when present, should also be SRGB (this is unusual)
   STBIR_TYPE_UINT16           = 3,
   STBIR_TYPE_FLOAT            = 4,
   STBIR_TYPE_HALF_FLOAT       = 5
@@ -692,15 +692,15 @@ STBIRDEF int stbir_resize_extended_split( STBIR_RESIZE * resize, int split_start
 
 //   The input callback is super flexible - it calls you with the input address
 //   (based on the stride and base pointer), it gives you an optional_output
-//   pointer that you can fill, or you can just return your own pointer into
+//   pointer that you can fill, or you can return your own pointer into
 //   your own data.
 //
 //   You can also do conversion from non-supported data types if necessary - in
-//   this case, you ignore the input_ptr and just use the x and y parameters to
+//   this case, you ignore the input_ptr and use the x and y parameters to
 //   calculate your own input_ptr based on the size of each non-supported pixel.
 //   (Something like the third example below.)
 //
-//   You can also install just an input or just an output callback by setting the
+//   You can also install an input or an output callback by setting the
 //   callback that you don't want to zero.
 //
 //     First example, progress: (getting a callback that you can monitor the progress):
@@ -725,7 +725,7 @@ STBIRDEF int stbir_resize_extended_split( STBIR_RESIZE * resize, int split_start
 //        }
 //
 //
-//   The output callback is considerably simpler - it just calls you so that you can dump
+//   The output callback is considerably simpler - it calls you so that you can dump
 //   out each scanline. You could even directly copy out to disk if you have a simple format
 //   like TGA or BMP. You can also convert to other output types here if you want.
 //
@@ -2266,7 +2266,7 @@ static stbir__inline stbir_uint8 stbir__linear_to_srgb_uchar(float in)
       {
         // use a magic value to align our 10 mantissa bits at the bottom of
         // the float. as long as FP addition is round-to-nearest-even this
-        // just works.
+        // works.
         f.f += denorm_magic.f;
         // and one integer subtract of the bias later, we have our final float!
         o.u = (unsigned short) ( f.u - denorm_magic.u );
@@ -2711,7 +2711,7 @@ static void stbir_overlapping_memcpy( void * dest, void const * src, size_t byte
 
 #else // no SSE2
 
-// when in scalar mode, we let unrolling happen, so this macro just does the __restrict
+// when in scalar mode, we let unrolling happen, so this macro does the __restrict
 #define STBIR_SIMD_STREAMOUT_PTR( star ) STBIR_STREAMOUT_PTR( star )
 #define STBIR_SIMD_NO_UNROLL(ptr)
 #define STBIR_SIMD_NO_UNROLL_LOOP_START
@@ -3219,7 +3219,7 @@ static void stbir__get_extents( stbir__sampler * samp, stbir__extents * scanline
   STBIR_ASSERT( scanline_extents->conservative.n0 <= min_n );
   STBIR_ASSERT( scanline_extents->conservative.n1 >= max_n );
 
-  // you get two ranges when you have the WRAP edge mode and you are doing just the a piece of the resize
+  // you get two ranges when you have the WRAP edge mode and you are doing the a piece of the resize
   //   so you need to get a second run of pixels from the opposite side of the scanline (which you
   //   wouldn't need except for WRAP)
 
@@ -3329,7 +3329,7 @@ static void stbir__calculate_coefficients_for_gather_upsample( float out_filter_
       // kill denormals
       if ( ( ( coeff < stbir__small_float ) && ( coeff > -stbir__small_float ) ) )
       {
-        if ( i == 0 )  // if we're at the front, just eat zero contributors
+        if ( i == 0 )  // if we're at the front, eat zero contributors
         {
           STBIR_ASSERT ( ( in_last_pixel - in_first_pixel ) != 0 ); // there should be at least one contrib
           ++in_first_pixel;
@@ -3527,7 +3527,7 @@ static void stbir__cleanup_gathered_coefficients( stbir_edge edge, stbir__filter
     // rescale
     if ( ( total_filter < stbir__small_float ) && ( total_filter > -stbir__small_float ) )
     {
-      // all coeffs are extremely small, just zero it
+      // all coeffs are extremely small, zero it
       contribs->n1 = contribs->n0;
       coeffs[0] = 0.0f;
     }
@@ -3571,7 +3571,7 @@ static void stbir__cleanup_gathered_coefficients( stbir_edge edge, stbir__filter
   {
     int i;
 
-    // in zero edge mode, just remove out of bounds contribs completely (since their weights are accounted for now)
+    // in zero edge mode, remove out of bounds contribs completely (since their weights are accounted for now)
     if ( edge == STBIR_EDGE_ZERO )
     {
       // shrink the right side if necessary
@@ -3597,7 +3597,7 @@ static void stbir__cleanup_gathered_coefficients( stbir_edge edge, stbir__filter
     }
     else if ( ( edge == STBIR_EDGE_CLAMP ) || ( edge == STBIR_EDGE_REFLECT ) )
     {
-      // for clamp and reflect, calculate the true inbounds position (based on edge type) and just add that to the existing weight
+      // for clamp and reflect, calculate the true inbounds position (based on edge type) and add that to the existing weight
 
       // right hand side first
       if ( contribs->n1 > input_last_n1 )
@@ -3938,7 +3938,7 @@ static void stbir__calculate_filters( stbir__sampler * samp, stbir__sampler * ot
       if ( !samp->is_gather )
       {
         // check if we are using the same gather downsample on the horizontal as this vertical,
-        //   if so, then we don't have to generate them, we can just pivot from the horizontal.
+        //   if so, then we don't have to generate them, we can pivot from the horizontal.
         if ( other_axis_for_pivot )
         {
           gather_contributors = other_axis_for_pivot->contributors;
@@ -4617,7 +4617,7 @@ static void stbir__decode_scanline(stbir__info const * stbir_info, int n, float 
     // if we have an input callback, call it to get the input data
     if ( stbir_info->in_pixels_cb )
     {
-      // call the callback with a temp buffer (that they can choose to use or not).  the temp is just right aligned memory in the decode_buffer itself
+      // call the callback with a temp buffer (that they can choose to use or not).  the temp is right aligned memory in the decode_buffer itself
       input_data = stbir_info->in_pixels_cb( ( (char*) end_decode ) - ( width * input_sample_in_bytes ) + ( ( stbir_info->input_type != STBIR_TYPE_FLOAT ) ? ( sizeof(float)*STBIR_INPUT_CALLBACK_PADDING ) : 0 ), input_plane_data, width, spans->pixel_offset_for_input, row, stbir_info->user_data );
     }
 
@@ -4638,7 +4638,7 @@ static void stbir__decode_scanline(stbir__info const * stbir_info, int n, float 
 
   // handle the edge_wrap filter (all other types are handled back out at the calculate_filter stage)
   // basically the idea here is that if we have the whole scanline in memory, we don't redecode the
-  //   wrapped edge pixels, and instead just memcpy them from the scanline into the edge positions
+  //   wrapped edge pixels, and instead memcpy them from the scanline into the edge positions
   if ( ( edge_horizontal == STBIR_EDGE_WRAP ) && ( stbir_info->scanline_extents.edge_sizes[0] | stbir_info->scanline_extents.edge_sizes[1] ) )
   {
     // this code only runs if we're in edge_wrap, and we're doing the entire scanline
@@ -4668,7 +4668,7 @@ static void stbir__decode_scanline(stbir__info const * stbir_info, int n, float 
   last_decoded[0] = 0.0f; 
 
   // we clear this extra float, because the final output pixel filter kernel might have used one less coeff than the max filter width
-  //   when this happens, we do read that pixel from the input, so it too could be Nan, so just zero an extra one.
+  //   when this happens, we do read that pixel from the input, so it too could be Nan, so zero an extra one.
   //   this fits because each scanline is padded by three floats (STBIR_INPUT_CALLBACK_PADDING)
   last_decoded[1] = 0.0f;
 }
@@ -6496,7 +6496,7 @@ static void stbir__vertical_scatter_loop( stbir__info const * stbir_info, stbir_
       if ( out_last_scanline >= end_output_y )
         out_last_scanline = end_output_y - 1;
 
-      // if very first scanline, init the index
+      // first scanline, init the index
       if (split_info->ring_buffer_begin_index < 0)
         split_info->ring_buffer_begin_index = out_first_scanline - start_output_y;
 
@@ -6587,11 +6587,11 @@ static void stbir__set_sampler(stbir__sampler * samp, stbir_filter filter, stbir
 
   // filter_pixel_width is the conservative size in pixels of input that affect an output pixel.
   //   In rare cases (only with 2 pix to 1 pix with the default filters), it's possible that the 
-  //   filter will extend before or after the scanline beyond just one extra entire copy of the 
+  //   filter will extend before or after the scanline beyond one extra entire copy of the 
   //   scanline (we would hit the edge twice). We don't let you do that, so we clamp the total 
   //   width to 3x the total of input pixel (once for the scanline, once for the left side 
   //   overhang, and once for the right side). We only do this for edge mode, since the other 
-  //   modes can just re-edge clamp back in again.
+  //   modes can re-edge clamp back in again.
   if ( edge == STBIR_EDGE_WRAP )
     if ( samp->filter_pixel_width > ( scale_info->input_full_size * 3 ) )
       samp->filter_pixel_width = scale_info->input_full_size * 3;
@@ -6600,7 +6600,7 @@ static void stbir__set_sampler(stbir__sampler * samp, stbir_filter filter, stbir
   // the image boundaries.
   samp->filter_pixel_margin = samp->filter_pixel_width / 2;
   
-  // filter_pixel_margin is the amount that this filter can overhang on just one side of either 
+  // filter_pixel_margin is the amount that this filter can overhang on one side of either 
   //   end of the scanline (left or the right). Since we only allow you to overhang 1 scanline's 
   //   worth of pixels, we clamp this one side of overhang to the input scanline size. Again, 
   //   this clamping only happens in rare cases with the default filters (2 pix to 1 pix). 
@@ -6692,7 +6692,7 @@ static void stbir__get_conservative_extents( stbir__sampler * samp, stbir__contr
 
   if ( samp->edge == STBIR_EDGE_WRAP )
   {
-    // if we are wrapping, and we are very close to the image size (so the edges might merge), just use the scanline up to the edge
+    // if we are wrapping, and we are close to the image size (so the edges might merge), use the scanline up to the edge
     if ( ( range->n0 > 0 ) && ( range->n1 >= input_full_size ) )
     {
       int marg = range->n1 - input_full_size + 1;
@@ -6735,14 +6735,14 @@ static void stbir__get_split_info( stbir__per_split_info* split_info, int splits
     //   resize at exactly the right phase, some of the coefficents can be zero. When they are zero, we
     //   don't process them at all.  But this leads to a tricky thing with the thread splits, where we
     //   might have a set of two coeffs like this for example: (4,4) and (3,6).  The 4,4 means there was
-    //   just one single coeff because things worked out perfectly (normally, they all have 4 coeffs
+    //   one single coeff because things worked out perfectly (normally, they all have 4 coeffs
     //   like the range 3,6.  The problem is that if we start right on the (4,4) on a brand new thread,
     //   then when we get to (3,6), we don't have the "3" sample in memory (because we didn't load
     //   it on the initial (4,4) range because it didn't have a 3 (we only add new samples that are 
-    //   larger than our existing samples - it's just how the eviction works). So, our solution here
+    //   larger than our existing samples - it's how the eviction works). So, our solution here
     //   is pretty simple, if we start right on a range that has samples that start earlier, then we 
     //   simply bump up our previous thread split range to include it, and then start this threads
-    //   range with the smaller sample. It just moves one scanline from one thread split to another,
+    //   range with the smaller sample. It moves one scanline from one thread split to another,
     //   so that we end with the unusual one, instead of start with it. To do this, we check 2-4 
     //   sample at each thread split start and then occassionally move them.
     
@@ -6941,9 +6941,9 @@ static STBIR__V_FIRST_INFO STBIR__V_FIRST_INFO_BUFFER = {0};
 //
 //   In more normal circumstances, this makes a 20-40% differences, so
 //     it's good to get right, but not critical. The normal way that you
-//     decide which direction goes first is just figuring out which
+//     decide which direction goes first is figuring out which
 //     direction does more multiplies. But with modern CPUs with their
-//     fancy caches and SIMD and high IPC abilities, so there's just a lot
+//     fancy caches and SIMD and high IPC abilities, so there's a lot
 //     more that goes into it.
 //
 //   My handwavy sort of solution is to have an app that does a whole
@@ -7071,7 +7071,7 @@ static stbir__info * stbir__alloc_internal_mem_and_build_samplers( stbir__sample
   vertical_first = stbir__should_do_vertical_first( stbir__compute_weights[ (int)stbir_channel_count_index[ effective_channels ] ], horizontal->filter_pixel_width, horizontal->scale_info.scale, horizontal->scale_info.output_sub_size, vertical->filter_pixel_width, vertical->scale_info.scale, vertical->scale_info.output_sub_size, vertical->is_gather, STBIR__V_FIRST_INFO_POINTER );
 
   // sometimes read one float off in some of the unrolled loops (with a weight of zero coeff, so it doesn't have an effect)
-  //   we use a few extra floats instead of just 1, so that input callback buffer can overlap with the decode buffer without
+  //   we use a few extra floats instead of 1, so that input callback buffer can overlap with the decode buffer without
   //   the conversion routines overwriting the callback input data.
   decode_buffer_size = ( conservative->n1 - conservative->n0 + 1 ) * effective_channels * sizeof(float) + sizeof(float)*STBIR_INPUT_CALLBACK_PADDING; // extra floats for input callback stagger
 
@@ -7100,7 +7100,7 @@ static stbir__info * stbir__alloc_internal_mem_and_build_samplers( stbir__sample
   // The vertical buffer is used differently, depending on whether we are scattering
   //   the vertical scanlines, or gathering them.
   //   If scattering, it's used at the temp buffer to accumulate each output.
-  //   If gathering, it's just the output buffer.
+  //   If gathering, it's the output buffer.
   vertical_buffer_size = (size_t)horizontal->scale_info.output_sub_size * (size_t)effective_channels * sizeof(float) + sizeof(float);  // extra float for padding
 
   // we make two passes through this loop, 1st to add everything up, 2nd to allocate and init
@@ -7225,7 +7225,7 @@ static stbir__info * stbir__alloc_internal_mem_and_build_samplers( stbir__sample
 
       // when in vertical scatter mode, we first build the coefficients in gather mode, and then pivot after,
       //   that means we need two buffers, so we try to use the decode buffer and ring buffer for this. if that
-      //   is too small, we just allocate extra memory to use as this temp.
+      //   is too small, we allocate extra memory to use as this temp.
 
       both = (size_t)vertical->gather_prescatter_contributors_size + (size_t)vertical->gather_prescatter_coefficients_size;
 
@@ -7881,7 +7881,7 @@ static int stbir__perform_build( STBIR_RESIZE * resize, int splits )
   if ( !stbir__calculate_region_transform( &vertical.scale_info, resize->output_h, &new_output_suby, resize->output_subh, resize->input_h, resize->input_t0, resize->input_t1 ) )
     return 0;
 
-  // if nothing to do, just return
+  // if nothing to do, return
   if ( ( horizontal.scale_info.output_sub_size == 0 ) || ( vertical.scale_info.output_sub_size == 0 ) )
     return 0;
 
@@ -7997,7 +7997,7 @@ STBIRDEF int stbir_resize_extended_split( STBIR_RESIZE * resize, int split_start
 {
   STBIR_ASSERT( resize->samplers );
 
-  // if we're just doing the whole thing, call full
+  // if we're doing the whole thing, call full
   if ( ( split_start == -1 ) || ( ( split_start == 0 ) && ( split_count == resize->splits ) ) )
     return stbir_resize_extended( resize );
 
@@ -8036,7 +8036,7 @@ static void * stbir_quick_resize_helper( const void *input_pixels , int input_w 
   if ( positive_output_stride_in_bytes < 0 )
     positive_output_stride_in_bytes = -positive_output_stride_in_bytes;
 
-  // is the requested stride smaller than the scanline output? if so, just fail
+  // is the requested stride smaller than the scanline output? if so, fail
   if ( positive_output_stride_in_bytes < scanline_output_in_bytes )
     return 0;
 

--- a/stb_image_resize_test/old_image_resize.h
+++ b/stb_image_resize_test/old_image_resize.h
@@ -510,10 +510,10 @@ typedef unsigned char stbir__validate_uint32[sizeof(stbir_uint32) == 4 ? 1 : -1]
 // because we store the indices in 16-bit variables
 #endif
 
-// This value is added to alpha just before premultiplication to avoid
+// This value is added to alpha before premultiplication to avoid
 // zeroing out color values. It is equivalent to 2^-80. If you don't want
 // that behavior (it may interfere if you have floating point images with
-// very small alpha values) then you can define STBIR_NO_ALPHA_EPSILON to
+// small alpha values) then you can define STBIR_NO_ALPHA_EPSILON to
 // disable it.
 #ifndef STBIR_ALPHA_EPSILON
 #define STBIR_ALPHA_EPSILON ((float)1 / (1 << 20) / (1 << 20) / (1 << 20) / (1 << 20))
@@ -2176,7 +2176,7 @@ static void stbir__buffer_loop_upsample(ostbir__info* stbir_info)
             {
                 if (stbir_info->ring_buffer_first_scanline == stbir_info->ring_buffer_last_scanline)
                 {
-                    // We just popped the last scanline off the ring buffer.
+                    // We popped the last scanline off the ring buffer.
                     // Reset it to the empty state.
                     stbir_info->ring_buffer_begin_index = -1;
                     stbir_info->ring_buffer_first_scanline = 0;
@@ -2234,7 +2234,7 @@ static void stbir__empty_ring_buffer(ostbir__info* stbir_info, int first_necessa
 
             if (stbir_info->ring_buffer_first_scanline == stbir_info->ring_buffer_last_scanline)
             {
-                // We just popped the last scanline off the ring buffer.
+                // We popped the last scanline off the ring buffer.
                 // Reset it to the empty state.
                 stbir_info->ring_buffer_begin_index = -1;
                 stbir_info->ring_buffer_first_scanline = 0;

--- a/stb_image_resize_test/stbirtest.c
+++ b/stb_image_resize_test/stbirtest.c
@@ -516,7 +516,7 @@ static int getprime( int v )
   for(;;)
   {
     if ( i >= v )
-      return v;  // can't find any, just return orig
+      return v;  // can't find any, return orig
     if (isprime(v - i))
       return v - i;
     if (isprime(v + i))

--- a/stb_image_resize_test/vf_train.c
+++ b/stb_image_resize_test/vf_train.c
@@ -169,7 +169,7 @@ static void build_bitmap( float weights[STBIR_RESIZE_CLASSIFICATIONS][4], int do
     {
       int ofs, h, hh;
 
-      // just do the type that we're on
+      // do the type that we're on
       if ( chanind != do_channel_count_index )
       {
         ts += 2 * fi[findex].dimensionx * fi[findex].dimensiony;
@@ -247,7 +247,7 @@ static void build_comp_bitmap( float weights[STBIR_RESIZE_CLASSIFICATIONS][4], i
     {
       int ofs, h, hh;
 
-      // just do the type that we're on
+      // do the type that we're on
       if ( chanind != do_channel_count_index )
       {
         ts0 += 2 * fi[0].dimensionx * fi[0].dimensiony;
@@ -334,7 +334,7 @@ static void calc_errors( float weights_table[STBIR_RESIZE_CLASSIFICATIONS][4], i
       {
         int h, hh;
 
-        // just do the type that we're on
+        // do the type that we're on
         if ( chanind != do_channel_count_index )
         {
           ts += 2 * fi[findex].dimensionx * fi[findex].dimensiony;

--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -1104,7 +1104,7 @@ static void stbiw__encode_png_line(unsigned char *pixels, int stride_bytes, int 
       return;
    }
 
-   // first loop isn't optimized since it's just one pixel
+   // first loop isn't optimized since it's one pixel
    for (i = 0; i < n; ++i) {
       switch (type) {
          case 1: line_buffer[i] = z[i]; break;

--- a/stb_rect_pack.h
+++ b/stb_rect_pack.h
@@ -363,7 +363,7 @@ static stbrp__findresult stbrp__skyline_find_best_pos(stbrp_context *c, int widt
    while (node->x + width <= c->width) {
       int y,waste;
       y = stbrp__skyline_find_min_y(c, node, node->x, width, &waste);
-      if (c->heuristic == STBRP_HEURISTIC_Skyline_BL_sortHeight) { // actually just want to test BL
+      if (c->heuristic == STBRP_HEURISTIC_Skyline_BL_sortHeight) { // actually want to test BL
          // bottom left
          if (y < best_y) {
             best_y = y;

--- a/stb_sprintf.h
+++ b/stb_sprintf.h
@@ -48,7 +48,7 @@ for 64-bit integers (among other small things), so this lets you use
 the same format strings in cross platform code.
 
 It uses the standard single file trick of being both the header file
-and the source itself. If you just include it normally, you just get
+and the source itself. If you include it normally, you get
 the header file function definitions. To get the code, you include
 it from a C or C++ file and define STB_SPRINTF_IMPLEMENTATION first.
 
@@ -1329,7 +1329,7 @@ STBSP__PUBLICDEF int STB_SPRINTF_DECORATE(vsprintfcb)(STBSP_SPRINTFCB *callback,
             }
          break;
 
-      default: // unknown, just copy code
+      default: // unknown, copy code
          s = num + STBSP__NUMSZ - 1;
          *s = f[0];
          l = 1;
@@ -1747,7 +1747,7 @@ static stbsp__int32 stbsp__real_to_str(char const **start, stbsp__uint32 *len, c
    {
       double ph, pl;
 
-      // log10 estimate - very specifically tweaked to hit or undershoot by no more than 1 of log10 of all expos 1..2046
+      // log10 estimate - specifically tweaked to hit or undershoot by no more than 1 of log10 of all expos 1..2046
       tens = expo - 1023;
       tens = (tens < 0) ? ((tens * 617) / 2048) : (((tens * 1233) / 4096) + 1);
 

--- a/stb_textedit.h
+++ b/stb_textedit.h
@@ -221,7 +221,7 @@
 //      cut:
 //          call this to delete the current selection; returns true if there was
 //          one. you should FIRST copy the current selection to the system paste buffer.
-//          (To copy, just copy the current selection out of the string yourself.)
+//          (To copy, copy the current selection out of the string yourself.)
 //
 //      paste:
 //          call this to paste text at the current cursor point or over the current
@@ -376,7 +376,7 @@ typedef struct
 
 
 // implementation isn't include-guarded, since it might have indirectly
-// included just the "header" portion
+// included the "header" portion
 #ifdef STB_TEXTEDIT_IMPLEMENTATION
 
 #ifndef STB_TEXTEDIT_memmove
@@ -453,7 +453,7 @@ static int stb_text_locate_coord(STB_TEXTEDIT_STRING *str, float x, float y)
 // API click: on mouse down, move the cursor to the clicked location, and reset the selection
 static void stb_textedit_click(STB_TEXTEDIT_STRING *str, STB_TexteditState *state, float x, float y)
 {
-   // In single-line mode, just always make y = 0. This lets the drag keep working if the mouse
+   // In single-line mode, always make y = 0. This lets the drag keep working if the mouse
    // goes off the top or bottom of the text
    if( state->single_line )
    {
@@ -473,7 +473,7 @@ static void stb_textedit_drag(STB_TEXTEDIT_STRING *str, STB_TexteditState *state
 {
    int p = 0;
 
-   // In single-line mode, just always make y = 0. This lets the drag keep working if the mouse
+   // In single-line mode, always make y = 0. This lets the drag keep working if the mouse
    // goes off the top or bottom of the text
    if( state->single_line )
    {

--- a/stb_tilemap_editor.h
+++ b/stb_tilemap_editor.h
@@ -50,7 +50,7 @@
 //   A: You have to do this yourself. The editor provides serialization
 //      functions (get & set) for reading and writing the map it holds.
 //      You can choose whatever format you want to store the map to on
-//      disk; you just need to provide functions to convert. (For example,
+//      disk; you need to provide functions to convert. (For example,
 //      I actually store the editor's map representation to disk basically
 //      as-is; then I have a single function that converts from the editor
 //      map representation to the game representation, which is used both
@@ -183,7 +183,7 @@
 //      #include "stb_tilemap_editor.h"
 //
 //   Optionally you can define the following functions before the include;
-//   note these must be macros (but they can just call a function) so
+//   note these must be macros (but they can call a function) so
 //   this library can #ifdef to detect if you've defined them:
 //
 //      #define STBTE_PROP_TYPE(int n, short *tiledata, float *params) ...
@@ -243,7 +243,7 @@
 //      #define STBTE_HITTEST_TILE(x0,y0,id,mx,my)   ...your code here...
 //      // this returns true or false depending on whether the mouse
 //      // pointer at mx,my is over (touching) a tile of type 'id'
-//      // displayed at x0,y0. Normally stb_tilemap_editor just does
+//      // displayed at x0,y0. Normally stb_tilemap_editor does
 //      // this hittest based on the tile geometry, but if you have
 //      // tiles whose images extend out of the tile, you'll need this.
 //
@@ -381,7 +381,7 @@ extern void stbte_define_tile(stbte_tilemap *tm, unsigned short id, unsigned int
 //   id        : unique identifier for each tile, 0 <= id < 32768
 //   layermask : bitmask of which layers tile is allowed on: 1 = layer 0, 255 = layers 0..7
 //               (note that onscreen, the editor numbers the layers from 1 not 0)
-//               layer 0 is the furthest back, layer 1 is just in front of layer 0, etc
+//               layer 0 is the furthest back, layer 1 is in front of layer 0, etc
 //   category  : which category this tile is grouped in
 
 extern void stbte_set_display(int x0, int y0, int x1, int y1);
@@ -3085,7 +3085,7 @@ static void stbte__tile(stbte_tilemap *tm, int sx, int sy, int mapx, int mapy)
             }
             break;
          case STBTE__leftup:
-            // just clear it no matter what, since they might click away to clear it
+            // clear it no matter what, since they might click away to clear it
             stbte__activate(0);
             break;
          case STBTE__rightdown:
@@ -3125,7 +3125,7 @@ static void stbte__tile(stbte_tilemap *tm, int sx, int sy, int mapx, int mapy)
          switch (stbte__ui.event) {
             case STBTE__mousemove:
                if (STBTE__IS_MAP_ACTIVE() && over) {
-                  // don't brush/erase same tile multiple times unless they move away and back @TODO should just be only once, but that needs another data structure
+                  // don't brush/erase same tile multiple times unless they move away and back @TODO should be only once, but that needs another data structure
                   if (!STBTE__IS_ACTIVE(id)) {
                      if (stbte__ui.active_event == STBTE__leftdown)
                         stbte__brush(tm, mapx, mapy);

--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -230,7 +230,7 @@
 //
 //    - Use the functions with Subpixel at the end to allow your characters
 //      to have subpixel positioning. Since the font is anti-aliased, not
-//      hinted, this is very import for quality. (This is not possible with
+//      hinted, this is import for quality. (This is not possible with
 //      baked fonts.)
 //
 //    - Kerning is now supported, and if you're supporting subpixel rendering
@@ -253,7 +253,7 @@
 //   on little-endian systems (the data is big-endian), but assuming you're
 //   caching the bitmaps or glyph shapes this shouldn't be a big deal.
 //
-//   It appears to be very hard to programmatically determine what font a
+//   It appears to be hard to programmatically determine what font a
 //   given file is in a general way. I provide an API for this, but I don't
 //   recommend it.
 //
@@ -538,7 +538,7 @@ STBTT_DEF int stbtt_BakeFontBitmap(const unsigned char *data, int offset,  // fo
 // if return is positive, the first unused row of the bitmap
 // if return is negative, returns the negative of the number of characters that fit
 // if return is 0, no characters fit and no rows were used
-// This uses a very crappy packing.
+// This uses a crappy packing.
 
 typedef struct
 {
@@ -992,7 +992,7 @@ STBTT_DEF unsigned char * stbtt_GetCodepointSDF(const stbtt_fontinfo *info, floa
 // and computing from that can allow drop-out prevention).
 //
 // The algorithm has not been optimized at all, so expect it to be slow
-// if computing lots of characters or very large sizes.
+// if computing lots of characters or large sizes.
 
 
 
@@ -1000,7 +1000,7 @@ STBTT_DEF unsigned char * stbtt_GetCodepointSDF(const stbtt_fontinfo *info, floa
 //
 // Finding the right font...
 //
-// You should really just solve this offline, keep your own tables
+// You should really solve this offline, keep your own tables
 // of what font is what, and don't try to get it out of the .ttf file.
 // That's because getting it out of the .ttf file is really hard, because
 // the names in the file can appear in many possible encodings, in many
@@ -1318,7 +1318,7 @@ static stbtt_uint32 stbtt__find_table(stbtt_uint8 *data, stbtt_uint32 fontstart,
 
 static int stbtt_GetFontOffsetForIndex_internal(unsigned char *font_collection, int index)
 {
-   // if it's just a font, there's only one valid index
+   // if it's a font, there's only one valid index
    if (stbtt__isfont(font_collection))
       return index == 0 ? 0 : -1;
 
@@ -1337,7 +1337,7 @@ static int stbtt_GetFontOffsetForIndex_internal(unsigned char *font_collection, 
 
 static int stbtt_GetNumberOfFonts_internal(unsigned char *font_collection)
 {
-   // if it's just a font, there's only one valid font
+   // if it's a font, there's only one valid font
    if (stbtt__isfont(font_collection))
       return 1;
 
@@ -1424,7 +1424,7 @@ static int stbtt_InitFont_internal(stbtt_fontinfo *info, unsigned char *data, in
       stbtt__buf_seek(&b, stbtt__buf_get8(&b)); // hdrsize
 
       // @TODO the name INDEX could list multiple fonts,
-      // but we just use the first one.
+      // but we use the first one.
       stbtt__cff_get_index(&b);  // name INDEX
       topdictidx = stbtt__cff_get_index(&b);
       topdict = stbtt__cff_index_get(topdictidx, 0);
@@ -1779,7 +1779,7 @@ static int stbtt__GetGlyphShapeTT(const stbtt_fontinfo *info, int glyph_index, s
                   sx = (x + (stbtt_int32) vertices[off+i+1].x) >> 1;
                   sy = (y + (stbtt_int32) vertices[off+i+1].y) >> 1;
                } else {
-                  // otherwise just use the next point as our start point
+                  // otherwise use the next point as our start point
                   sx = (stbtt_int32) vertices[off+i+1].x;
                   sy = (stbtt_int32) vertices[off+i+1].y;
                   ++i; // we're using point i+1 as the starting point, so skip it
@@ -3230,7 +3230,7 @@ static void stbtt__fill_active_edges_new(float *scanline, float *scanline_fill, 
          } else {
             // if edge goes outside of box we're drawing, we require
             // clipping logic. since this does not match the intended use
-            // of this library, we use a different, very slow brute
+            // of this library, we use a different, slow brute
             // force implementation
             // note though that this does happen some of the time because
             // x_top and x_bottom can be extrapolated at the top & bottom of
@@ -3574,7 +3574,7 @@ static int stbtt__tesselate_curve(stbtt__point *points, int *num_points, float x
 
 static void stbtt__tesselate_cubic(stbtt__point *points, int *num_points, float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3, float objspace_flatness_squared, int n)
 {
-   // @TODO this "flatness" calculation is just made-up nonsense that seems to work well enough
+   // @TODO this "flatness" calculation is made-up nonsense that seems to work well enough
    float dx0 = x1-x0;
    float dy0 = y1-y0;
    float dx1 = x2-x1;
@@ -4642,7 +4642,7 @@ STBTT_DEF unsigned char * stbtt_GetGlyphSDF(const stbtt_fontinfo *info, float sc
             float x_gspace = (sx / scale_x);
             float y_gspace = (sy / scale_y);
 
-            int winding = stbtt__compute_crossings_x(x_gspace, y_gspace, num_verts, verts); // @OPTIMIZE: this could just be a rasterization, but needs to be line vs. non-tesselated curves so a new path
+            int winding = stbtt__compute_crossings_x(x_gspace, y_gspace, num_verts, verts); // @OPTIMIZE: this could be a rasterization, but needs to be line vs. non-tesselated curves so a new path
 
             for (i=0; i < num_verts; ++i) {
                float x0 = verts[i].x*scale_x, y0 = verts[i].y*scale_y;
@@ -4905,7 +4905,7 @@ static int stbtt__matches(stbtt_uint8 *fc, stbtt_uint32 offset, stbtt_uint8 *nam
    if (!nm) return 0;
 
    if (flags) {
-      // if we checked the macStyle flags, then just check the family and ignore the subfamily
+      // if we checked the macStyle flags, then check the family and ignore the subfamily
       if (stbtt__matchpair(fc, nm, name, nlen, 16, -1))  return 1;
       if (stbtt__matchpair(fc, nm, name, nlen,  1, -1))  return 1;
       if (stbtt__matchpair(fc, nm, name, nlen,  3, -1))  return 1;

--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -112,7 +112,7 @@ extern "C" {
 // this is lame).
 //
 // If you pass in a non-NULL buffer of the type below, allocation
-// will occur from it as described above. Otherwise just pass NULL
+// will occur from it as described above. Otherwise pass NULL
 // to use malloc()/alloca()
 
 typedef struct
@@ -186,7 +186,7 @@ extern stb_vorbis *stb_vorbis_open_pushdata(
          int *error,
          const stb_vorbis_alloc *alloc_buffer);
 // create a vorbis decoder by passing in the initial data block containing
-//    the ogg&vorbis headers (you don't need to do parse them, just provide
+//    the ogg&vorbis headers (you don't need to do parse them, provide
 //    the first N bytes of the file--you're told if it's not enough, see below)
 // on success, returns an stb_vorbis *, does not set error, returns the amount of
 //    data parsed/consumed on this call in *datablock_memory_consumed_in_bytes;
@@ -252,7 +252,7 @@ extern void stb_vorbis_flush_pushdata(stb_vorbis *f);
 // FILE * that you or it create, or possibly some other reading mechanism
 // if you go modify the source to replace the FILE * case with some kind
 // of callback to your code. (But if you don't support seeking, you may
-// just want to go ahead and use pushdata.)
+// want to go ahead and use pushdata.)
 
 #if !defined(STB_VORBIS_NO_STDIO) && !defined(STB_VORBIS_NO_INTEGER_CONVERSION)
 extern int stb_vorbis_decode_filename(const char *filename, int *channels, int *sample_rate, short **output);
@@ -263,7 +263,7 @@ extern int stb_vorbis_decode_memory(const unsigned char *mem, int len, int *chan
 // decode an entire file and output the data interleaved into a malloc()ed
 // buffer stored in *output. The return value is the number of samples
 // decoded, or -1 if the file could not be opened or was not an ogg vorbis file.
-// When you're done with it, just free() the pointer returned in *output.
+// When you're done with it, free() the pointer returned in *output.
 
 extern stb_vorbis * stb_vorbis_open_memory(const unsigned char *data, int len,
                                   int *error, const stb_vorbis_alloc *alloc_buffer);
@@ -347,7 +347,7 @@ extern int stb_vorbis_get_frame_short            (stb_vorbis *f, int num_c, shor
 //        2    *      stereo L, stereo R
 //        k    l      k > l, the first l channels, then 0s
 //        k    l      k <= l, the first k channels
-//    Note that this is not _good_ surround etc. mixing at all! It's just so
+//    Note that this is not _good_ surround etc. mixing at all! It's so
 //    you get something useful.
 
 extern int stb_vorbis_get_samples_float_interleaved(stb_vorbis *f, int channels, float *buffer, int num_floats);
@@ -420,7 +420,7 @@ enum STBVorbisError
 #ifndef STB_VORBIS_HEADER_ONLY
 
 // global configuration settings (e.g. set these in the project/makefile),
-// or just set them in this file at the top (although ideally the first few
+// or set them in this file at the top (although ideally the first few
 // should be visible when the header file is compiled too, although it's not
 // crucial)
 
@@ -540,7 +540,7 @@ enum STBVorbisError
 // STB_VORBIS_NO_DEFER_FLOOR
 //     Normally we only decode the floor without synthesizing the actual
 //     full curve. We can instead synthesize the curve immediately. This
-//     requires more memory and is very likely slower, so I don't think
+//     requires more memory and is likely slower, so I don't think
 //     you'd ever want to do it except for debugging.
 // #define STB_VORBIS_NO_DEFER_FLOOR
 
@@ -665,7 +665,7 @@ typedef float codetype;
 //
 // Some arrays below are tagged "//varies", which means it's actually
 // a variable-sized piece of data, but rather than malloc I assume it's
-// small enough it's better to just allocate it all together with the
+// small enough it's better to allocate it all together with the
 // main thing
 //
 // Most of the variables are specified with the smallest size I could pack
@@ -1068,7 +1068,7 @@ static float float32_unpack(uint32 x)
 // zlib & jpeg huffman tables assume that the output symbols
 // can either be arbitrarily arranged, or have monotonically
 // increasing frequencies--they rely on the lengths being sorted;
-// this makes for a very simple generation algorithm.
+// this makes for a simple generation algorithm.
 // vorbis allows a huffman table with non-sorted lengths. This
 // requires a more sophisticated construction, since symbols in
 // order do not map to huffman codes "in order".
@@ -2308,7 +2308,7 @@ void inverse_mdct_slow(float *buffer, int n)
    free(x);
 }
 #elif 0
-// same as above, but just barely able to run in real time on modern machines
+// same as above, but barely able to run in real time on modern machines
 void inverse_mdct_slow(float *buffer, int n, vorb *f, int blocktype)
 {
    float mcos[16384];
@@ -3281,7 +3281,7 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
            error:
             zero_channel[i] = TRUE;
          }
-         // So we just defer everything else to later
+         // So we defer everything else to later
 
          // at this point we've decoded the floor into buffer
       }
@@ -3428,7 +3428,7 @@ static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start,
             return TRUE;
          }
       }
-      // otherwise, just set our sample loc
+      // otherwise, set our sample loc
       // guess that the ogg granule pos refers to the _middle_ of the
       // last frame?
       // set f->current_loc to the position of left_start
@@ -3554,7 +3554,7 @@ static int is_whole_packet_present(stb_vorbis *f)
          if (f->previous_length)
             if ((p[5] & PAGEFLAG_continued_packet))  return error(f, VORBIS_invalid_stream);
          // if no previous length, we're resynching, so we can come in on a continued-packet,
-         // which we'll just drop
+         // which we'll drop
       } else {
          if (!(p[5] & PAGEFLAG_continued_packet)) return error(f, VORBIS_invalid_stream);
       }
@@ -4483,7 +4483,7 @@ int stb_vorbis_decode_frame_pushdata(
       if (error == VORBIS_continued_packet_flag_invalid) {
          if (f->previous_length == 0) {
             // we may be resynching, in which case it's ok to hit one
-            // of these; just discard the packet
+            // of these; discard the packet
             f->error = VORBIS__no_error;
             while (get8_packet(f) != EOP)
                if (f->eof) break;
@@ -4785,7 +4785,7 @@ static int seek_to_sample_coarse(stb_vorbis *f, uint32 sample_number)
          assert(mid.page_start < right.page_start);
       }
 
-      // if we've just found the last page again then we're in a tricky file,
+      // if we've found the last page again then we're in a tricky file,
       // and we're close enough (if it wasn't an interpolation probe).
       if (mid.page_start == right.page_start) {
          if (probe >= 2 || delta <= 65536)

--- a/stb_voxel_render.h
+++ b/stb_voxel_render.h
@@ -7,7 +7,7 @@
 //    Video introduction:
 //       http://www.youtube.com/watch?v=2vnTtiLrV1w
 //
-//    Minecraft-viewer sample app (not very simple though):
+//    Minecraft-viewer sample app (not simple though):
 //       http://github.com/nothings/stb/tree/master/tests/caveview
 //
 // It works by creating triangle meshes. The library includes
@@ -44,7 +44,7 @@
 //   - you can choose textured blocks with the features below,
 //     or colored voxels with 2^24 colors and no textures.
 //
-//   - voxels are mostly just cubes, but there's support for
+//   - voxels are mostly cubes, but there's support for
 //     half-height cubes and diagonal slopes, half-height
 //     diagonals, and even odder shapes especially for doing
 //     more-continuous "ground".
@@ -131,7 +131,7 @@
 //
 //   I am willing to do the work to improve these things if someone is
 //   going to ship a substantial program that would be improved by them.
-//   (It need not be commercial, nor need it be a game.) I just didn't
+//   (It need not be commercial, nor need it be a game.) I didn't
 //   want to do the work up front if it might never be leveraged. So just
 //   submit a bug report as usual (github is preferred), but add a note
 //   that this is for a thing that is really going to ship. (That means
@@ -146,9 +146,9 @@
 //     To understand the API, make sure you first understand the feature set
 //     listed above.
 //
-//     Because the vertices are compact, they have very limited spatial
+//     Because the vertices are compact, they have limited spatial
 //     precision. Thus a single mesh can only contain the data for a limited
-//     area. To make very large voxel maps, you'll need to build multiple
+//     area. To make large voxel maps, you'll need to build multiple
 //     vertex buffers. (But you want this anyway for frustum culling.)
 //
 //     Each generated mesh has three components:
@@ -168,14 +168,14 @@
 //
 //     Because there is so much per-vertex and per-face data possible
 //     in the output, and each voxel can have 6 faces and 8 vertices, it
-//     would require an very large data structure to describe all
+//     would require an large data structure to describe all
 //     of the possibilities, and this would cause the mesh-creation
 //     process to be slow. Instead, the API provides multiple ways
 //     to express each property, some more compact, others less so;
 //     each such way has some limitations on what it can express.
 //
 //     Note that there are so many paths and combinations, not all of them
-//     have been tested. Just report bugs and I'll fix 'em.
+//     have been tested. Report bugs and I'll fix 'em.
 //
 //   Details
 //
@@ -268,7 +268,7 @@ extern "C" {
 //     modes 0,1,20,21, Z in the mesh can extend to 511 instead
 //     of 255. However, half-height blocks cannot be used.
 //
-// All of the following are just #ifdef tested so need no values, and are optional.
+// All of the following are #ifdef tested so need no values, and are optional.
 //
 //    STBVOX_CONFIG_BLOCKTYPE_SHORT
 //        use unsigned 16-bit values for 'blocktype' in the input instead of 8-bit values
@@ -396,7 +396,7 @@ STBVXDEC int stbvox_get_buffer_size_per_quad(stbvox_mesh_maker *mm, int slot);
 STBVXDEC void stbvox_set_default_mesh(stbvox_mesh_maker *mm, int mesh);
 // Selects which mesh the mesher will output to (see previous function)
 // if the input doesn't specify a per-voxel selector. (I doubt this is
-// useful, but it's here just in case.)
+// useful, but it's here in case.)
 
 STBVXDEC stbvox_input_description *stbvox_get_input_description(stbvox_mesh_maker *mm);
 // This function call returns a pointer to the stbvox_input_description part
@@ -482,7 +482,7 @@ STBVXDEC void stbvox_set_mesh_coordinates(stbvox_mesh_maker *mm, int x, int y, i
 
 STBVXDEC void stbvox_get_bounds(stbvox_mesh_maker *mm, float bounds[2][3]);
 // Returns the bounds for the mesh in global coordinates. Use this
-// for e.g. frustum culling the mesh. @BUG: this just uses the
+// for e.g. frustum culling the mesh. @BUG: this uses the
 // values from stbvox_set_input_range(), so if you build by
 // appending multiple values, this will be wrong, and you need to
 // set stbvox_set_input_range() to the full size. Someday this
@@ -1023,7 +1023,7 @@ struct stbvox_input_description
 //  "vheight" is the internal name for the special block types
 //  with sloped tops or bottoms. "vheight" stands for "vertex height".
 //
-//  Note that these blocks are very flexible (there are 256 of them,
+//  Note that these blocks are flexible (there are 256 of them,
 //  although at least 17 of them should never be used), but they
 //  also have a disadvantage that they generate extra invisible
 //  faces; the generator does not currently detect whether adjacent
@@ -1080,17 +1080,17 @@ enum
 // look, choose the edge based on actual vertex heights.
 //
 // The four vertex heights can come from several places. The simplest
-// encoding is to just use the 'vheight' parameter which stores four
+// encoding is to use the 'vheight' parameter which stores four
 // explicit vertex heights for every block. This allows total independence,
 // but at the cost of the largest memory usage, 1 byte per 3D block.
 // Encode this with STBVOX_MAKE_VHEIGHT(vh_sw, vh_se, vh_nw, vh_ne).
 // These coordinates are absolute, not affected by block rotations.
 //
-// An alternative if you just want to encode some very specific block
-// types, not all the possibilities--say you just want half-height slopes,
+// An alternative if you want to encode some specific block
+// types, not all the possibilities--say you want half-height slopes,
 // so you want (0,0,1,1) and (1,1,2,2)--then you can use block_vheight
 // to specify them. The geometry rotation will cause block_vheight values
-// to be rotated (because it's as if you're just defining a type of
+// to be rotated (because it's as if you're defining a type of
 // block). This value is also encoded with STBVOX_MAKE_VHEIGHT.
 //
 // If you want to save memory and you're creating a "continuous ground"
@@ -1177,7 +1177,7 @@ enum
 #define STBVOX_MAX_MESH_SLOTS  3           // one vertex & two faces, or two vertex and one face
 
 
-// don't mess with this directly, it's just here so you can
+// don't mess with this directly, it's here so you can
 // declare stbvox_mesh_maker on the stack or as a global
 struct stbvox_mesh_maker
 {
@@ -3055,7 +3055,7 @@ static void stbvox_make_mesh_for_block_with_geo(stbvox_mesh_maker *mm, stbvox_po
       // Note that this means we don't support any transparentshapes other
       // than solid blocks, since detecting them is too complicated. If
       // you wanted to do something like minecraft water, you probably
-      // should just do that with a separate renderer anyway. (We don't
+      // should do that with a separate renderer anyway. (We don't
       // support transparency sorting so you need to use alpha test
       // anyway)
       int i;
@@ -3121,14 +3121,14 @@ static void stbvox_make_mesh_for_block_with_geo(stbvox_mesh_maker *mm, stbvox_po
       mesh = mm->input.block_selector[bt];
 
    if (geo <= STBVOX_GEOM_ceil_slope_north_is_bottom) {
-      // this is the simple case, we can just use regular block gen with special vmesh calculated with vheight
+      // this is the simple case, we can use regular block gen with special vmesh calculated with vheight
       stbvox_mesh_vertex basevert;
       stbvox_mesh_vertex vmesh[6][4];
       stbvox_rotate rotate = { 0,0,0,0 };
       unsigned char simple_rot = rot;
       int i;
       // we only need to do this for the displayed faces, but it's easier
-      // to just do it up front; @OPTIMIZE check if it's faster to do it
+      // to do it up front; @OPTIMIZE check if it's faster to do it
       // for visible faces only
       for (i=0; i < 6*4; ++i) {
          int vert = stbvox_vertex_selector[0][i];

--- a/tests/caveview/README.md
+++ b/tests/caveview/README.md
@@ -29,7 +29,7 @@ Not very. Many Minecraft blocks are not handled correctly:
 *         Transparent textures have black fringes due to non-premultiplied-alpha
 *         Skylight and block light are combined in a single value
 *         Only blocks at y=1..255 are shown (not y=0)
-*         If a 32x32x256 "quad-chunk" needs more than 800K quads, isn't handled (very unlikely)
+*         If a 32x32x256 "quad-chunk" needs more than 800K quads, isn't handled (unlikely)
 
 Some of these are due to engine limitations, and some of
 these are because I didn't make the effort since my

--- a/tests/caveview/cave_render.c
+++ b/tests/caveview/cave_render.c
@@ -503,7 +503,7 @@ void world_init(void)
    // wait until all the workers are done,
    // (this is only needed if we want to time
    // when the build finishes, or when we want to reset the
-   // cache size; otherwise we could just go ahead and
+   // cache size; otherwise we could go ahead and
    // start rendering whatever we've got)
    for(;;) {
       int i;
@@ -565,7 +565,7 @@ int mesh_worker_handler(void *data)
 
       // when done, free the chunks
 
-      // for efficiency we just take the mutex once around the whole thing,
+      // for efficiency we take the mutex once around the whole thing,
       // though this spreads the mutex logic over two files
       SDL_LockMutex(chunk_cache_mutex);
       for (j=0; j < 4; ++j)
@@ -609,7 +609,7 @@ void prepare_threads(void)
 
 // @TODO
 //   Thread usage is probably pretty terrible; need to make a
-//   separate queue of needed chunks, instead of just generating
+//   separate queue of needed chunks, instead of generating
 //   one request per thread per frame, and a separate queue of
 //   results. (E.g. If it takes 1.5 frames to build mesh, thread
 //   is idle for 0.5 frames.) To fake this for now, I've just
@@ -808,7 +808,7 @@ void render_caves(float campos[3])
                // check if chunk pos actually matches
                if (cm->chunk_x != cx || cm->chunk_y != cy) {
                   // we have a stale chunk we need to recreate
-                  free_chunk(slot_x, slot_y); // it probably will have already gotten freed, but just in case
+                  free_chunk(slot_x, slot_y); // it probably will have already gotten freed, but in case
                }
             }
             if (cm->state == STATE_invalid) {
@@ -919,7 +919,7 @@ void render_caves(float campos[3])
 
       // I couldn't find any straightforward logic that avoids
       // the hysteresis problem of continually creating & freeing
-      // a block on the margin, so I just don't free a block until
+      // a block on the margin, so I don't free a block until
       // it's out of range, but this doesn't actually correctly
       // handle when the cache is too small for the given range
       if (chunk_storage_total >= min_chunk_storage && lowest_i >= 0) {

--- a/tests/caveview/stb_gl.h
+++ b/tests/caveview/stb_gl.h
@@ -1,7 +1,7 @@
 // stbgl - v0.04 - Sean Barrett 2008 - public domain
 //
 // Note that the gl extensions support requires glext.h. In fact, it works
-// if you just concatenate glext.h onto the end of this file. In that case,
+// if you concatenate glext.h onto the end of this file. In that case,
 // this file is covered by the SGI FreeB license, and is not public domain.
 //
 // Extension usage:
@@ -23,7 +23,7 @@
 //         #define STB_GLEXT_DEFINE "extlist.txt"
 //         #include "stb_gl.h"
 //
-//       If you've already defined STB_GLEXT_DECLARE, you can just do:
+//       If you've already defined STB_GLEXT_DECLARE, you can do:
 //         #define STB_GLEXT_DEFINE_DECLARE
 //         #include "stb_gl.h"
 //
@@ -82,7 +82,7 @@ extern int stbgl_LoadTexture(char *filename, char *props); // only if stb_image 
 
 extern int stbgl_TestTexture(int w);
 extern int stbgl_TestTextureEx(int w, char *scale_table, int checks_log2, int r1,int g1,int b1, int r2, int b2, int g2);
-extern unsigned int stbgl_rand(void); // internal, but exposed just in case; LCG, so use middle bits
+extern unsigned int stbgl_rand(void); // internal, but exposed in case; LCG, so use middle bits
 
 extern int stbgl_TexImage2D(int texid, int w, int h, void *data, char *props);
 extern int stbgl_TexImage2D_Extra(int texid, int w, int h, void *data, int chan, char *props, int preserve_data);
@@ -459,7 +459,7 @@ int stbgl_TestTextureEx(int w, char *scale_table, int checks_log2, int r1,int g1
          }
       }
       scale = scale_table[s-k+1];
-      if (!scale) continue; // just interpolate down the remaining data
+      if (!scale) continue; // interpolate down the remaining data
       for (j=0,i=0; i < 256; i += 2, j == scale ? j=0 : ++j)
          modded[i] = j, modded[i+1] = -j; // precompute i%scale (plus sign)
       for (j=0; j < w; j += step)

--- a/tests/caveview/stb_glprog.h
+++ b/tests/caveview/stb_glprog.h
@@ -119,7 +119,7 @@ extern void stbgl_find_uniforms(GLuint prog, GLint *locations, char const **unif
 // the locations of each of those uniforms for the specified program.
 // If num_uniforms is -1, then uniforms[] must be NULL-terminated
 
-// the following functions just wrap the difference in naming between GL2+ and ARB,
+// the following functions wrap the difference in naming between GL2+ and ARB,
 // so you don't need them unless you're using both ARB and GL2+ in the same codebase,
 // or you're relying on this lib to provide the extensions
 extern void stbglUseProgram(GLuint program);

--- a/tests/caveview/win32/SDL_windows_main.c
+++ b/tests/caveview/win32/SDL_windows_main.c
@@ -27,7 +27,7 @@
 #define WIN_StringToUTF8(S) SDL_iconv_string("UTF-8", "UTF-16LE", (char *)(S), (SDL_wcslen(S)+1)*sizeof(WCHAR))
 #define WIN_UTF8ToString(S) (WCHAR *)SDL_iconv_string("UTF-16LE", "UTF-8", (char *)(S), SDL_strlen(S)+1)
 #else
-/* !!! FIXME: UTF8ToString() can just be a SDL_strdup() here. */
+/* !!! FIXME: UTF8ToString() can be a SDL_strdup() here. */
 #define WIN_StringToUTF8(S) SDL_iconv_string("UTF-8", "ASCII", (char *)(S), (SDL_strlen(S)+1))
 #define WIN_UTF8ToString(S) SDL_iconv_string("ASCII", "UTF-8", (char *)(S), SDL_strlen(S)+1)
 #endif

--- a/tests/oversample/README.md
+++ b/tests/oversample/README.md
@@ -63,7 +63,7 @@ by your text rendering.)
 
 ## What about gamma?
 
-Gamma-correction for fonts just doesn't work. This doesn't seem to make
+Gamma-correction for fonts doesn't work. This doesn't seem to make
 much sense -- it's physically correct, it simulates what we'd see if you
 shrunk a font down really far, right?
 
@@ -74,12 +74,12 @@ no way to adjust the font's inherent thickness (i.e. by switching to
 bold) to fix this for both; making the font thicker will make white
 text worse, and making the font thinner will make black text worse.
 Obviously you could use different fonts for light and dark cases, but
-this doesn't seem like a very good way for fonts to work.
+this doesn't seem like a good way for fonts to work.
 
 Multiple people who have experimented with this independently (me,
 Fabian Giesen,and Maxim Shemanarev of Anti-Grain Geometry) have all
 concluded that correct gamma-correction does not produce the best
-results for fonts. Font rendering just generally looks better without
+results for fonts. Font rendering generally looks better without
 gamma correction (or possibly with some arbitrary power stuck in
 there, but it's not really correcting for gamma at that point). Maybe
 this is in part a product of how we're used to fonts being on screens

--- a/tests/oversample/stb_wingraph.h
+++ b/tests/oversample/stb_wingraph.h
@@ -722,7 +722,7 @@ int stbwingraph_MainLoop(stbwingraph_update func, float mintime)
          // only force a draw for certain messages...
          // if I don't do this, we peg at 50% for some reason... must
          // be a bug somewhere, because we peg at 100% when rendering...
-         // very weird... looks like NVIDIA is pumping some messages
+         // weird... looks like NVIDIA is pumping some messages
          // through our pipeline? well, ok, I guess if we can get
          // non-user-generated messages we have to do this
          if (!stbwingraph_force_update) {

--- a/tests/prerelease/stb_lib.h
+++ b/tests/prerelease/stb_lib.h
@@ -12,7 +12,7 @@
       #define STB_LIB_IMPLEMENTATION
       #include "stblib_files.h"
       
-   All other files should just #include "stblib_files.h" without the #define.
+   All other files should #include "stblib_files.h" without the #define.
  ============================================================================
 
 LICENSE
@@ -635,7 +635,7 @@ int stb_suffixi(char *s, char *t)
 // originally I was using this table so that I could create known sentinel
 // values--e.g. change whitetable[0] to be true if I was scanning for whitespace,
 // and false if I was scanning for nonwhite. I don't appear to be using that
-// functionality anymore (I do for tokentable, though), so just replace it
+// functionality anymore (I do for tokentable, though), so replace it
 // with isspace()
 char *stb_skipwhite(char *s)
 {
@@ -793,7 +793,7 @@ static char **stb_tokens_raw(char *src_, char *delimit, int *count,
    // two passes through: the first time, counting how many
    s = (unsigned char *) src;
    while (*s) {
-      // state: just found delimiter
+      // state: found delimiter
       // skip further delimiters
       if (!allow_empty) {
          stb_tokentable[0] = 0;
@@ -851,7 +851,7 @@ static char **stb_tokens_raw(char *src_, char *delimit, int *count,
    nested = 0;
    while (*s) {
       char *last_nonwhite;
-      // state: just found delimiter
+      // state: found delimiter
       // skip further delimiters
       if (!allow_empty) {
          stb_tokentable[0] = 0;
@@ -1089,7 +1089,7 @@ static char *stb__splitpath_raw(char *buffer, char *path, int flag)
    if (!(flag & (STB_PATH | STB_FILE | STB_EXT))) return NULL;
 
    f1 = s == NULL ? 0 : s-path; // start of filename
-   f2 = t == NULL ? n : t-path; // just past end of filename
+   f2 = t == NULL ? n : t-path; // past end of filename
 
    if (flag & STB_PATH) {
       x = 0; if (f1 == 0 && flag == STB_PATH) len=2;
@@ -1466,7 +1466,7 @@ void stb__arr_deleten_(void **pp, int size, int i, int n)
 //
 //      ok, so I've added something that generates _two separate_
 //      32-bit hashes simultaneously which should scale better to
-//      very large tables.
+//      large tables.
 
 #ifndef STB_INCLUDE_STB_LIB_H
 STB_EXTERN unsigned int stb_hash(char *str);
@@ -2248,7 +2248,7 @@ char ** stb_stringfile(char *filename, int *plen)
          list = (char **) malloc(sizeof(*list) * (count+1) + len+1);
          if (!list) return NULL;
          list[count] = 0;
-         // recopy the file so there's just a single allocation to free
+         // recopy the file so there's a single allocation to free
          memcpy(&list[count+1], buffer, len+1);
          free(buffer);
          buffer = (char *) &list[count+1];

--- a/tests/resample_test.cpp
+++ b/tests/resample_test.cpp
@@ -736,7 +736,7 @@ void test_filters(void)
 	verify_filter_normalized(STBIR_FILTER_MITCHELL, 1, value);
 
 	{
-		// This test is designed to produce coefficients that are very badly denormalized.
+		// This test is designed to produce coefficients that are badly denormalized.
 		unsigned int v = 556;
 
 		unsigned int input[100 * 100];

--- a/tests/resample_test_c.c
+++ b/tests/resample_test_c.c
@@ -2,7 +2,7 @@
 #define STB_IMAGE_RESIZE_STATIC
 #include "stb_image_resize.h"
 
-// Just to make sure it will build properly with a c compiler
+// To make sure it builds properly with a c compiler
 
 int main() {
 }

--- a/tests/stb.c
+++ b/tests/stb.c
@@ -1226,12 +1226,12 @@ int main(int argc, char **argv)
    fclose(f);
    #endif
    if (!stb_fexists("data/stb.test")) {
-      fprintf(stderr, "Error: couldn't open file just written, or stb_fexists() is broken.\n");
+      fprintf(stderr, "Error: couldn't open file written, or stb_fexists() is broken.\n");
    }
 
    f = fopen("data/stb.test", "rb");
    // f = NULL; // test stb_fatal()
-   if (!f) { stb_fatal("Error: couldn't open file just written\n"); }
+   if (!f) { stb_fatal("Error: couldn't open file written\n"); }
    else {
       char temp[4];
       int len1 = stb_filelen(f), len2;

--- a/tests/test_ds.c
+++ b/tests/test_ds.c
@@ -1012,7 +1012,7 @@ int main(int arg, char **argv)
   begin(); for (n=0; n <    7; ++n) { churn_skip(100000,300000,10);          } end(); printf("  // %7.2fms :  2,000,000 inserts & deletes in 200K table\n", timer);
   begin(); for (n=0; n <    2; ++n) { churn_skip(1000000,3000000,10);        } end(); printf("  // %7.2fms : 20,000,000 inserts & deletes in 2M table\n", timer);
 
-  // search for bad intervals.. in practice this just seems to measure execution variance
+  // search for bad intervals.. in practice this seems to measure execution variance
   for (s = 2; s < 64; ++s) {
     begin(); for (n=0; n < 50; ++n) { build(200000,0,0,s); } end();
     if (timer > worst) {

--- a/tests/test_ds_cpp.cpp
+++ b/tests/test_ds_cpp.cpp
@@ -396,7 +396,7 @@ int main(int arg, char **argv)
   begin(); for (n=0; n <    7; ++n) { churn_skip(100000,300000,10);          } end(); printf("  // %7.2fms :  2,000,000 inserts & deletes in 200K table\n", timer);
   begin(); for (n=0; n <    2; ++n) { churn_skip(1000000,3000000,10);        } end(); printf("  // %7.2fms : 20,000,000 inserts & deletes in 2M table\n", timer);
 
-  // search for bad intervals.. in practice this just seems to measure execution variance
+  // search for bad intervals.. in practice this seems to measure execution variance
   for (s = 2; s < 64; ++s) {
     begin(); for (n=0; n < 50; ++n) { build(200000,0,0,s); } end();
     if (timer > worst) {

--- a/tests/textedit_sample.c
+++ b/tests/textedit_sample.c
@@ -1,4 +1,4 @@
-// I haven't actually tested this yet, this is just to make sure it compiles
+// I haven't actually tested this yet, this is to make sure it compiles
 
 #include <stdlib.h>
 #include <string.h> // memmove

--- a/tools/README.footer.md
+++ b/tools/README.footer.md
@@ -69,7 +69,7 @@ You can use [this URL](https://github.com/nothings/stb#stb_libs) to link directl
 
 #### Why do you list "lines of code"? It's a terrible metric.
 
-Just to give you some idea of the internal complexity of the library,
+To give you some idea of the internal complexity of the library,
 to help you manage your expectations, or to let you know what you're
 getting into. While not all the libraries are written in the same
 style, they're certainly similar styles, and so comparisons between
@@ -88,10 +88,10 @@ realize. (It also makes library dependencies a lot worse in Windows.)
 There's also a common problem in Windows where a library was built
 against a different version of the runtime library, which causes
 link conflicts and confusion. Shipping the libs as headers means
-you normally just compile them straight into your project without
+you normally compile them straight into your project without
 making libraries, thus sidestepping that problem.
 
-Making them a single file makes it very easy to just
+Making them a single file makes it easy to just
 drop them into a project that needs them. (Of course you can
 still put them in a proper shared library tree if you want.)
 
@@ -103,7 +103,7 @@ remember to attach *two* files, etc.
 
 #### Why "stb"? Is this something to do with Set-Top Boxes?
 
-No, they are just the initials for my name, Sean T. Barrett.
+No, they are the initials for my name, Sean T. Barrett.
 This was not chosen out of egomania, but as a moderately sane
 way of namespacing the filenames and source function names.
 

--- a/tools/unicode.c
+++ b/tools/unicode.c
@@ -397,7 +397,7 @@ table pack_for_mode(table *t, int mode, char *table_name)
                else
                   trim = end_trim+1;
 
-               assert(pos < 65536); // @TODO: if this triggers, just bail on this search path
+               assert(pos < 65536); // @TODO: if this triggers, bail on this search path
                pos = pos + (trim << 16);
             }
 
@@ -447,7 +447,7 @@ table pack_for_mode(table *t, int mode, char *table_name)
          else
             trim = end_trim;
 
-         assert(pos < 65536); // @TODO: if this triggers, just bail on this search path
+         assert(pos < 65536); // @TODO: if this triggers, bail on this search path
          pos = pos + (trim << 16);
 
          newval = pos;
@@ -515,7 +515,7 @@ table pack_for_mode(table *t, int mode, char *table_name)
       if (mi.trim_end)
          output_table_with_trims(table_name, "_index", indirect, stb_arr_len(indirect));
       else {
-         assert(0); // this case should only trigger in very extreme circumstances
+         assert(0); // this case should only trigger in extreme circumstances
          output_table(table_name, "_index", indirect, stb_arr_len(indirect), 0, NULL);
       }
       mi.trim_end = mi.special = 0;


### PR DESCRIPTION
This removes the usage of "just" and "very", fixing #1899.

Didn't touch the deprecated folder. Retained casing, where it made sense.
