### PR TITLE
stb_rect_pack: fix corner case in best-fit waste calculation

### DIFF
--- a/stb_rect_pack.h
+++ b/stb_rect_pack.h
@@ -1,4 +1,4 @@
-// stb_rect_pack.h - v1.01 - public domain - rectangle packing
+// stb_rect_pack.h - v1.02 - public domain - rectangle packing
 // Sean Barrett 2014
 //
 // Useful for e.g. packing rectangular textures into an atlas.
@@ -38,9 +38,11 @@
 //  Bugfixes / warning fixes
 //    Jeremy Jaussaud
 //    Fabian Giesen
+//    Robert Hrusecky
 //
 // Version history:
 //
+//     1.02  (          )  fix corner case in best-fit waste calculation 
 //     1.01  (2021-07-11)  always use large rect mode, expose STBRP__MAXVAL in public section
 //     1.00  (2019-02-25)  avoid small space waste; gracefully fail too-wide rectangles
 //     0.99  (2019-02-07)  warning fixes
@@ -304,21 +306,20 @@ static int stbrp__skyline_find_min_y(stbrp_context *c, stbrp_node *first, int x0
 
    STBRP_ASSERT(node->x <= x0);
 
-   min_y = 0;
+   // handle the first node before entering the loop
+   min_y = node->y;
    waste_area = 0;
-   visited_width = 0;
+   // the first time through, visited_width might be reduced
+   visited_width = node->next->x - x0;
+   node = node->next;
    while (node->x < x1) {
       if (node->y > min_y) {
          // raise min_y higher.
          // we've accounted for all waste up to min_y,
-         // but we'll now add more waste for everything we've visted
+         // but we'll now add more waste for everything we've visited
          waste_area += visited_width * (node->y - min_y);
          min_y = node->y;
-         // the first time through, visited_width might be reduced
-         if (node->x < x0)
-            visited_width += node->next->x - x0;
-         else
-            visited_width += node->next->x - node->x;
+         visited_width += node->next->x - node->x;
       } else {
          // add waste area
          int under_width = node->next->x - node->x;


### PR DESCRIPTION
Under the best-fit heuristic, the waste calculation for a candidate x-coordinate may be incorrect when the initial node has `y == 0`. In this case, `node->y == min_y == 0` and the first loop iteration enters the `else` block, which does not account for the possibility of a reduced first-iteration `visited_width`.

To fix this, handle the first-iteration case (`visited_width == 0`) explicitly.

This case was found by comparing my own implementation vs stb_rect_pack on a randomized skyline. The test case that triggered the issue was the following:

```
width: 12, height: 10
nodes:
    .{ .x = 0, .y = 5 }
    .{ .x = 1, .y = 0 }
    .{ .x = 5, .y = 5 }
    .{ .x = 7, .y = 1 }
    .{ .x = 9, .y = 3 }
    .{ .x = 12, .y = 1073741824 }
input rectangle: .{ .w = 9, .h = 2 }
candidate xpos: 3

            =
            =
            =
   ---------=
   ---------=
+    ++     =
|    |+     =
|    |+  +++=
|    |+  |++=
|    |+++|++=
=============

```
