### PR TITLE
Fix NULL pointer crash in vorbis_deinit when comment_list allocation fails

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -4209,12 +4209,12 @@ static void vorbis_deinit(stb_vorbis *p)
 {
    int i,j;
 
-   setup_free(p, p->vendor);
-   for (i=0; i < p->comment_list_length; ++i) {
-      setup_free(p, p->comment_list[i]);
-   }
-   setup_free(p, p->comment_list);
-
+    setup_free(p, p->vendor);
+    if (!p->comment_list) return;
+    for (i=0; i < p->comment_list_length; ++i) {
+       setup_free(p, p->comment_list[i]);
+    }
+    
    if (p->residue_config) {
       for (i=0; i < p->residue_count; ++i) {
          Residue *r = p->residue_config+i;


### PR DESCRIPTION
79885cd

Closes #1981

## Summary
- Add a NULL guard in vorbis_deinit() to prevent SIGSEGV when comment_list allocation fails after get32_packet succeeds but setup_malloc fails.

## Details
- When start_decoder() parses a valid Ogg Vorbis file, get32_packet() at line 3660 sets comment_list_length to a positive value,
  but setup_malloc() at line 3664 can return NULL.
- Without this guard, vorbis_deinit() iterates over the NULL pointer,
  causing a crash.
- Fix: one-line NULL check before the deallocation loop.
- Only stb_vorbis.c is modified.