### PR TITLE
stb_vorbis: zero-entry codebook support

### DIFF
--- a/stb_vorbis.c
+++ b/stb_vorbis.c
@@ -34,6 +34,7 @@
 //    github:audinowho   Dougall Johnson     David Reid
 //    github:Clownacy    Pedro J. Estebanez  Remi Verschelde
 //    AnthoFoxo          github:morlat       Gabriel Ravier
+//    Alejandro González
 //
 // Partial history:
 //    1.22    - 2021-07-11 - various small fixes
@@ -974,7 +975,7 @@ static void *setup_temp_malloc(vorb *f, int sz)
       f->temp_offset -= sz;
       return (char *) f->alloc.alloc_buffer + f->temp_offset;
    }
-   return malloc(sz);
+   return sz ? malloc(sz) : NULL;
 }
 
 static void setup_temp_free(vorb *f, void *p, int sz)
@@ -3720,7 +3721,7 @@ static int start_decoder(vorb *f)
       uint32 *values;
       int ordered, sorted_count;
       int total=0;
-      uint8 *lengths;
+      uint8 *lengths=NULL;
       Codebook *c = f->codebooks+i;
       CHECK(f);
       x = get_bits(f, 8); if (x != 0x42)            return error(f, VORBIS_invalid_setup);
@@ -3736,12 +3737,14 @@ static int start_decoder(vorb *f)
 
       if (c->dimensions == 0 && c->entries != 0)    return error(f, VORBIS_invalid_setup);
 
-      if (c->sparse)
-         lengths = (uint8 *) setup_temp_malloc(f, c->entries);
-      else
-         lengths = c->codeword_lengths = (uint8 *) setup_malloc(f, c->entries);
+      if (c->entries > 0) {
+        if (c->sparse)
+           lengths = (uint8 *) setup_temp_malloc(f, c->entries);
+        else
+           lengths = c->codeword_lengths = (uint8 *) setup_malloc(f, c->entries);
 
-      if (!lengths) return error(f, VORBIS_outofmem);
+        if (!lengths) return error(f, VORBIS_outofmem);
+      }
 
       if (ordered) {
          int current_entry = 0;
@@ -3774,11 +3777,13 @@ static int start_decoder(vorb *f)
          if (c->entries > (int) f->setup_temp_memory_required)
             f->setup_temp_memory_required = c->entries;
 
-         c->codeword_lengths = (uint8 *) setup_malloc(f, c->entries);
-         if (c->codeword_lengths == NULL) return error(f, VORBIS_outofmem);
-         memcpy(c->codeword_lengths, lengths, c->entries);
-         setup_temp_free(f, lengths, c->entries); // note this is only safe if there have been no intervening temp mallocs!
-         lengths = c->codeword_lengths;
+         if (c->entries > 0) {
+           c->codeword_lengths = (uint8 *) setup_malloc(f, c->entries);
+           if (c->codeword_lengths == NULL) return error(f, VORBIS_outofmem);
+           memcpy(c->codeword_lengths, lengths, c->entries);
+           setup_temp_free(f, lengths, c->entries); // note this is only safe if there have been no intervening temp mallocs!
+           lengths = c->codeword_lengths;
+         }
          c->sparse = 0;
       }
 
@@ -3798,7 +3803,7 @@ static int start_decoder(vorb *f)
       values = NULL;
 
       CHECK(f);
-      if (!c->sparse) {
+      if (!c->sparse && c->entries > 0) {
          c->codewords = (uint32 *) setup_malloc(f, sizeof(c->codewords[0]) * c->entries);
          if (!c->codewords)                  return error(f, VORBIS_outofmem);
       } else {


### PR DESCRIPTION
The [Vorbis I specification](https://xiph.org/vorbis/doc/Vorbis_I_spec.html) defines how to read and use codebooks with several entries encoded in the setup header, and it also describes the expected decoder behavior for the edge case of single-entry codebooks. However, codebooks without entries are not clearly addressed.

It is my interpretation of the specification that zero-entry codebooks are not forbidden, and are therefore allowed, provided that no bound on the codebook entry count is violated by its use for residue or vector decoding and, obviously, that the codebook is not actually used in any audio packet.

While no Vorbis encoder I know of generates streams with zero-entry codebooks, my OptiVorbis project recently added [unused codebook entry truncation support](https://github.com/OptiVorbis/OptiVorbis/pull/187), which I verified to work successfully with the reference `libvorbis` decoder. However, after that change had circulated for a while, people began encountering issues playing files containing such codebooks with both `stb_vorbis` and JOrbis. This prompted me to take a closer look at how `stb_vorbis` handled such codebooks as part of a broader effort to address the situation.

My findings for `stb_vorbis` were that it failed to play such files because its `start_decoder` function attempted to `malloc` a zero-sized buffer for `lengths`, which is allowed by [POSIX and ISO C standards](https://pubs.opengroup.org/onlinepubs/9799919799/functions/malloc.html) to return a null pointer:

https://github.com/nothings/stb/blob/2c980bb59875b0d32144a71867fbdebb2f77cd20/stb_vorbis.c#L3739-L3744

The changes proposed here skip the problematic allocations during setup header decoding when there are no entries, which have been tested to allow `stb_vorbis` to work with several files containing zero-entry codebooks. While at it, I have also modified the `setup_temp_malloc` function so that it consistently returns `NULL` when its `sz` parameter is zero, which prevents `stb_vorbis` from depending on the platform-specific behavior of `malloc(0)`, similarly to the existing `setup_malloc` case.

Please be advised that C is not my wheelhouse, so I may have missed some edge case, UB, ABI/API compatibility concern, or something else. Any feedback is welcome!