### PR TITLE
Fix stbi_write_bmp invalid bV4CSType header value for 32-bit images

### DIFF
--- a/stb_image_write.h
+++ b/stb_image_write.h
@@ -505,7 +505,7 @@ static int stbi_write_bmp_core(stbi__write_context *s, int x, int y, int comp, c
       return stbiw__outfile(s,-1,-1,x,y,comp,1,(void *)data,1,0,
          "11 4 22 4" "4 44 22 444444 4444 4 444 444 444 444",
          'B', 'M', 14+108+x*y*4, 0, 0, 14+108, // file header
-         108, x,y, 1,32, 3,0,0,0,0,0, 0xff0000,0xff00,0xff,0xff000000u, 0, 0,0,0, 0,0,0, 0,0,0, 0,0,0); // bitmap V4 header
+         108, x,y, 1,32, 3,0,0,0,0,0, 0xff0000,0xff00,0xff,0xff000000u, 0x73524742, 0,0,0, 0,0,0, 0,0,0, 0,0,0); // bitmap V4 header
    }
 }
 


### PR DESCRIPTION
### Problem
When writing 32-bit RGBA images via `stbi_write_bmp`, the function utilizes a `BITMAPV4HEADER` but assigns `0` (`LCS_CALIBRATED_RGB`) to the `bV4CSType` field. Because the subsequent endpoint profiles are also written as zero, strict image parsers—such as Microsoft Paint (`pbrush`)—fail to validate the header, resulting in a file load error.

### Solution
This PR changes the `bV4CSType` parameter from `0` to `0x73524742` (`LCS_sRGB`). This explicitly marks the color space as standard sRGB, ensuring compliance with strict OS-level parsers and fixing the load failures without altering the structural layout or size of the header.

---
*I dedicate this modification to the public domain.*