### PR TITLE
Fix for GCC 3.0 and below in C99 mode

### DIFF
--- a/stb_ds.h
+++ b/stb_ds.h
@@ -513,7 +513,7 @@ extern void * stbds_shmode_func(size_t elemsize, int mode);
 #endif
 
 #if !defined(__cplusplus)
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L && (!defined(__GNUC__) || (__GNUC__ >= 4 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1)))
 #define STBDS_HAS_LITERAL_ARRAY
 #endif
 #endif


### PR DESCRIPTION
GCC 3.0 and 2.95 hadn't implemented this particular part of the C99 standard, so if you try to use stb_ds along with `-std=c9x` you'll get cryptic errors about lvalues.  This just makes those particular compilers fallback to the C89 path which works fine.