### PR TITLE
stb_image: Fix build on arm64ec.

### DIFF
--- a/stb_image.h
+++ b/stb_image.h
@@ -103,7 +103,7 @@ RECENT REVISION HISTORY:
     Phil Jordan                                Dave Moore           Roy Eltham
     Hayaki Saito            Nathan Reed        Won Chun
     Luke Graham             Johan Duparc       Nick Verigakis       the Horde3D community
-    Thomas Ruf              Ronny Chevalier                         github:rlyeh
+    Thomas Ruf              Ronny Chevalier    Esme Povirk          github:rlyeh
     Janez Zemva             John Bartholomew   Michal Cichon        github:romigrou
     Jonathan Blow           Ken Hamada         Tero Hanninen        github:svdijk
     Eugene Golushkov        Laurent Gomila     Cort Stratton        github:snagar
@@ -721,7 +721,7 @@ typedef unsigned char validate_uint32[sizeof(stbi__uint32)==4 ? 1 : -1];
 #define STBI_NO_SIMD
 #endif
 
-#if !defined(STBI_NO_SIMD) && (defined(STBI__X86_TARGET) || defined(STBI__X64_TARGET))
+#if !defined(STBI_NO_SIMD) && (defined(STBI__X86_TARGET) || defined(STBI__X64_TARGET)) && !defined(__arm64ec__)
 #define STBI_SSE2
 #include <emmintrin.h>
 


### PR DESCRIPTION
arm64ec reports itself as x86_64, but it doesn't have sse because it's not really x86_64.

I encountered this in the arm64ec build of FNA3D, as I'm working on an arm64 package of Wine Mono.