### PR TITLE
Enable Windows ARM64 & ARM64EC in "stb_image.h" and "stb_image_resize2.h" and fix build failures. 

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -688,10 +688,8 @@ typedef unsigned char validate_uint32[sizeof(stbi__uint32)==4 ? 1 : -1];
 #define STBI_REALLOC_SIZED(p,oldsz,newsz) STBI_REALLOC(p,newsz)
 #endif
 
-// x86/x64/ARM64/AArch64 detection
-#if defined(_M_ARM64) || defined(_M_ARM64EC) || defined(__aarch64__) || defined(__arm64__)
-#define STBI__ARM64_TARGET
-#elif defined(__x86_64__) || defined(_M_X64)
+// x86/x64 detection
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_M_ARM64EC)
 #define STBI__X64_TARGET
 #elif defined(__i386) || defined(_M_IX86)
 #define STBI__X86_TARGET
@@ -777,17 +775,15 @@ static int stbi__sse2_available(void)
 #endif
 
 // ARM NEON
-#if !defined(STBI_NO_SIMD) && defined(STBI__ARM64_TARGET)
-#define STBI_NEON
+#if defined(STBI_NO_SIMD) && defined(STBI_NEON)
+#undef STBI_NEON
 #endif
 
 #ifdef STBI_NEON
+#include <arm_neon.h>
 #ifdef _MSC_VER
-#include <intrin.h>
-#include <arm64_neon.h>
 #define STBI_SIMD_ALIGN(type, name) __declspec(align(16)) type name
 #else
-#include <arm_neon.h>	
 #define STBI_SIMD_ALIGN(type, name) type name __attribute__((aligned(16)))
 #endif
 #endif

--- a/stb_image_resize2.h
+++ b/stb_image_resize2.h
@@ -2729,7 +2729,7 @@ static void stbir_overlapping_memcpy( void * dest, void const * src, size_t byte
 
 #ifndef STBIR_PROFILE_FUNC
 
-#if defined(_x86_64) || defined( __x86_64__ ) || defined( _M_X64 ) || defined(__x86_64) || defined(__SSE2__) || defined(STBIR_SSE) || defined( _M_IX86_FP ) || defined(__i386) || defined( __i386__ ) || defined( _M_IX86 ) || defined( _X86_ )
+#if (defined(_x86_64) || defined( __x86_64__ ) || defined( _M_X64 ) || defined(__x86_64) || defined(__SSE2__) || defined(STBIR_SSE) || defined( _M_IX86_FP ) || defined(__i386) || defined( __i386__ ) || defined( _M_IX86 ) || defined( _X86_ )) && !defined(_M_ARM64EC)
 
 #ifdef _MSC_VER
 


### PR DESCRIPTION
**Summary**
-----------------------------
This PR adds proper detection and support for Windows ARM64 and ARM64EC:
 - Treat ARM64EC as native ARM64 and enable NEON where allowed.
 - Include the correct MSVC headers on ARM64/ARM64EC (<intrin.h>, <arm64_neon.h>).
 - Respect STBI_NO_SIMD (don’t enable NEON when SIMD is disabled).
 - Avoid accidentally selecting x86/SSE intrinsics on ARM64EC.
 - No behavior changes for existing x86/x64 builds.

**Background**
---------------------------------
On MSVC ARM64EC, building could pull in x86 headers (<emmintrin.h>) and fail with:
error C1189: #error:  this header should only be included through <intrin.h>
This came from incorrect architecture gating that didn’t exclude ARM64EC from x86/SSE paths.

**Fix**
---------------------------------
Architecture selection updated to detect _M_ARM64EC.
ARM64/ARM64EC: include <intrin.h> and <arm64_neon.h> when NEON is enabled.
Ensure STBI_NO_SIMD disables NEON as intended.
In "stb_image_resize2.h" add NEON support for ARM64EC code paths.

**Build & Test**
-----------------------------
Environment: Windows 11 on ARM64; MSVC (VS 2022 v143 toolset).
Result: ARM64 and ARM64EC configurations compile cleanly; x86/x64 unchanged.
