### PR TITLE
[stb_vorbis.c] Undefined behavior with pointer arithmetic

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -1401,7 +1401,8 @@ static int set_file_offset(stb_vorbis *f, unsigned int loc)
    #endif
    f->eof = 0;
    if (USE_MEMORY(f)) {
-      if (f->stream_start + loc >= f->stream_end || f->stream_start + loc < f->stream_start) {
+      size_t len = (size_t) (f->stream_end - f->stream_start);
+      if (loc >= len) {
          f->stream = f->stream_end;
          f->eof = 1;
          return 0;


### PR DESCRIPTION
Fixed a bug with overflow without invoking undefined behavior on pointer arithmetic.
