### PR TITLE
stb_truetype.h: Fix typo

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -230,7 +230,7 @@
 //
 //    - Use the functions with Subpixel at the end to allow your characters
 //      to have subpixel positioning. Since the font is anti-aliased, not
-//      hinted, this is very import for quality. (This is not possible with
+//      hinted, this is very important for quality. (This is not possible with
 //      baked fonts.)
 //
 //    - Kerning is now supported, and if you're supporting subpixel rendering


### PR DESCRIPTION
Fixed typo in stb_truetype.h

`import` -> `important`