### PR TITLE
fix: at stb_truetype in stb_truetype.h

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -1870,6 +1870,11 @@ static int stbtt__GetGlyphShapeTT(const stbtt_fontinfo *info, int glyph_index, s
                v->cy = (stbtt_vertex_type)(n * (mtx[1]*x + mtx[3]*y + mtx[5]));
             }
             // Append vertices.
+            if (num_vertices < 0 || comp_num_verts < 0 || num_vertices > (0x7FFFFFFF - comp_num_verts)) {
+               if (vertices) STBTT_free(vertices, info->userdata);
+               if (comp_verts) STBTT_free(comp_verts, info->userdata);
+               return 0;
+            }
             tmp = (stbtt_vertex*)STBTT_malloc((num_vertices+comp_num_verts)*sizeof(stbtt_vertex), info->userdata);
             if (!tmp) {
                if (vertices) STBTT_free(vertices, info->userdata);


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `stb_truetype.h`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `stb_truetype.h:1873` |

**Description**: At stb_truetype.h:1873, a heap buffer is allocated for (num_vertices + comp_num_verts) vertex elements. The subsequent STBTT_memcpy calls at lines 1879-1880 copy data into this buffer. Neither num_vertices nor comp_num_verts is validated against the actual bounds of the font data buffer before use. An attacker who supplies a crafted TrueType font file with manipulated composite glyph component counts can cause the memcpy operations to write beyond the allocated heap region, corrupting adjacent heap memory.

## Changes
- `stb_truetype.h`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
